### PR TITLE
chore: Add SPDX license headers

### DIFF
--- a/modules/core/src/classes/base/math-array.ts
+++ b/modules/core/src/classes/base/math-array.ts
@@ -1,4 +1,7 @@
-// math.gl, MIT License
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {NumericArray} from '@math.gl/types';
 import {ConfigurationOptions, config, formatValue, equals, isArray} from '../../lib/common';
 

--- a/modules/core/src/classes/base/matrix.ts
+++ b/modules/core/src/classes/base/matrix.ts
@@ -1,5 +1,8 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
+
 import {NumericArray} from '@math.gl/types';
 import {MathArray} from './math-array';
 import {checkNumber} from '../../lib/validators';

--- a/modules/core/src/classes/base/vector.ts
+++ b/modules/core/src/classes/base/vector.ts
@@ -1,5 +1,8 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
+
 import {NumericArray} from '@math.gl/types';
 import {MathArray} from './math-array';
 import {checkNumber} from '../../lib/validators';

--- a/modules/core/src/classes/euler.ts
+++ b/modules/core/src/classes/euler.ts
@@ -1,5 +1,8 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
+
 import {MathArray} from './base/math-array';
 import {Quaternion} from './quaternion';
 import {NumericArray} from '@math.gl/types';

--- a/modules/core/src/classes/matrix3.ts
+++ b/modules/core/src/classes/matrix3.ts
@@ -1,5 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
 
 import {NumericArray} from '@math.gl/types';
 import {Matrix} from './base/matrix';

--- a/modules/core/src/classes/matrix4.ts
+++ b/modules/core/src/classes/matrix4.ts
@@ -1,5 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
 
 import {NumericArray} from '@math.gl/types';
 import {Matrix} from './base/matrix';

--- a/modules/core/src/classes/pose.ts
+++ b/modules/core/src/classes/pose.ts
@@ -1,5 +1,8 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
+
 import {Matrix4} from './matrix4';
 import {Vector3} from './vector3';
 import {Euler} from './euler';

--- a/modules/core/src/classes/quaternion.ts
+++ b/modules/core/src/classes/quaternion.ts
@@ -1,5 +1,8 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
+
 import {NumericArray} from '@math.gl/types';
 import {MathArray} from './base/math-array';
 import {checkNumber, checkVector} from '../lib/validators';

--- a/modules/core/src/classes/spherical-coordinates.ts
+++ b/modules/core/src/classes/spherical-coordinates.ts
@@ -1,5 +1,8 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
+
 // Adaptation of THREE.js Spherical class, under MIT license
 import {NumericArray} from '@math.gl/types';
 import {Vector3} from './vector3';

--- a/modules/core/src/classes/vector2.ts
+++ b/modules/core/src/classes/vector2.ts
@@ -1,5 +1,8 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
+
 import {Vector} from './base/vector';
 import {config, isArray} from '../lib/common';
 import {checkNumber} from '../lib/validators';

--- a/modules/core/src/classes/vector3.ts
+++ b/modules/core/src/classes/vector3.ts
@@ -1,5 +1,8 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
+
 import {NumericArray} from '@math.gl/types';
 import {Vector} from './base/vector';
 import {config, isArray} from '../lib/common';

--- a/modules/core/src/classes/vector4.ts
+++ b/modules/core/src/classes/vector4.ts
@@ -1,5 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
 
 import {NumericArray} from '@math.gl/types';
 /* eslint-disable camelcase */

--- a/modules/core/src/gl-matrix/wip/index.js
+++ b/modules/core/src/gl-matrix/wip/index.js
@@ -1,3 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // @eslint-disable
 // @ts-nocheck
 

--- a/modules/core/src/gl-matrix/wip/mat2.js
+++ b/modules/core/src/gl-matrix/wip/mat2.js
@@ -1,3 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // @ts-nocheck
 /* eslint-disable */
 

--- a/modules/core/src/gl-matrix/wip/mat2d.js
+++ b/modules/core/src/gl-matrix/wip/mat2d.js
@@ -1,3 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // @ts-nocheck
 /* eslint-disable */
 

--- a/modules/core/src/gl-matrix/wip/quat2.ts
+++ b/modules/core/src/gl-matrix/wip/quat2.ts
@@ -1,3 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // @ts-nocheck
 /* eslint-disable */
 import * as glMatrix from './common.js';

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -1,4 +1,6 @@
-// luma.gl, MIT license
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 
 // types
 export type {TypedArray, TypedArrayConstructor, NumberArray, NumericArray} from '@math.gl/types';

--- a/modules/core/src/lib/assert.ts
+++ b/modules/core/src/lib/assert.ts
@@ -1,3 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 export function assert(condition: unknown, message?: string): void {
   if (!condition) {
     throw new Error(`math.gl assertion ${message}`);

--- a/modules/core/src/lib/common.ts
+++ b/modules/core/src/lib/common.ts
@@ -1,4 +1,6 @@
-// math.gl, MIT license
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 
 import type {NumericArray} from '@math.gl/types';
 

--- a/modules/core/src/lib/gl-matrix-extras.ts
+++ b/modules/core/src/lib/gl-matrix-extras.ts
@@ -1,3 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /* eslint-disable camelcase */
 import {NumericArray} from '@math.gl/types';
 // vec2 additions

--- a/modules/core/src/lib/gl-matrix.d.ts
+++ b/modules/core/src/lib/gl-matrix.d.ts
@@ -1,3 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 type NumericArray =
   | Int8Array
   | Uint8Array

--- a/modules/core/src/lib/math-utils.ts
+++ b/modules/core/src/lib/math-utils.ts
@@ -1,3 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // NOTE: Added to make Cesium-derived test cases work
 // TODO: Determine if/how to keep
 export const EPSILON1 = 1e-1;

--- a/modules/core/src/lib/validators.ts
+++ b/modules/core/src/lib/validators.ts
@@ -1,22 +1,7 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {NumberArray} from '@math.gl/types';
 import {config} from './common';
 

--- a/modules/core/test/bench.ts
+++ b/modules/core/test/bench.ts
@@ -1,22 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2015 - 2017 Uber Technologies, Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 import javascriptBench from './lib/javascript.bench';
 import commonBench from './lib/common.bench';

--- a/modules/core/test/classes/classes.bench.ts
+++ b/modules/core/test/classes/classes.bench.ts
@@ -1,22 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2015 - 2017 Uber Technologies, Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 import {configure, Vector2, Vector3, Vector4, Matrix3, Matrix4} from '@math.gl/core';
 

--- a/modules/core/test/classes/euler.spec.ts
+++ b/modules/core/test/classes/euler.spec.ts
@@ -1,3 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {Euler, Matrix4, Quaternion, Pose} from '@math.gl/core';
 import test from 'tape-promise/tape';
 import {tapeEquals} from 'test/utils/tape-assertions';

--- a/modules/core/test/classes/matrix3.spec.ts
+++ b/modules/core/test/classes/matrix3.spec.ts
@@ -1,5 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
 
 /* eslint-disable max-statements */
 import {Matrix3, config} from '@math.gl/core';

--- a/modules/core/test/classes/matrix4.bench.ts
+++ b/modules/core/test/classes/matrix4.bench.ts
@@ -1,22 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2015 - 2017 Uber Technologies, Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 import {configure, Vector4, Matrix4, mat4} from '@math.gl/core';
 

--- a/modules/core/test/classes/matrix4.spec.ts
+++ b/modules/core/test/classes/matrix4.spec.ts
@@ -1,5 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
 
 /* eslint-disable max-statements */
 import {Matrix4, Vector3, config, configure} from '@math.gl/core';

--- a/modules/core/test/classes/pose.spec.ts
+++ b/modules/core/test/classes/pose.spec.ts
@@ -1,3 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'tape-promise/tape';
 import {Matrix4, Vector3, equals} from '@math.gl/core';
 import {Euler, Pose} from '@math.gl/core';

--- a/modules/core/test/classes/quaternion.spec.ts
+++ b/modules/core/test/classes/quaternion.spec.ts
@@ -1,22 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the 'Software'), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 /* eslint-disable*/
 import test from 'tape-promise/tape';

--- a/modules/core/test/classes/spherical-coordinates.spec.ts
+++ b/modules/core/test/classes/spherical-coordinates.spec.ts
@@ -1,5 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
 
 /* eslint-disable max-statements, max-depth */
 import test from 'tape-promise/tape';

--- a/modules/core/test/classes/vector2.bench.ts
+++ b/modules/core/test/classes/vector2.bench.ts
@@ -1,22 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2015 - 2017 Uber Technologies, Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 import {Vector2} from '@math.gl/core';
 

--- a/modules/core/test/classes/vector2.spec.ts
+++ b/modules/core/test/classes/vector2.spec.ts
@@ -1,5 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
 
 /* eslint-disable max-statements */
 import test from 'tape-promise/tape';

--- a/modules/core/test/classes/vector3.bench.ts
+++ b/modules/core/test/classes/vector3.bench.ts
@@ -1,22 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2015 - 2017 Uber Technologies, Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 import {Vector3} from '@math.gl/core';
 

--- a/modules/core/test/classes/vector3.spec.ts
+++ b/modules/core/test/classes/vector3.spec.ts
@@ -1,5 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
 
 /* eslint-disable max-statements */
 import test from 'tape-promise/tape';

--- a/modules/core/test/classes/vector4.bench.ts
+++ b/modules/core/test/classes/vector4.bench.ts
@@ -1,22 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2015 - 2017 Uber Technologies, Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 import {Vector4} from '@math.gl/core';
 

--- a/modules/core/test/classes/vector4.spec.ts
+++ b/modules/core/test/classes/vector4.spec.ts
@@ -1,5 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
 
 /* eslint-disable max-statements */
 import test from 'tape-promise/tape';

--- a/modules/core/test/classes/vectors.spec.ts
+++ b/modules/core/test/classes/vectors.spec.ts
@@ -1,5 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
 
 /* eslint-disable max-statements */
 import test, {Test} from 'tape-promise/tape';

--- a/modules/core/test/index.ts
+++ b/modules/core/test/index.ts
@@ -1,5 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
 
 import './lib/common.spec';
 

--- a/modules/core/test/lib/common.bench.ts
+++ b/modules/core/test/lib/common.bench.ts
@@ -1,22 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2015 - 2017 Uber Technologies, Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 import {Vector3, toRadians, radians} from '@math.gl/core';
 import {isArray} from '@math.gl/core';

--- a/modules/core/test/lib/common.spec.ts
+++ b/modules/core/test/lib/common.spec.ts
@@ -1,5 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright (c) 2017 Uber Technologies, Inc.
-// MIT License
 
 import test, {Test} from 'tape-promise/tape';
 import {Vector2, Vector3, Pose, _MathUtils} from '@math.gl/core';

--- a/modules/core/test/lib/javascript.bench.ts
+++ b/modules/core/test/lib/javascript.bench.ts
@@ -1,3 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // CLASS INHERITANCE
 //
 // This class identifies

--- a/modules/core/test/threejs-tests/constants.ts
+++ b/modules/core/test/threejs-tests/constants.ts
@@ -1,24 +1,7 @@
-// The MIT License
-//
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright © 2010-2018 three.js authors
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 // @author bhouston / http://exocortex.com
 

--- a/modules/core/test/threejs-tests/euler-three.spec.ts
+++ b/modules/core/test/threejs-tests/euler-three.spec.ts
@@ -1,24 +1,7 @@
-// The MIT License
-//
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright © 2010-2018 three.js authors
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 // This file was copied from THREE.js math test suite (MIT licensed)
 // Original authors:

--- a/modules/core/test/threejs-tests/index.ts
+++ b/modules/core/test/threejs-tests/index.ts
@@ -1,3 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import './vector2-three.spec';
 import './vector3-three.spec';
 import './vector4-three.spec';

--- a/modules/core/test/threejs-tests/matrix3-three.spec.ts
+++ b/modules/core/test/threejs-tests/matrix3-three.spec.ts
@@ -1,24 +1,7 @@
-// The MIT License
-//
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright © 2010-2018 three.js authors
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 // This file is copied from THREE.js math test suite (MIT licensed)
 // @author bhouston / http://exocortex.com

--- a/modules/core/test/threejs-tests/matrix4-three.spec.ts
+++ b/modules/core/test/threejs-tests/matrix4-three.spec.ts
@@ -1,24 +1,7 @@
-// The MIT License
-//
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright © 2010-2018 three.js authors
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 // This file is copied from THREE.js math test suite (MIT licensed)
 // @author bhouston / http://exocortex.com

--- a/modules/core/test/threejs-tests/quaternion-three.spec.ts
+++ b/modules/core/test/threejs-tests/quaternion-three.spec.ts
@@ -1,24 +1,7 @@
-// The MIT License
-//
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright © 2010-2018 three.js authors
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 // This file was copied from THREE.js math test suite (MIT licensed)
 // @author bhouston / http://exocortex.com

--- a/modules/core/test/threejs-tests/vector2-three.spec.ts
+++ b/modules/core/test/threejs-tests/vector2-three.spec.ts
@@ -1,24 +1,7 @@
-// The MIT License
-//
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright © 2010-2018 three.js authors
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 // This file is copied from THREE.js math test suite (MIT licensed)
 // @author bhouston / http://exocortex.com

--- a/modules/core/test/threejs-tests/vector3-three.spec.ts
+++ b/modules/core/test/threejs-tests/vector3-three.spec.ts
@@ -1,24 +1,7 @@
-// The MIT License
-//
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright © 2010-2018 three.js authors
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 // This file is copied from THREE.js math test suite (MIT licensed)
 // @author bhouston / http://exocortex.com

--- a/modules/core/test/threejs-tests/vector4-three.spec.ts
+++ b/modules/core/test/threejs-tests/vector4-three.spec.ts
@@ -1,24 +1,7 @@
-// The MIT License
-//
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 // Copyright © 2010-2018 three.js authors
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 // @author bhouston / http://exocortex.com
 // @author TristanVALCKE / https://github.com/Itee

--- a/modules/types/src/array-types.ts
+++ b/modules/types/src/array-types.ts
@@ -1,3 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /**
  * TypeScript type covering all typed arrays
  */

--- a/modules/types/src/bigint.ts
+++ b/modules/types/src/bigint.ts
@@ -1,3 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // BigInt compatibility layer
 // Inspired by ArrowJS (under Apache2 license)
 // https://github.com/apache/arrow/blob/master/js/src/util/compat.ts

--- a/modules/types/src/index.ts
+++ b/modules/types/src/index.ts
@@ -1,2 +1,6 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 export type {TypedArray, TypedArrayConstructor, NumericArray, NumberArray} from './array-types';
 export {isTypedArray, isNumericArray} from './is-array';

--- a/modules/types/src/is-array.ts
+++ b/modules/types/src/is-array.ts
@@ -1,3 +1,7 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {TypedArray, NumericArray} from './array-types';
 
 /**

--- a/modules/types/test/index.ts
+++ b/modules/types/test/index.ts
@@ -1,3 +1,5 @@
-// math.gl, MIT license
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 
 import './is-array.spec';

--- a/modules/types/test/is-array.spec.ts
+++ b/modules/types/test/is-array.spec.ts
@@ -1,4 +1,6 @@
-// math.gl, MIT license
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';
 import {isTypedArray, isNumericArray} from '@math.gl/types';


### PR DESCRIPTION
Align math.gl with OpenJS license header conventions.