### PR TITLE
chore: Fix CI release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           echo "result=${result}" >> "$GITHUB_OUTPUT"
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: check_branch
     permissions:
       contents: write


### PR DESCRIPTION
release action has multiple places where linux version needs to be pinned