### PR TITLE
feat: export the base class MathArray、Matrix、Vector

### DIFF
--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -21,6 +21,9 @@ export type {
 export type {isTypedArray, isNumberArray, isNumericArray} from '@math.gl/types';
 
 // classes
+export {MathArray} from './classes/base/math-array';
+export {Matrix} from './classes/base/matrix';
+export {Vector} from './classes/base/vector';
 export {Vector2} from './classes/vector2';
 export {Vector3} from './classes/vector3';
 export {Vector4} from './classes/vector4';

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -21,9 +21,9 @@ export type {
 export type {isTypedArray, isNumberArray, isNumericArray} from '@math.gl/types';
 
 // classes
-export {MathArray} from './classes/base/math-array';
-export {Matrix} from './classes/base/matrix';
-export {Vector} from './classes/base/vector';
+export {MathArray as _MathArray} from './classes/base/math-array';
+export {Matrix as _Matrix} from './classes/base/matrix';
+export {Vector as _Vector} from './classes/base/vector';
 export {Vector2} from './classes/vector2';
 export {Vector3} from './classes/vector3';
 export {Vector4} from './classes/vector4';


### PR DESCRIPTION
I'm a library developer, and I often need to inherit MathArray, Matrix, and Vector to implement some subclasses, and I often use these base classes as type constraints, but @math.gl/core doesn't expose these classes