### PR TITLE
Fix documentation: It said radians, but code uses degrees!

### DIFF
--- a/dev-docs/RFCs/math-monorepo-rfc.md
+++ b/dev-docs/RFCs/math-monorepo-rfc.md
@@ -30,7 +30,7 @@ Using with pure javascript `Array`
 
 ```js
 import {Ellipsoid} from '@math.gl/geospatial';
-const cartesian = Ellipsoid.WSG84.cartographicToCartesian([lng, lat, z]);
+const cartesian = Ellipsoid.WSG84.cartographicToCartesian([lngDegrees, latDegress, zMetresFromEllipsoid]);
 ```
 
 Using with math.gl `Vector3`:
@@ -38,7 +38,7 @@ Using with math.gl `Vector3`:
 ```js
 import {Ellipsoid} from '@math.gl/geospatial';
 import {Vector3} from '@math.gl/core';
-const cartesian = Ellipsoid.WSG84.cartographicToCartesian(new Vector3(lng, lat, z));
+const cartesian = Ellipsoid.WSG84.cartographicToCartesian(new Vector3(lngDegrees, latDegress, zMetresFromEllipsoid));
 ```
 
 ### Dependencies and Bundle Size

--- a/dev-docs/RFCs/math-monorepo-rfc.md
+++ b/dev-docs/RFCs/math-monorepo-rfc.md
@@ -30,7 +30,8 @@ Using with pure javascript `Array`
 
 ```js
 import {Ellipsoid} from '@math.gl/geospatial';
-const cartesian = Ellipsoid.WSG84.cartographicToCartesian([lngDegrees, latDegress, zMetresFromEllipsoid]);
+const cartographic = [longitudeDegrees, latitudeDegrees, heightMeters];
+const cartesian = Ellipsoid.WGS84.cartographicToCartesian(cartographic);
 ```
 
 Using with math.gl `Vector3`:
@@ -38,7 +39,8 @@ Using with math.gl `Vector3`:
 ```js
 import {Ellipsoid} from '@math.gl/geospatial';
 import {Vector3} from '@math.gl/core';
-const cartesian = Ellipsoid.WSG84.cartographicToCartesian(new Vector3(lngDegrees, latDegress, zMetresFromEllipsoid));
+const cartographic = new Vector3(longitudeDegrees, latitudeDegrees, heightMeters);
+const cartesian = Ellipsoid.WGS84.cartographicToCartesian(cartographic);
 ```
 
 ### Dependencies and Bundle Size

--- a/docs/modules/geospatial/README.md
+++ b/docs/modules/geospatial/README.md
@@ -22,16 +22,15 @@ Attribution: From <a href="https://en.wikipedia.org/wiki/World_Geodetic_System#/
 
 ## Usage Examples
 
-A major use of this library is to convert between "cartesian" (`x`, `y`, `z`) and "cartographic" (`longitude`, `latitude`, `height`) representations of WSG84 coordinates. The `Ellipsoid` class implements these calculations.
+A major use of this library is to convert between "cartesian" (`x`, `y`, `z`) and "cartographic" (`longitude degrees`, `latitude degrees`, `height in metres from ellipsoid`) representations of WSG84 coordinates. The `Ellipsoid` class implements these calculations.
 
 ## Usage
 
 Determine the Cartesian representation of a Cartographic position on a WGS84 ellipsoid.
 
 ```js
-import {toRadians} from '@math.gl/core';
 import {Ellipsoid} from '@math.gl/geospatial';
-const cartographicPosition = [toRadians(21), toRadians(78), 5000];
+const cartographicPosition = [21, 78, 5000]; // longitude degrees, latitude degrees, meters above ellipsoid
 const cartesianPosition = Ellipsoid.WGS84.cartographicToCartesian(cartographicPosition);
 ```
 
@@ -47,7 +46,8 @@ Get the transform from local east-north-up at cartographic (0.0, 0.0) to Earth's
 
 ```js
 import {Ellipsoid} from '@math.gl/geospatial';
-const transformMatrix = Ellipsoid.WGS84.eastNorthUpToFixedFrame([0, 0, 0]);
+const cartesianOrigin = [17832.12, 83234.52, 952313.73]
+const transformMatrix = Ellipsoid.WGS84.eastNorthUpToFixedFrame(cartesianOrigin);
 ```
 
 ## Framework Independence

--- a/docs/modules/geospatial/README.md
+++ b/docs/modules/geospatial/README.md
@@ -18,11 +18,11 @@ Attribution: From <a href="https://en.wikipedia.org/wiki/World_Geodetic_System#/
 | Class             | Description                                                     |
 | ----------------- | --------------------------------------------------------------- |
 | `Ellipsoid`       | Implements ellipsoid                                            |
-| `Ellipsoid.WSG84` | An `Ellipsoid` instance initialized with Earth radii per WGS84. |
+| `Ellipsoid.WGS84` | An `Ellipsoid` instance initialized with Earth radii per WGS84. |
 
 ## Usage Examples
 
-A major use of this library is to convert between "cartesian" (`x`, `y`, `z`) and "cartographic" (`longitude degrees`, `latitude degrees`, `height in metres from ellipsoid`) representations of WSG84 coordinates. The `Ellipsoid` class implements these calculations.
+A major use of this library is to convert between "cartesian" (`x`, `y`, `z`) and "cartographic" (`longitude` and `latitude` in degrees, `height` in meters above the ellipsoid) representations of WGS84 coordinates. The `Ellipsoid` class implements these calculations.
 
 ## Usage
 
@@ -30,7 +30,7 @@ Determine the Cartesian representation of a Cartographic position on a WGS84 ell
 
 ```js
 import {Ellipsoid} from '@math.gl/geospatial';
-const cartographicPosition = [21, 78, 5000]; // longitude degrees, latitude degrees, meters above ellipsoid
+const cartographicPosition = [21, 78, 5000]; // [longitude, latitude, height]
 const cartesianPosition = Ellipsoid.WGS84.cartographicToCartesian(cartographicPosition);
 ```
 
@@ -42,11 +42,11 @@ const cartesianPosition = [17832.12, 83234.52, 952313.73];
 const cartographicPosition = Ellipsoid.WGS84.cartesianToCartographic(cartesianPosition);
 ```
 
-Get the transform from local east-north-up at cartographic (0.0, 0.0) to Earth's fixed frame.
+Get the transform from a local east-north-up frame at a point on the WGS84 ellipsoid to Earth's fixed frame.
 
 ```js
 import {Ellipsoid} from '@math.gl/geospatial';
-const cartesianOrigin = [17832.12, 83234.52, 952313.73]
+const cartesianOrigin = Ellipsoid.WGS84.cartographicToCartesian([21, 78, 0]);
 const transformMatrix = Ellipsoid.WGS84.eastNorthUpToFixedFrame(cartesianOrigin);
 ```
 

--- a/docs/modules/geospatial/api-reference/ellipsoid.md
+++ b/docs/modules/geospatial/api-reference/ellipsoid.md
@@ -15,9 +15,8 @@ Rather than constructing this object directly, one of the provided constants is 
 Determine the Cartesian representation of a Cartographic position on a WGS84 ellipsoid.
 
 ```js
-import {toRadians} from '@math.gl/core';
 import {Ellipsoid} from '@math.gl/geospatial';
-const cartographicPosition = [toRadians(21), toRadians(78), 5000];
+const cartographicPosition = [21, 78, 5000]; // longitude degrees, latitude degrees, meters above ellipsoid
 const cartesianPosition = Ellipsoid.WGS84.cartographicToCartesian(cartographicPosition);
 ```
 
@@ -33,7 +32,8 @@ Get the transform from local east-north-up at cartographic (0.0, 0.0) to Earth's
 
 ```js
 import {Ellipsoid} from '@math.gl/geospatial';
-const transformMatrix = Ellipsoid.WGS84.eastNorthUpToFixedFrame([0, 0, 0]);
+const cartesianOrigin = [17832.12, 83234.52, 952313.73]
+const transformMatrix = Ellipsoid.WGS84.eastNorthUpToFixedFrame(cartesianOrigin);
 ```
 
 ## Static Fields
@@ -116,7 +116,7 @@ Returns
 
 Converts the provided cartographic to Cartesian representation.
 
-- `cartographic` The cartographic position.
+- `cartographic` The cartographic position (degrees).
 - `result` Optional object onto which to store the result.
 
 Returns
@@ -144,7 +144,7 @@ The local axes are defined as:
 - The `y` axis points in the local north direction.
 - The `z` axis points in the direction of the ellipsoid surface normal which passes through the position.
 
-- `origin` The center point of the local reference frame.
+- `origin` The cartesian coordinate of the center point of the local reference frame.
 - `ellipsoid`=`Ellipsoid.WGS84` The ellipsoid whose fixed frame is used in the transformation.
 - `result` Optional object onto which to store the result.
 
@@ -163,7 +163,7 @@ Computes a 4x4 transformation matrix from a reference frame centered at the prov
 - `firstAxis` name of the first axis of the local reference frame. Must be 'east', 'north', 'up', 'west', 'south' or 'down'.
 - `secondAxis` name of the second axis of the local reference frame.
 - `thirdAxis` name of the third axis of the local reference frame. Can be omitted as it is implied by the cross product of the first two axis.
-- `origin` The center point of the local reference frame.
+- `origin` The cartesian coordinate of the center point of the local reference frame.
 - `result` Optional object onto which to store the result.
 
 Returns

--- a/docs/modules/geospatial/api-reference/ellipsoid.md
+++ b/docs/modules/geospatial/api-reference/ellipsoid.md
@@ -8,6 +8,8 @@ A quadratic surface defined in Cartesian coordinates by the equation `(x / a)^2 
 
 The main use of this class is to convert between the "cartesian" and "cartographic" coordinate systems.
 
+Cartographic positions are represented as `[longitude, latitude, height]`. Longitude and latitude are in degrees, and height is in meters above the ellipsoid.
+
 Rather than constructing this object directly, one of the provided constants is used.
 
 ## Usage
@@ -16,7 +18,7 @@ Determine the Cartesian representation of a Cartographic position on a WGS84 ell
 
 ```js
 import {Ellipsoid} from '@math.gl/geospatial';
-const cartographicPosition = [21, 78, 5000]; // longitude degrees, latitude degrees, meters above ellipsoid
+const cartographicPosition = [21, 78, 5000]; // [longitude, latitude, height]
 const cartesianPosition = Ellipsoid.WGS84.cartographicToCartesian(cartographicPosition);
 ```
 
@@ -28,11 +30,11 @@ const cartesianPosition = [17832.12, 83234.52, 952313.73];
 const cartographicPosition = Ellipsoid.WGS84.cartesianToCartographic(cartesianPosition);
 ```
 
-Get the transform from local east-north-up at cartographic (0.0, 0.0) to Earth's fixed frame.
+Get the transform from a local east-north-up frame at a point on the WGS84 ellipsoid to Earth's fixed frame.
 
 ```js
 import {Ellipsoid} from '@math.gl/geospatial';
-const cartesianOrigin = [17832.12, 83234.52, 952313.73]
+const cartesianOrigin = Ellipsoid.WGS84.cartographicToCartesian([21, 78, 0]);
 const transformMatrix = Ellipsoid.WGS84.eastNorthUpToFixedFrame(cartesianOrigin);
 ```
 
@@ -112,29 +114,29 @@ Returns
 
 - A string representing this ellipsoid in the format '(radii.x, radii.y, radii.z)'.
 
-### cartographicToCartesian(cartographic : Number[3], result : Number[3]]) : Vector3 | Number[3]
+### cartographicToCartesian(cartographic : Number[3], result : Number[3]) : Vector3 | Number[3]
 
 Converts the provided cartographic to Cartesian representation.
 
-- `cartographic` The cartographic position (degrees).
+- `cartographic` The cartographic position as `[longitude, latitude, height]`. Longitude and latitude are in degrees, and height is in meters above the ellipsoid.
 - `result` Optional object onto which to store the result.
 
 Returns
 
 - The modified `result` parameter or a new `Vector3` instance if none was provided.
 
-### cartesianToCartographic(cartesian : Number[3], result : Number[3]]) : Vector3 | Number[3] | `undefined`
+### cartesianToCartographic(cartesian : Number[3], result : Number[3]) : Vector3 | Number[3] | `undefined`
 
-Converts the provided cartesian to cartographic representation. The cartesian is `undefined` at the center of the ellipsoid.
+Converts the provided Cartesian position to cartographic representation. The result is `undefined` when the Cartesian position is at the center of the ellipsoid.
 
 - `cartesian` The Cartesian position to convert to cartographic representation.
 - `result` Optional object onto which to store the result.
 
 Returns
 
-- The modified result parameter, new `Vector3` instance if none was provided, or undefined if the cartesian is at the center of the ellipsoid.
+- The modified result parameter, a new `Vector3` instance if none was provided, or `undefined` if the Cartesian position is at the center of the ellipsoid. A defined result contains `[longitude, latitude, height]`, with longitude and latitude in degrees and height in meters above the ellipsoid.
 
-### eastNorthUpToFixedFrame(origin : Number[3], ellpsoid : Ellipsoid, result : Number[16]) : Matrix4 | Number[16]
+### eastNorthUpToFixedFrame(origin : Number[3], result : Number[16]) : Matrix4 | Number[16]
 
 Computes a 4x4 transformation matrix from a reference frame with an east-north-up axes centered at the provided origin to the provided ellipsoid's fixed reference frame.
 
@@ -144,8 +146,7 @@ The local axes are defined as:
 - The `y` axis points in the local north direction.
 - The `z` axis points in the direction of the ellipsoid surface normal which passes through the position.
 
-- `origin` The cartesian coordinate of the center point of the local reference frame.
-- `ellipsoid`=`Ellipsoid.WGS84` The ellipsoid whose fixed frame is used in the transformation.
+- `origin` The Cartesian position at the center of the local reference frame.
 - `result` Optional object onto which to store the result.
 
 Returns
@@ -163,40 +164,40 @@ Computes a 4x4 transformation matrix from a reference frame centered at the prov
 - `firstAxis` name of the first axis of the local reference frame. Must be 'east', 'north', 'up', 'west', 'south' or 'down'.
 - `secondAxis` name of the second axis of the local reference frame.
 - `thirdAxis` name of the third axis of the local reference frame. Can be omitted as it is implied by the cross product of the first two axis.
-- `origin` The cartesian coordinate of the center point of the local reference frame.
+- `origin` The Cartesian position at the center of the local reference frame.
 - `result` Optional object onto which to store the result.
 
 Returns
 
 - A 4x4 transformation matrix from a reference frame, with first axis and second axis compliant with the parameters, in the modified `result` parameter or a new `Matrix4` instance if none was provided.
 
-### geocentricSurfaceNormal(cartesian : Number[3], result : Number[3]]) : Vector3 | Number[3]
+### geocentricSurfaceNormal(cartesian : Number[3], result : Number[3]) : Vector3 | Number[3]
 
 Computes the unit vector directed from the center of this ellipsoid toward the provided Cartesian position.
 
-- `cartesian` - The WSG84 cartesian coordinate for which to to determine the geocentric normal.
+- `cartesian` - The WGS84 Cartesian coordinate for which to determine the geocentric normal.
 - `result` - Optional object onto which to store the result.
 
 Returns
 
 - The modified result parameter or a new `Vector3` instance if none was provided.
 
-### geodeticSurfaceNormalCartographic(cartographic : Number[3], result : Number[3]]) : Vector3 | Number[3]
+### geodeticSurfaceNormalCartographic(cartographic : Number[3], result : Number[3]) : Vector3 | Number[3]
 
 Computes the normal of the plane tangent to the surface of the ellipsoid at the provided position.
 
-- `cartographic` The cartographic position for which to to determine the geodetic normal.
+- `cartographic` The cartographic position as `[longitude, latitude, height]`. Longitude and latitude are in degrees.
 - `result` Optional object onto which to store the result.
 
 Returns
 
 The modified result parameter or a new `Vector3` instance if none was provided.
 
-### geodeticSurfaceNormal(cartesian : Number[3], result : Number[3]]) : Vector3 | Number[3]
+### geodeticSurfaceNormal(cartesian : Number[3], result : Number[3]) : Vector3 | Number[3]
 
 Computes the normal of the plane tangent to the surface of the ellipsoid at the provided position.
 
-- `cartesian` The Cartesian position for which to to determine the surface normal.
+- `cartesian` The Cartesian position for which to determine the surface normal.
 - `result` Optional object onto which to store the result.
 
 Returns

--- a/modules/geospatial/src/ellipsoid.ts
+++ b/modules/geospatial/src/ellipsoid.ts
@@ -89,7 +89,10 @@ export class Ellipsoid {
     return this.radii.toString();
   }
 
-  /** Converts the provided cartographic to Cartesian representation. */
+  /** Converts the provided cartographic position to Cartesian representation.
+   * The position is supplied as [longitude, latitude, height], where longitude and latitude
+   * are in degrees and height is in meters above the ellipsoid.
+   */
   cartographicToCartesian(cartographic: number[], result: Vector3): Vector3;
   cartographicToCartesian(cartographic: number[], result?: number[]): number[];
 
@@ -111,8 +114,10 @@ export class Ellipsoid {
     return k.to(result);
   }
 
-  /** Converts the provided cartesian to cartographic (lng/lat/z) representation.
-   * The cartesian is undefined at the center of the ellipsoid. */
+  /** Converts the provided Cartesian position to [longitude, latitude, height],
+   * where longitude and latitude are in degrees and height is in meters above the ellipsoid.
+   * The cartographic position is undefined at the center of the ellipsoid.
+   */
   cartesianToCartographic(cartesian: Readonly<NumericArray>, result: Vector3): Vector3;
   cartesianToCartographic(cartesian: Readonly<NumericArray>, result?: number[]): number[];
 
@@ -183,7 +188,9 @@ export class Ellipsoid {
     return scratchVector.from(cartesian).normalize().to(result);
   }
 
-  /** Computes the normal of the plane tangent to the surface of the ellipsoid at provided position. */
+  /** Computes the normal of the plane tangent to the surface of the ellipsoid at the provided
+   * [longitude, latitude, height], where longitude and latitude are in degrees.
+   */
   geodeticSurfaceNormalCartographic<NumArray>(
     cartographic: Readonly<NumericArray>,
     result: NumArray

--- a/modules/geospatial/test/ellipsoid/ellipsoid.spec.ts
+++ b/modules/geospatial/test/ellipsoid/ellipsoid.spec.ts
@@ -27,6 +27,7 @@ const spaceCartesianGeodeticSurfaceNormal = new Vector3(
   0.25889908678270795
 );
 
+// [longitude, latitude, height] in degrees, degrees, and meters
 const spaceCartographic = new Vector3(-45.0, 15.0, 330000.0);
 const spaceCartographicGeodeticSurfaceNormal = new Vector3(
   0.68301270189221941,
@@ -126,7 +127,7 @@ test('Ellipsoid#geocentricSurfaceNormal works with a result parameter', (t) => {
   t.end();
 });
 
-test('Ellipsoid#cartographicToCartesian works without a result parameter', (t) => {
+test('Ellipsoid#cartographicToCartesian interprets degrees without a result parameter', (t) => {
   const ellipsoid = Ellipsoid.WGS84;
   const returnedResult = ellipsoid.cartographicToCartesian(spaceCartographic);
   tapeEqualsEpsilon(t, returnedResult, spaceCartesian, _MathUtils.EPSILON7);


### PR DESCRIPTION
This took me 1 day to find out. I assumed the toRadians() was needed, but it must be removed.