### PR TITLE
feat(expressions): add stable expression parser module

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,13 +22,13 @@ math.gl is a toolbox that offers a suite of composable modules.
 | **Core math libraries**           | Module <span style={{width: 300}} /> | Description                                  |
 | --------------------------------- | ------------------------------------ | -------------------------------------------- |
 |                                   | **`@math.gl/types`**                 | Basic math type helpers (`NumericArray` etc) |
-| ![core](./images/core.png "core") | **`@math.gl/core`**                  | Basic math classes (vectors, matrices, etc)  |
+| ![core](./images/core.png 'core') | **`@math.gl/core`**                  | Basic math classes (vectors, matrices, etc)  |
 |                                   | **`@math.gl/expressions`**           | Parse and evaluate lightweight expressions.  |
 
 | **Geospatial math libraries**                       | Module <span style={{width: 300}} /> | Description                                        |
 | --------------------------------------------------- | ------------------------------------ | -------------------------------------------------- |
-| ![geospatial](./images/geospatial.svg "geospatial") | **`@math.gl/geospatial`**            | Ellipsoidal math for WGS84 coordinates.            |
-| ![geoid](./images/geoid.png "geoid")                | **`@math.gl/geoid`**                 | Earth Gravity Model support .                      |
+| ![geospatial](./images/geospatial.svg 'geospatial') | **`@math.gl/geospatial`**            | Ellipsoidal math for WGS84 coordinates.            |
+| ![geoid](./images/geoid.png 'geoid')                | **`@math.gl/geoid`**                 | Earth Gravity Model support .                      |
 |                                                     | **`@math.gl/polygon`**               | Polygon math, including geospatial cutting etc.    |
 |                                                     | **`@math.gl/proj4`**                 | Conversion between coordinate reference systems.   |
 |                                                     | **`@math.gl/sun`**                   | Solar position / direction from position and time. |
@@ -36,13 +36,13 @@ math.gl is a toolbox that offers a suite of composable modules.
 
 | **DGGS (Discrete global grid support) libraries** | Module <span style={{width: 300}} /> | Description                     |
 | ------------------------------------------------- | ------------------------------------ | ------------------------------- |
-| ![geohash](./images/dggs/geohash.png "geohash")   | **`@math.gl/dggs-geohash`**          | Get geometry of GeoHash tokens. |
-| ![quadkey](./images/dggs/quadkey.png "quadkey")   | **`@math.gl/dggs-quadkey`**          | Get geometry of QuadKey tokens  |
-| ![s2](./images/dggs/s2.png "s2")                  | **`@math.gl/dggs-s2`**               | Get geometry of S2 tokens.      |
+| ![geohash](./images/dggs/geohash.png 'geohash')   | **`@math.gl/dggs-geohash`**          | Get geometry of GeoHash tokens. |
+| ![quadkey](./images/dggs/quadkey.png 'quadkey')   | **`@math.gl/dggs-quadkey`**          | Get geometry of QuadKey tokens  |
+| ![s2](./images/dggs/s2.png 's2')                  | **`@math.gl/dggs-s2`**               | Get geometry of S2 tokens.      |
 
 | **3D math libraries**                      | Module <span style={{width: 300}} /> | Description                                |
 | ------------------------------------------ | ------------------------------------ | ------------------------------------------ |
-| ![culling](./images/culling.png "culling") | **`@math.gl/culling`**               | Bounding volumes and intersection testing. |
+| ![culling](./images/culling.png 'culling') | **`@math.gl/culling`**               | Bounding volumes and intersection testing. |
 
 <br/>
 In addition, math.gl provides a few deprecated legacy modules, to avoid breaking older applications.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ math.gl is **optimized for use with WebGL and WebGPU**, however it is not a GPU 
 ## Features
 
 - **Core classes** - Basic vectors and matrices: **`@math.gl/types`**, **`@math.gl/core`**
+- **Expression parsing** - Parse and evaluate compact JavaScript-style expressions: **`@math.gl/expressions`**
 - **Geospatial projections** - Support for a variety of geospatial projections **`@math.gl/geospatial`**, **`@math.gl/geoid`**, **`@math.gl/proj4`**, **`@math.gl/web-mercator`**
 - **Geospatial utilities** - Cutting polygons and calculating sun position and direction **`@math.gl/polygon`**, **`@math.gl/sun`**
 - **Discrete Global Grids** - Standardized interfaces to a number of the major discrete global grids. **`@math.gl/dggs-geohash`**, **`@math.gl/dggs-quadkey`**, **`@math.gl/dggs-s2`**
@@ -21,12 +22,13 @@ math.gl is a toolbox that offers a suite of composable modules.
 | **Core math libraries**           | Module <span style={{width: 300}} /> | Description                                  |
 | --------------------------------- | ------------------------------------ | -------------------------------------------- |
 |                                   | **`@math.gl/types`**                 | Basic math type helpers (`NumericArray` etc) |
-| ![core](./images/core.png 'core') | **`@math.gl/core`**                  | Basic math classes (vectors, matrices, etc)  |
+| ![core](./images/core.png "core") | **`@math.gl/core`**                  | Basic math classes (vectors, matrices, etc)  |
+|                                   | **`@math.gl/expressions`**           | Parse and evaluate lightweight expressions.  |
 
 | **Geospatial math libraries**                       | Module <span style={{width: 300}} /> | Description                                        |
 | --------------------------------------------------- | ------------------------------------ | -------------------------------------------------- |
-| ![geospatial](./images/geospatial.svg 'geospatial') | **`@math.gl/geospatial`**            | Ellipsoidal math for WGS84 coordinates.            |
-| ![geoid](./images/geoid.png 'geoid')                | **`@math.gl/geoid`**                 | Earth Gravity Model support .                      |
+| ![geospatial](./images/geospatial.svg "geospatial") | **`@math.gl/geospatial`**            | Ellipsoidal math for WGS84 coordinates.            |
+| ![geoid](./images/geoid.png "geoid")                | **`@math.gl/geoid`**                 | Earth Gravity Model support .                      |
 |                                                     | **`@math.gl/polygon`**               | Polygon math, including geospatial cutting etc.    |
 |                                                     | **`@math.gl/proj4`**                 | Conversion between coordinate reference systems.   |
 |                                                     | **`@math.gl/sun`**                   | Solar position / direction from position and time. |
@@ -34,13 +36,13 @@ math.gl is a toolbox that offers a suite of composable modules.
 
 | **DGGS (Discrete global grid support) libraries** | Module <span style={{width: 300}} /> | Description                     |
 | ------------------------------------------------- | ------------------------------------ | ------------------------------- |
-| ![geohash](./images/dggs/geohash.png 'geohash')   | **`@math.gl/dggs-geohash`**          | Get geometry of GeoHash tokens. |
-| ![quadkey](./images/dggs/quadkey.png 'quadkey')   | **`@math.gl/dggs-quadkey`**          | Get geometry of QuadKey tokens  |
-| ![s2](./images/dggs/s2.png 's2')                  | **`@math.gl/dggs-s2`**               | Get geometry of S2 tokens.      |
+| ![geohash](./images/dggs/geohash.png "geohash")   | **`@math.gl/dggs-geohash`**          | Get geometry of GeoHash tokens. |
+| ![quadkey](./images/dggs/quadkey.png "quadkey")   | **`@math.gl/dggs-quadkey`**          | Get geometry of QuadKey tokens  |
+| ![s2](./images/dggs/s2.png "s2")                  | **`@math.gl/dggs-s2`**               | Get geometry of S2 tokens.      |
 
 | **3D math libraries**                      | Module <span style={{width: 300}} /> | Description                                |
 | ------------------------------------------ | ------------------------------------ | ------------------------------------------ |
-| ![culling](./images/culling.png 'culling') | **`@math.gl/culling`**               | Bounding volumes and intersection testing. |
+| ![culling](./images/culling.png "culling") | **`@math.gl/culling`**               | Bounding volumes and intersection testing. |
 
 <br/>
 In addition, math.gl provides a few deprecated legacy modules, to avoid breaking older applications.
@@ -76,6 +78,7 @@ math.gl is fully supported on:
 math.gl was inspired by and built upon some of the most proven open source JavaScript math libraries:
 
 - [`gl-matrix`](http://glmatrix.net/) - math.gl classes use gl-matrix under the hood
+- [`expression-eval`](https://www.npmjs.com/package/expression-eval) by [@donmccurdy](https://github.com/donmccurdy) - inspiration and source material for `@math.gl/expressions`
 - THREE.js math library - math.gl classes are API-compatible with a subset of the THREE.js classes and pass THREE.js test suites.
 - The CesiumJS math library (Apache2) - The geospatial and culling modules were ported from Cesium code base.
 

--- a/docs/modules/expressions/README.md
+++ b/docs/modules/expressions/README.md
@@ -1,0 +1,101 @@
+# Overview
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v4.2-blue.svg?style=flat-square" alt="From-v4.2" />
+</p>
+
+The `@math.gl/expressions` module provides a compact expression parser and evaluator for JavaScript-style expressions.
+
+It extracts the expression machinery that has shipped inside `@deck.gl/json` and promotes it to a standalone, documented math.gl module with a stable public API.
+
+## Installation
+
+```bash
+npm install @math.gl/expressions
+```
+
+## Usage
+
+Evaluate a parsed expression against a data object:
+
+```js
+import { parse, eval as evaluate } from "@math.gl/expressions";
+
+const expression = parse("value * scale + 1");
+const result = evaluate(expression, { value: 3, scale: 2 });
+// 7
+```
+
+Compile an expression once and reuse it:
+
+```js
+import { compile } from "@math.gl/expressions";
+
+const accessor = compile("points[1].value");
+const result = accessor({ points: [{ value: 1 }, { value: 4 }] });
+// 4
+```
+
+Supply function libraries through parser options:
+
+```js
+import {
+  BASIC_MATH_FUNCTION_LIBRARY,
+  GEOSPATIAL_FUNCTION_LIBRARY,
+  compile,
+} from "@math.gl/expressions";
+
+const fn = compile(
+  "cartographicToCartesian([toRadians(longitude), toRadians(latitude), 0])",
+  {
+    libraries: [BASIC_MATH_FUNCTION_LIBRARY, GEOSPATIAL_FUNCTION_LIBRARY],
+  },
+);
+
+const cartesian = fn({ longitude: 0, latitude: 0 });
+// [6378137, 0, 0]
+```
+
+Compile a JSON-style accessor expression that disallows function calls:
+
+```js
+import { parseExpressionString } from "@math.gl/expressions";
+
+const getFill = parseExpressionString("style.fill.color");
+const fill = getFill({ style: { fill: { color: "#08f" } } });
+// '#08f'
+```
+
+## API Surface
+
+| Export                        | Description                                                             |
+| ----------------------------- | ----------------------------------------------------------------------- |
+| `parse`                       | Parses an expression string into a JSEP AST.                            |
+| `eval`                        | Evaluates a parsed AST against a context object.                        |
+| `evalAsync`                   | Async evaluator for expressions containing async function calls.        |
+| `compile`                     | Compiles an expression string or AST into a reusable function.          |
+| `compileAsync`                | Async variant of `compile`.                                             |
+| `addUnaryOp`                  | Registers a custom unary operator with the parser and evaluator.        |
+| `addBinaryOp`                 | Registers a custom binary operator with the parser and evaluator.       |
+| `BASIC_MATH_FUNCTION_LIBRARY` | Built-in scalar and vector-aware math helpers for expression contexts.  |
+| `GEOSPATIAL_FUNCTION_LIBRARY` | Built-in WGS84 geospatial helpers for expression contexts.              |
+| `mergeFunctionLibraries`      | Merges one or more function libraries into an evaluation context.       |
+| `parseExpressionString`       | Compiles a JSON-style accessor expression with function calls disabled. |
+
+## Function Libraries
+
+The evaluator APIs accept a `libraries` option:
+
+```ts
+compile(expression, { libraries: [BASIC_MATH_FUNCTION_LIBRARY] });
+eval(ast, row, { libraries: [GEOSPATIAL_FUNCTION_LIBRARY] });
+evalAsync(ast, row, { libraries: [customLibrary] });
+```
+
+Libraries are merged left-to-right and then overlaid with the input context object, so row values win if a field name collides with a library export.
+
+## Attribution
+
+This module is adapted from the expression parser that ships in [`@deck.gl/json`](https://www.npmjs.com/package/@deck.gl/json).
+
+Its evaluator is based on Stephen Oney's [`jsep`](https://github.com/EricSmekens/jsep) parser and on [@donmccurdy](https://github.com/donmccurdy)'s deprecated [`expression-eval`](https://www.npmjs.com/package/expression-eval) module. math.gl keeps that lineage explicit here because the public module is intentionally preserving and documenting the behavior that previously lived inside deck.gl internals.

--- a/docs/modules/expressions/README.md
+++ b/docs/modules/expressions/README.md
@@ -19,20 +19,20 @@ npm install @math.gl/expressions
 Evaluate a parsed expression against a data object:
 
 ```js
-import { parse, eval as evaluate } from "@math.gl/expressions";
+import {parse, eval as evaluate} from '@math.gl/expressions';
 
-const expression = parse("value * scale + 1");
-const result = evaluate(expression, { value: 3, scale: 2 });
+const expression = parse('value * scale + 1');
+const result = evaluate(expression, {value: 3, scale: 2});
 // 7
 ```
 
 Compile an expression once and reuse it:
 
 ```js
-import { compile } from "@math.gl/expressions";
+import {compile} from '@math.gl/expressions';
 
-const accessor = compile("points[1].value");
-const result = accessor({ points: [{ value: 1 }, { value: 4 }] });
+const accessor = compile('points[1].value');
+const result = accessor({points: [{value: 1}, {value: 4}]});
 // 4
 ```
 
@@ -42,27 +42,24 @@ Supply function libraries through parser options:
 import {
   BASIC_MATH_FUNCTION_LIBRARY,
   GEOSPATIAL_FUNCTION_LIBRARY,
-  compile,
-} from "@math.gl/expressions";
+  compile
+} from '@math.gl/expressions';
 
-const fn = compile(
-  "cartographicToCartesian([toRadians(longitude), toRadians(latitude), 0])",
-  {
-    libraries: [BASIC_MATH_FUNCTION_LIBRARY, GEOSPATIAL_FUNCTION_LIBRARY],
-  },
-);
+const fn = compile('cartographicToCartesian([toRadians(longitude), toRadians(latitude), 0])', {
+  libraries: [BASIC_MATH_FUNCTION_LIBRARY, GEOSPATIAL_FUNCTION_LIBRARY]
+});
 
-const cartesian = fn({ longitude: 0, latitude: 0 });
+const cartesian = fn({longitude: 0, latitude: 0});
 // [6378137, 0, 0]
 ```
 
 Compile a JSON-style accessor expression that disallows function calls:
 
 ```js
-import { parseExpressionString } from "@math.gl/expressions";
+import {parseExpressionString} from '@math.gl/expressions';
 
-const getFill = parseExpressionString("style.fill.color");
-const fill = getFill({ style: { fill: { color: "#08f" } } });
+const getFill = parseExpressionString('style.fill.color');
+const fill = getFill({style: {fill: {color: '#08f'}}});
 // '#08f'
 ```
 
@@ -87,9 +84,9 @@ const fill = getFill({ style: { fill: { color: "#08f" } } });
 The evaluator APIs accept a `libraries` option:
 
 ```ts
-compile(expression, { libraries: [BASIC_MATH_FUNCTION_LIBRARY] });
-eval(ast, row, { libraries: [GEOSPATIAL_FUNCTION_LIBRARY] });
-evalAsync(ast, row, { libraries: [customLibrary] });
+compile(expression, {libraries: [BASIC_MATH_FUNCTION_LIBRARY]});
+eval(ast, row, {libraries: [GEOSPATIAL_FUNCTION_LIBRARY]});
+evalAsync(ast, row, {libraries: [customLibrary]});
 ```
 
 Libraries are merged left-to-right and then overlaid with the input context object, so row values win if a field name collides with a library export.

--- a/docs/modules/expressions/api-reference/expression-eval.md
+++ b/docs/modules/expressions/api-reference/expression-eval.md
@@ -1,5 +1,9 @@
 # Expression Evaluator
 
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v4.2-blue.svg?style=flat-square" alt="From-v4.2" />
+</p>
+
 The core evaluator API is useful when you want direct control over parsing, AST reuse, or custom operator registration.
 
 ## `parse(expression: string | Expression): Expression`
@@ -22,15 +26,19 @@ Compiles an expression into a reusable function.
 
 Async variant of `compile`.
 
-## `addUnaryOp(operator: string, callback): void`
+## `addUnaryOp(operator: string, callback: UnaryOperator): void`
 
 Registers a unary operator with both JSEP and the evaluator.
 
-## `addBinaryOp(operator: string, precedenceOrCallback, callback?): void`
+`UnaryOperator` receives the evaluated operand and returns the operator result.
+
+## `addBinaryOp(operator: string, precedenceOrCallback: number | BinaryOperator, callback?: BinaryOperator): void`
 
 Registers a binary operator with both JSEP and the evaluator.
 
 If `callback` is omitted, the second argument is treated as the evaluator implementation and the parser uses the default precedence map bundled with the module.
+
+`BinaryOperator` receives the evaluated left and right operands and returns the operator result. Supply an explicit precedence when registering a new operator.
 
 ## Function Libraries
 
@@ -38,8 +46,29 @@ If `callback` is omitted, the second argument is treated as the evaluator implem
 
 - `libraries?: ExpressionFunctionLibrary[]`
 
-The module ships with:
+Each library is a `Record<string, ExpressionFunction>`. Libraries are merged left-to-right. A later library replaces same-named functions in an earlier library, and values supplied in the evaluation context take final precedence.
 
-- `BASIC_MATH_FUNCTION_LIBRARY`
-- `GEOSPATIAL_FUNCTION_LIBRARY`
-- `mergeFunctionLibraries(context, options)`
+```ts
+import {
+  BASIC_MATH_FUNCTION_LIBRARY,
+  compile,
+  type ExpressionFunctionLibrary
+} from '@math.gl/expressions';
+
+const statistics: ExpressionFunctionLibrary = {
+  mean: (...values: number[]) => values.reduce((sum, value) => sum + value, 0) / values.length
+};
+
+const evaluate = compile('round(mean(a, b, c))', {
+  libraries: [BASIC_MATH_FUNCTION_LIBRARY, statistics]
+});
+
+evaluate({a: 1, b: 2, c: 4}); // 2
+```
+
+The module provides these importable libraries:
+
+- `BASIC_MATH_FUNCTION_LIBRARY` provides common `Math` functions and math.gl helpers including `clamp`, `lerp`, angle conversion, normalization, and safe modulo.
+- `GEOSPATIAL_FUNCTION_LIBRARY` provides WGS84 coordinate conversion, surface projection, local frame, and ellipsoid helpers.
+
+Use `mergeFunctionLibraries(context, options)` when integrating libraries with a custom evaluation workflow. It does not mutate the supplied context or libraries.

--- a/docs/modules/expressions/api-reference/expression-eval.md
+++ b/docs/modules/expressions/api-reference/expression-eval.md
@@ -1,0 +1,45 @@
+# Expression Evaluator
+
+The core evaluator API is useful when you want direct control over parsing, AST reuse, or custom operator registration.
+
+## `parse(expression: string | Expression): Expression`
+
+Parses a string into a JSEP AST. Passing an AST returns it unchanged.
+
+## `eval(expression: Expression, context: ExpressionContext, options?: ExpressionEvaluationOptions): unknown`
+
+Evaluates a parsed expression against the supplied context object.
+
+## `evalAsync(expression: Expression, context: ExpressionContext, options?: ExpressionEvaluationOptions): Promise<unknown>`
+
+Async variant of `eval`. Useful when expressions may call async functions present on the context object.
+
+## `compile(expression: string | Expression, options?: ExpressionEvaluationOptions): (context: ExpressionContext) => unknown`
+
+Compiles an expression into a reusable function.
+
+## `compileAsync(expression: string | Expression, options?: ExpressionEvaluationOptions): (context: ExpressionContext) => Promise<unknown>`
+
+Async variant of `compile`.
+
+## `addUnaryOp(operator: string, callback): void`
+
+Registers a unary operator with both JSEP and the evaluator.
+
+## `addBinaryOp(operator: string, precedenceOrCallback, callback?): void`
+
+Registers a binary operator with both JSEP and the evaluator.
+
+If `callback` is omitted, the second argument is treated as the evaluator implementation and the parser uses the default precedence map bundled with the module.
+
+## Function Libraries
+
+`ExpressionEvaluationOptions` currently supports:
+
+- `libraries?: ExpressionFunctionLibrary[]`
+
+The module ships with:
+
+- `BASIC_MATH_FUNCTION_LIBRARY`
+- `GEOSPATIAL_FUNCTION_LIBRARY`
+- `mergeFunctionLibraries(context, options)`

--- a/docs/modules/expressions/api-reference/parse-expression-string.md
+++ b/docs/modules/expressions/api-reference/parse-expression-string.md
@@ -1,0 +1,19 @@
+# Accessor Compiler
+
+`parseExpressionString(expression: string): (row: Record<string, unknown>) => unknown`
+
+Compiles a JSON-style accessor expression into a reusable function.
+
+## Supported forms
+
+- `-` returns the input object unchanged.
+- `a.b.c` resolves nested properties using dot-path access.
+- General expressions like `value * 100` are parsed and evaluated against the input object.
+
+## Restrictions
+
+Function calls are rejected when using `parseExpressionString()`.
+
+That restriction mirrors the original use inside `@deck.gl/json`, where accessor expressions are evaluated against plain data objects rather than executable environments.
+
+Because of that restriction, function libraries such as `BASIC_MATH_FUNCTION_LIBRARY` and `GEOSPATIAL_FUNCTION_LIBRARY` are intended for `eval()`, `evalAsync()`, `compile()`, and `compileAsync()`, not for `parseExpressionString()`.

--- a/docs/modules/expressions/api-reference/parse-expression-string.md
+++ b/docs/modules/expressions/api-reference/parse-expression-string.md
@@ -1,5 +1,9 @@
 # Accessor Compiler
 
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v4.2-blue.svg?style=flat-square" alt="From-v4.2" />
+</p>
+
 `parseExpressionString(expression: string): (row: Record<string, unknown>) => unknown`
 
 Compiles a JSON-style accessor expression into a reusable function.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -135,10 +135,7 @@
       {
         "type": "category",
         "label": "@math.gl/proj4",
-        "items": [
-          "modules/proj4/README",
-          "modules/proj4/api-reference/proj4-projection"
-        ]
+        "items": ["modules/proj4/README", "modules/proj4/api-reference/proj4-projection"]
       },
       {
         "type": "category",
@@ -161,18 +158,12 @@
       {
         "type": "category",
         "label": "@math.gl/dggs-geohash",
-        "items": [
-          "modules/dggs-geohash/README",
-          "modules/dggs-geohash/api-reference/geohash"
-        ]
+        "items": ["modules/dggs-geohash/README", "modules/dggs-geohash/api-reference/geohash"]
       },
       {
         "type": "category",
         "label": "@math.gl/dggs-quadkey",
-        "items": [
-          "modules/dggs-quadkey/README",
-          "modules/dggs-quadkey/api-reference/quadkey"
-        ]
+        "items": ["modules/dggs-quadkey/README", "modules/dggs-quadkey/api-reference/quadkey"]
       },
       {
         "type": "category",

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -2,11 +2,7 @@
   {
     "type": "category",
     "label": "Overview",
-    "items": [
-      "README",
-      "whats-new",
-      "upgrade-guide"
-    ]
+    "items": ["README", "whats-new", "upgrade-guide"]
   },
   {
     "type": "category",
@@ -34,9 +30,7 @@
       {
         "type": "category",
         "label": "Discrete Global Grid Systems Math",
-        "items": [
-          "developer-guide/geospatial/dggs"
-        ]
+        "items": ["developer-guide/geospatial/dggs"]
       },
       {
         "type": "category",
@@ -83,6 +77,15 @@
           "modules/core/api-reference/vector2",
           "modules/core/api-reference/vector3",
           "modules/core/api-reference/vector4"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "@math.gl/expressions",
+        "items": [
+          "modules/expressions/README",
+          "modules/expressions/api-reference/expression-eval",
+          "modules/expressions/api-reference/parse-expression-string"
         ]
       },
       {
@@ -174,10 +177,7 @@
       {
         "type": "category",
         "label": "@math.gl/dggs-s2",
-        "items": [
-          "modules/dggs-s2/README",
-          "modules/dggs-s2/api-reference/s2"
-        ]
+        "items": ["modules/dggs-s2/README", "modules/dggs-s2/api-reference/s2"]
       }
     ]
   }

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -57,6 +57,13 @@ Release Date: TBD, maybe Q1, 2024.
 
 Goal: Minor functionality additions, as required.
 
+**`@math.gl/expressions`** (NEW MODULE)
+
+- Promotes the expression parser previously embedded in `@deck.gl/json` to a stable, documented module.
+- Parses, evaluates, and compiles synchronous or asynchronous JavaScript-style expressions.
+- Provides configurable function libraries, including importable basic math and WGS84 geospatial libraries.
+- Compiles restricted JSON-style accessor expressions with function calls disabled.
+
 ## v4.1
 
 Release Date: Sep 7, 2024.

--- a/modules/expressions/README.md
+++ b/modules/expressions/README.md
@@ -1,0 +1,7 @@
+# @math.gl/expressions
+
+[math.gl](https://math.gl/docs) expression parsing and evaluation helpers.
+
+This module contains a small expression parser and accessor compiler.
+
+For documentation please visit the [website](https://math.gl).

--- a/modules/expressions/package.json
+++ b/modules/expressions/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@math.gl/expressions",
+  "description": "Expression parsing and evaluation utilities",
+  "license": "MIT",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "version": "4.2.0-alpha.3",
+  "keywords": [
+    "javascript",
+    "math",
+    "expressions",
+    "parser",
+    "evaluator",
+    "jsep"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/math.gl.git"
+  },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "dependencies": {
+    "@math.gl/core": "4.2.0-alpha.3",
+    "@math.gl/geospatial": "4.2.0-alpha.3",
+    "jsep": "^1.4.0"
+  }
+}

--- a/modules/expressions/src/expression-eval.ts
+++ b/modules/expressions/src/expression-eval.ts
@@ -9,13 +9,17 @@
  */
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/restrict-plus-operands */
 
-import jsep from "jsep";
-import {
-  mergeFunctionLibraries,
-  type ExpressionEvaluationOptions,
-} from "./function-libraries";
+import jsep from 'jsep';
+import {mergeFunctionLibraries, type ExpressionEvaluationOptions} from './function-libraries';
 
+/**
+ * Named values and functions available while evaluating an expression.
+ */
 export type ExpressionContext = Record<string, unknown>;
+
+/**
+ * A JSEP abstract syntax tree node supported by the evaluator.
+ */
 export type Expression =
   | jsep.ArrayExpression
   | jsep.BinaryExpression
@@ -27,95 +31,108 @@ export type Expression =
   | jsep.ThisExpression
   | jsep.UnaryExpression;
 
-type Operand = number | string;
-type UnaryCallback = (a: Operand) => Operand;
-type BinaryCallback = (a: Operand, b: Operand) => Operand;
+/**
+ * Evaluator implementation for a custom unary operator.
+ *
+ * @param operand - Value produced by the operator's operand expression.
+ * @returns The operator result.
+ */
+export type UnaryOperator = (operand: any) => any;
+
+/**
+ * Evaluator implementation for a custom binary operator.
+ *
+ * @param left - Value produced by the left operand expression.
+ * @param right - Value produced by the right operand expression.
+ * @returns The operator result.
+ */
+export type BinaryOperator = (left: any, right: any) => any;
+
 type Callable = (...args: any[]) => any;
 
 const DEFAULT_PRECEDENCE: Record<string, number> = {
-  "||": 1,
-  "&&": 2,
-  "|": 3,
-  "^": 4,
-  "&": 5,
-  "==": 6,
-  "!=": 6,
-  "===": 6,
-  "!==": 6,
-  "<": 7,
-  ">": 7,
-  "<=": 7,
-  ">=": 7,
-  "<<": 8,
-  ">>": 8,
-  ">>>": 8,
-  "+": 9,
-  "-": 9,
-  "*": 10,
-  "/": 10,
-  "%": 10,
+  '||': 1,
+  '&&': 2,
+  '|': 3,
+  '^': 4,
+  '&': 5,
+  '==': 6,
+  '!=': 6,
+  '===': 6,
+  '!==': 6,
+  '<': 7,
+  '>': 7,
+  '<=': 7,
+  '>=': 7,
+  '<<': 8,
+  '>>': 8,
+  '>>>': 8,
+  '+': 9,
+  '-': 9,
+  '*': 10,
+  '/': 10,
+  '%': 10
 };
 
 const binops: Record<string, (...args: any[]) => any> = {
-  "||": (a: unknown, b: unknown) => a || b,
-  "&&": (a: unknown, b: unknown) => a && b,
-  "|": (a: number, b: number) => a | b,
-  "^": (a: number, b: number) => a ^ b,
-  "&": (a: number, b: number) => a & b,
-  "==": (a: unknown, b: unknown) => {
+  '||': (a: unknown, b: unknown) => a || b,
+  '&&': (a: unknown, b: unknown) => a && b,
+  '|': (a: number, b: number) => a | b,
+  '^': (a: number, b: number) => a ^ b,
+  '&': (a: number, b: number) => a & b,
+  '==': (a: unknown, b: unknown) => {
     // eslint-disable-next-line eqeqeq
     return a == b;
   },
-  "!=": (a: unknown, b: unknown) => {
+  '!=': (a: unknown, b: unknown) => {
     // eslint-disable-next-line eqeqeq
     return a != b;
   },
-  "===": (a: unknown, b: unknown) => a === b,
-  "!==": (a: unknown, b: unknown) => a !== b,
-  "<": (a: number | string, b: number | string) => a < b,
-  ">": (a: number | string, b: number | string) => a > b,
-  "<=": (a: number | string, b: number | string) => a <= b,
-  ">=": (a: number | string, b: number | string) => a >= b,
-  "<<": (a: number, b: number) => a << b,
-  ">>": (a: number, b: number) => a >> b,
-  ">>>": (a: number, b: number) => a >>> b,
-  "+": (a: unknown, b: unknown) => {
+  '===': (a: unknown, b: unknown) => a === b,
+  '!==': (a: unknown, b: unknown) => a !== b,
+  '<': (a: number | string, b: number | string) => a < b,
+  '>': (a: number | string, b: number | string) => a > b,
+  '<=': (a: number | string, b: number | string) => a <= b,
+  '>=': (a: number | string, b: number | string) => a >= b,
+  '<<': (a: number, b: number) => a << b,
+  '>>': (a: number, b: number) => a >> b,
+  '>>>': (a: number, b: number) => a >>> b,
+  '+': (a: unknown, b: unknown) => {
     // @ts-expect-error Addition intentionally supports JS coercion semantics.
     return a + b;
   },
-  "-": (a: number, b: number) => a - b,
-  "*": (a: number, b: number) => a * b,
-  "/": (a: number, b: number) => a / b,
-  "%": (a: number, b: number) => a % b,
+  '-': (a: number, b: number) => a - b,
+  '*': (a: number, b: number) => a * b,
+  '/': (a: number, b: number) => a / b,
+  '%': (a: number, b: number) => a % b
 };
 
 const unops: Record<string, (...args: any[]) => any> = {
-  "-": (a: number) => -a,
-  "+": (a: unknown) => {
+  '-': (a: number) => -a,
+  '+': (a: unknown) => {
     // eslint-disable-next-line no-implicit-coercion
     return +a;
   },
-  "~": (a: number) => ~a,
-  "!": (a: unknown) => !a,
+  '~': (a: number) => ~a,
+  '!': (a: unknown) => !a
 };
 
-function evaluateArray(
-  list: jsep.Expression[],
-  context: ExpressionContext,
-): unknown[] {
+function evaluateArray(list: jsep.Expression[], context: ExpressionContext): unknown[] {
   return list.map((value) => evaluate(value, context));
 }
 
+/** Evaluates each expression in an array concurrently. */
 async function evaluateArrayAsync(
   list: jsep.Expression[],
-  context: ExpressionContext,
+  context: ExpressionContext
 ): Promise<unknown[]> {
   return await Promise.all(list.map((value) => evalAsync(value, context)));
 }
 
+/** Resolves a member expression and preserves its receiver for method calls. */
 function evaluateMember(
   node: jsep.MemberExpression,
-  context: ExpressionContext,
+  context: ExpressionContext
 ): [Record<string, unknown>, unknown] {
   const object = evaluate(node.object, context) as Record<string, unknown>;
   const key = node.computed
@@ -129,14 +146,12 @@ function evaluateMember(
   return [object, object?.[key]];
 }
 
+/** Asynchronously resolves a member expression and its receiver. */
 async function evaluateMemberAsync(
   node: jsep.MemberExpression,
-  context: ExpressionContext,
+  context: ExpressionContext
 ): Promise<[Record<string, unknown>, unknown]> {
-  const object = (await evalAsync(node.object, context)) as Record<
-    string,
-    unknown
-  >;
+  const object = (await evalAsync(node.object, context)) as Record<string, unknown>;
   const key = node.computed
     ? ((await evalAsync(node.property, context)) as string)
     : (node.property as jsep.Identifier).name;
@@ -148,114 +163,118 @@ async function evaluateMemberAsync(
   return [object, object?.[key]];
 }
 
+/** Evaluates one expression node synchronously. */
 // eslint-disable-next-line complexity
 function evaluateExpression(
   node: jsep.Expression,
   context: ExpressionContext,
-  options?: ExpressionEvaluationOptions,
+  options?: ExpressionEvaluationOptions
 ): unknown {
   const expression = node as Expression;
   const mergedContext = mergeFunctionLibraries(context, options);
 
   switch (expression.type) {
-    case "ArrayExpression":
+    case 'ArrayExpression':
       return evaluateArray(expression.elements, mergedContext);
 
-    case "BinaryExpression":
-      if (expression.operator === "||") {
+    case 'BinaryExpression':
+      if (expression.operator === '||') {
         return (
-          evaluate(expression.left, mergedContext) ||
-          evaluate(expression.right, mergedContext)
+          evaluate(expression.left, mergedContext) || evaluate(expression.right, mergedContext)
         );
       }
-      if (expression.operator === "&&") {
+      if (expression.operator === '&&') {
         return (
-          evaluate(expression.left, mergedContext) &&
-          evaluate(expression.right, mergedContext)
+          evaluate(expression.left, mergedContext) && evaluate(expression.right, mergedContext)
         );
       }
       return binops[expression.operator](
         evaluate(expression.left, mergedContext),
-        evaluate(expression.right, mergedContext),
+        evaluate(expression.right, mergedContext)
       );
 
-    case "CallExpression": {
+    case 'CallExpression': {
       let caller: Record<string, unknown> | undefined;
       let fn: Callable | undefined;
 
-      if (expression.callee.type === "MemberExpression") {
-        const member = evaluateMember(
-          expression.callee as jsep.MemberExpression,
-          mergedContext,
-        );
+      if (expression.callee.type === 'MemberExpression') {
+        const member = evaluateMember(expression.callee as jsep.MemberExpression, mergedContext);
         caller = member[0];
         fn = member[1] as Callable | undefined;
       } else {
         fn = evaluate(expression.callee, mergedContext) as Callable | undefined;
       }
 
-      if (typeof fn !== "function") {
+      if (typeof fn !== 'function') {
         return undefined;
       }
 
-      return fn.apply(
-        caller,
-        evaluateArray(expression.arguments, mergedContext),
-      );
+      return fn.apply(caller, evaluateArray(expression.arguments, mergedContext));
     }
 
-    case "ConditionalExpression":
+    case 'ConditionalExpression':
       return evaluate(expression.test, mergedContext)
         ? evaluate(expression.consequent, mergedContext)
         : evaluate(expression.alternate, mergedContext);
 
-    case "Identifier":
+    case 'Identifier':
       return mergedContext[expression.name];
 
-    case "Literal":
+    case 'Literal':
       return expression.value;
 
-    case "MemberExpression":
+    case 'MemberExpression':
       return evaluateMember(expression, mergedContext)[1];
 
-    case "ThisExpression":
+    case 'ThisExpression':
       return mergedContext;
 
-    case "UnaryExpression":
-      return unops[expression.operator](
-        evaluate(expression.argument, mergedContext),
-      );
+    case 'UnaryExpression':
+      return unops[expression.operator](evaluate(expression.argument, mergedContext));
 
     default:
       return undefined;
   }
 }
 
+/** Evaluates a nested expression using an already-merged context. */
 function evaluate(node: jsep.Expression, context: ExpressionContext): unknown {
   return evaluateExpression(node, context);
 }
 
+/**
+ * Evaluates a parsed expression asynchronously.
+ *
+ * @param node - Expression AST to evaluate.
+ * @param context - Named values and functions available to the expression.
+ * @param options - Function libraries to add to the context.
+ * @returns The resolved expression value.
+ *
+ * @remarks
+ * Function calls are awaited, including calls nested inside arrays, member
+ * expressions, conditionals, unary expressions, and binary expressions.
+ */
 // eslint-disable-next-line complexity
 export async function evalAsync(
   node: jsep.Expression,
   context: ExpressionContext,
-  options?: ExpressionEvaluationOptions,
+  options?: ExpressionEvaluationOptions
 ): Promise<unknown> {
   const expression = node as Expression;
   const mergedContext = mergeFunctionLibraries(context, options);
 
   switch (expression.type) {
-    case "ArrayExpression":
+    case 'ArrayExpression':
       return await evaluateArrayAsync(expression.elements, mergedContext);
 
-    case "BinaryExpression":
-      if (expression.operator === "||") {
+    case 'BinaryExpression':
+      if (expression.operator === '||') {
         return (
           (await evalAsync(expression.left, mergedContext)) ||
           (await evalAsync(expression.right, mergedContext))
         );
       }
-      if (expression.operator === "&&") {
+      if (expression.operator === '&&') {
         return (
           (await evalAsync(expression.left, mergedContext)) &&
           (await evalAsync(expression.right, mergedContext))
@@ -263,89 +282,117 @@ export async function evalAsync(
       }
       return binops[expression.operator](
         await evalAsync(expression.left, mergedContext),
-        await evalAsync(expression.right, mergedContext),
+        await evalAsync(expression.right, mergedContext)
       );
 
-    case "CallExpression": {
+    case 'CallExpression': {
       let caller: Record<string, unknown> | undefined;
       let fn: Callable | undefined;
 
-      if (expression.callee.type === "MemberExpression") {
+      if (expression.callee.type === 'MemberExpression') {
         const member = await evaluateMemberAsync(
           expression.callee as jsep.MemberExpression,
-          mergedContext,
+          mergedContext
         );
         caller = member[0];
         fn = member[1] as Callable | undefined;
       } else {
-        fn = (await evalAsync(expression.callee, mergedContext)) as
-          | Callable
-          | undefined;
+        fn = (await evalAsync(expression.callee, mergedContext)) as Callable | undefined;
       }
 
-      if (typeof fn !== "function") {
+      if (typeof fn !== 'function') {
         return undefined;
       }
 
-      return await fn.apply(
-        caller,
-        await evaluateArrayAsync(expression.arguments, mergedContext),
-      );
+      return await fn.apply(caller, await evaluateArrayAsync(expression.arguments, mergedContext));
     }
 
-    case "ConditionalExpression":
+    case 'ConditionalExpression':
       return (await evalAsync(expression.test, mergedContext))
         ? await evalAsync(expression.consequent, mergedContext)
         : await evalAsync(expression.alternate, mergedContext);
 
-    case "Identifier":
+    case 'Identifier':
       return mergedContext[expression.name];
 
-    case "Literal":
+    case 'Literal':
       return expression.value;
 
-    case "MemberExpression":
+    case 'MemberExpression':
       return (await evaluateMemberAsync(expression, mergedContext))[1];
 
-    case "ThisExpression":
+    case 'ThisExpression':
       return mergedContext;
 
-    case "UnaryExpression":
-      return unops[expression.operator](
-        await evalAsync(expression.argument, mergedContext),
-      );
+    case 'UnaryExpression':
+      return unops[expression.operator](await evalAsync(expression.argument, mergedContext));
 
     default:
       return undefined;
   }
 }
 
+/**
+ * Compiles an expression into a reusable synchronous evaluator.
+ *
+ * @param expression - Expression source or a previously parsed AST.
+ * @param options - Function libraries to add to each evaluation context.
+ * @returns A function that evaluates the expression against a context.
+ */
 export function compile(
   expression: string | jsep.Expression,
-  options?: ExpressionEvaluationOptions,
+  options?: ExpressionEvaluationOptions
 ): (context: ExpressionContext) => unknown {
   const ast = parse(expression);
-  return (context: ExpressionContext) =>
-    evaluateExpression(ast, context, options);
+  return (context: ExpressionContext) => evaluateExpression(ast, context, options);
 }
 
+/**
+ * Compiles an expression into a reusable asynchronous evaluator.
+ *
+ * @param expression - Expression source or a previously parsed AST.
+ * @param options - Function libraries to add to each evaluation context.
+ * @returns A function that asynchronously evaluates the expression.
+ */
 export function compileAsync(
   expression: string | jsep.Expression,
-  options?: ExpressionEvaluationOptions,
+  options?: ExpressionEvaluationOptions
 ): (context: ExpressionContext) => Promise<unknown> {
   const ast = parse(expression);
   return (context: ExpressionContext) => evalAsync(ast, context, options);
 }
 
-export function addUnaryOp(operator: string, fn: UnaryCallback): void {
+/**
+ * Registers a custom unary operator with the parser and evaluator.
+ *
+ * @param operator - Operator token to register.
+ * @param fn - Evaluator implementation for the operator.
+ *
+ * @remarks
+ * Registration changes module-global parser state and affects subsequent
+ * calls to {@link parse}.
+ */
+export function addUnaryOp(operator: string, fn: UnaryOperator): void {
   jsep.addUnaryOp(operator);
   unops[operator] = fn;
 }
 
+/**
+ * Registers a custom binary operator with the parser and evaluator.
+ *
+ * @param operator - Operator token to register.
+ * @param precedenceOrFn - Parser precedence, or the evaluator implementation
+ * when using the default precedence for a built-in operator.
+ * @param fn - Evaluator implementation when an explicit precedence is given.
+ *
+ * @remarks
+ * Registration changes module-global parser state and affects subsequent
+ * calls to {@link parse}. New operators should provide explicit precedence.
+ */
 export function addBinaryOp(
   operator: string,
-  precedenceOrFn: number | BinaryCallback,
-  fn?: BinaryCallback,
+  precedenceOrFn: number | BinaryOperator,
+  fn?: BinaryOperator
 ): void {
   if (fn) {
     jsep.addBinaryOp(operator, precedenceOrFn as number);
@@ -354,11 +401,26 @@ export function addBinaryOp(
   }
 
   jsep.addBinaryOp(operator, DEFAULT_PRECEDENCE[operator] || 1);
-  binops[operator] = precedenceOrFn as BinaryCallback;
+  binops[operator] = precedenceOrFn as BinaryOperator;
 }
 
+/**
+ * Parses expression source into a JSEP abstract syntax tree.
+ *
+ * @param expression - Expression source or an existing AST.
+ * @returns A parsed AST, or the supplied AST unchanged.
+ * @throws If the expression string is not valid JSEP syntax.
+ */
 export function parse(expression: string | jsep.Expression): jsep.Expression {
-  return typeof expression === "string" ? jsep(expression) : expression;
+  return typeof expression === 'string' ? jsep(expression) : expression;
 }
 
-export { evaluateExpression as eval };
+/**
+ * Evaluates a parsed expression synchronously.
+ *
+ * @param node - Expression AST to evaluate.
+ * @param context - Named values and functions available to the expression.
+ * @param options - Function libraries to add to the context.
+ * @returns The expression value.
+ */
+export {evaluateExpression as eval};

--- a/modules/expressions/src/expression-eval.ts
+++ b/modules/expressions/src/expression-eval.ts
@@ -1,0 +1,364 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/**
+ * Sources:
+ * - Copyright (c) 2013 Stephen Oney, http://jsep.from.so/, MIT License
+ * - Copyright (c) 2023 Don McCurdy, https://github.com/donmccurdy/expression-eval, MIT License
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/restrict-plus-operands */
+
+import jsep from "jsep";
+import {
+  mergeFunctionLibraries,
+  type ExpressionEvaluationOptions,
+} from "./function-libraries";
+
+export type ExpressionContext = Record<string, unknown>;
+export type Expression =
+  | jsep.ArrayExpression
+  | jsep.BinaryExpression
+  | jsep.CallExpression
+  | jsep.ConditionalExpression
+  | jsep.Identifier
+  | jsep.Literal
+  | jsep.MemberExpression
+  | jsep.ThisExpression
+  | jsep.UnaryExpression;
+
+type Operand = number | string;
+type UnaryCallback = (a: Operand) => Operand;
+type BinaryCallback = (a: Operand, b: Operand) => Operand;
+type Callable = (...args: any[]) => any;
+
+const DEFAULT_PRECEDENCE: Record<string, number> = {
+  "||": 1,
+  "&&": 2,
+  "|": 3,
+  "^": 4,
+  "&": 5,
+  "==": 6,
+  "!=": 6,
+  "===": 6,
+  "!==": 6,
+  "<": 7,
+  ">": 7,
+  "<=": 7,
+  ">=": 7,
+  "<<": 8,
+  ">>": 8,
+  ">>>": 8,
+  "+": 9,
+  "-": 9,
+  "*": 10,
+  "/": 10,
+  "%": 10,
+};
+
+const binops: Record<string, (...args: any[]) => any> = {
+  "||": (a: unknown, b: unknown) => a || b,
+  "&&": (a: unknown, b: unknown) => a && b,
+  "|": (a: number, b: number) => a | b,
+  "^": (a: number, b: number) => a ^ b,
+  "&": (a: number, b: number) => a & b,
+  "==": (a: unknown, b: unknown) => {
+    // eslint-disable-next-line eqeqeq
+    return a == b;
+  },
+  "!=": (a: unknown, b: unknown) => {
+    // eslint-disable-next-line eqeqeq
+    return a != b;
+  },
+  "===": (a: unknown, b: unknown) => a === b,
+  "!==": (a: unknown, b: unknown) => a !== b,
+  "<": (a: number | string, b: number | string) => a < b,
+  ">": (a: number | string, b: number | string) => a > b,
+  "<=": (a: number | string, b: number | string) => a <= b,
+  ">=": (a: number | string, b: number | string) => a >= b,
+  "<<": (a: number, b: number) => a << b,
+  ">>": (a: number, b: number) => a >> b,
+  ">>>": (a: number, b: number) => a >>> b,
+  "+": (a: unknown, b: unknown) => {
+    // @ts-expect-error Addition intentionally supports JS coercion semantics.
+    return a + b;
+  },
+  "-": (a: number, b: number) => a - b,
+  "*": (a: number, b: number) => a * b,
+  "/": (a: number, b: number) => a / b,
+  "%": (a: number, b: number) => a % b,
+};
+
+const unops: Record<string, (...args: any[]) => any> = {
+  "-": (a: number) => -a,
+  "+": (a: unknown) => {
+    // eslint-disable-next-line no-implicit-coercion
+    return +a;
+  },
+  "~": (a: number) => ~a,
+  "!": (a: unknown) => !a,
+};
+
+function evaluateArray(
+  list: jsep.Expression[],
+  context: ExpressionContext,
+): unknown[] {
+  return list.map((value) => evaluate(value, context));
+}
+
+async function evaluateArrayAsync(
+  list: jsep.Expression[],
+  context: ExpressionContext,
+): Promise<unknown[]> {
+  return await Promise.all(list.map((value) => evalAsync(value, context)));
+}
+
+function evaluateMember(
+  node: jsep.MemberExpression,
+  context: ExpressionContext,
+): [Record<string, unknown>, unknown] {
+  const object = evaluate(node.object, context) as Record<string, unknown>;
+  const key = node.computed
+    ? (evaluate(node.property, context) as string)
+    : (node.property as jsep.Identifier).name;
+
+  if (/^__proto__|prototype|constructor$/.test(key)) {
+    throw new Error(`Access to member "${key}" disallowed.`);
+  }
+
+  return [object, object?.[key]];
+}
+
+async function evaluateMemberAsync(
+  node: jsep.MemberExpression,
+  context: ExpressionContext,
+): Promise<[Record<string, unknown>, unknown]> {
+  const object = (await evalAsync(node.object, context)) as Record<
+    string,
+    unknown
+  >;
+  const key = node.computed
+    ? ((await evalAsync(node.property, context)) as string)
+    : (node.property as jsep.Identifier).name;
+
+  if (/^__proto__|prototype|constructor$/.test(key)) {
+    throw new Error(`Access to member "${key}" disallowed.`);
+  }
+
+  return [object, object?.[key]];
+}
+
+// eslint-disable-next-line complexity
+function evaluateExpression(
+  node: jsep.Expression,
+  context: ExpressionContext,
+  options?: ExpressionEvaluationOptions,
+): unknown {
+  const expression = node as Expression;
+  const mergedContext = mergeFunctionLibraries(context, options);
+
+  switch (expression.type) {
+    case "ArrayExpression":
+      return evaluateArray(expression.elements, mergedContext);
+
+    case "BinaryExpression":
+      if (expression.operator === "||") {
+        return (
+          evaluate(expression.left, mergedContext) ||
+          evaluate(expression.right, mergedContext)
+        );
+      }
+      if (expression.operator === "&&") {
+        return (
+          evaluate(expression.left, mergedContext) &&
+          evaluate(expression.right, mergedContext)
+        );
+      }
+      return binops[expression.operator](
+        evaluate(expression.left, mergedContext),
+        evaluate(expression.right, mergedContext),
+      );
+
+    case "CallExpression": {
+      let caller: Record<string, unknown> | undefined;
+      let fn: Callable | undefined;
+
+      if (expression.callee.type === "MemberExpression") {
+        const member = evaluateMember(
+          expression.callee as jsep.MemberExpression,
+          mergedContext,
+        );
+        caller = member[0];
+        fn = member[1] as Callable | undefined;
+      } else {
+        fn = evaluate(expression.callee, mergedContext) as Callable | undefined;
+      }
+
+      if (typeof fn !== "function") {
+        return undefined;
+      }
+
+      return fn.apply(
+        caller,
+        evaluateArray(expression.arguments, mergedContext),
+      );
+    }
+
+    case "ConditionalExpression":
+      return evaluate(expression.test, mergedContext)
+        ? evaluate(expression.consequent, mergedContext)
+        : evaluate(expression.alternate, mergedContext);
+
+    case "Identifier":
+      return mergedContext[expression.name];
+
+    case "Literal":
+      return expression.value;
+
+    case "MemberExpression":
+      return evaluateMember(expression, mergedContext)[1];
+
+    case "ThisExpression":
+      return mergedContext;
+
+    case "UnaryExpression":
+      return unops[expression.operator](
+        evaluate(expression.argument, mergedContext),
+      );
+
+    default:
+      return undefined;
+  }
+}
+
+function evaluate(node: jsep.Expression, context: ExpressionContext): unknown {
+  return evaluateExpression(node, context);
+}
+
+// eslint-disable-next-line complexity
+export async function evalAsync(
+  node: jsep.Expression,
+  context: ExpressionContext,
+  options?: ExpressionEvaluationOptions,
+): Promise<unknown> {
+  const expression = node as Expression;
+  const mergedContext = mergeFunctionLibraries(context, options);
+
+  switch (expression.type) {
+    case "ArrayExpression":
+      return await evaluateArrayAsync(expression.elements, mergedContext);
+
+    case "BinaryExpression":
+      if (expression.operator === "||") {
+        return (
+          (await evalAsync(expression.left, mergedContext)) ||
+          (await evalAsync(expression.right, mergedContext))
+        );
+      }
+      if (expression.operator === "&&") {
+        return (
+          (await evalAsync(expression.left, mergedContext)) &&
+          (await evalAsync(expression.right, mergedContext))
+        );
+      }
+      return binops[expression.operator](
+        await evalAsync(expression.left, mergedContext),
+        await evalAsync(expression.right, mergedContext),
+      );
+
+    case "CallExpression": {
+      let caller: Record<string, unknown> | undefined;
+      let fn: Callable | undefined;
+
+      if (expression.callee.type === "MemberExpression") {
+        const member = await evaluateMemberAsync(
+          expression.callee as jsep.MemberExpression,
+          mergedContext,
+        );
+        caller = member[0];
+        fn = member[1] as Callable | undefined;
+      } else {
+        fn = (await evalAsync(expression.callee, mergedContext)) as
+          | Callable
+          | undefined;
+      }
+
+      if (typeof fn !== "function") {
+        return undefined;
+      }
+
+      return await fn.apply(
+        caller,
+        await evaluateArrayAsync(expression.arguments, mergedContext),
+      );
+    }
+
+    case "ConditionalExpression":
+      return (await evalAsync(expression.test, mergedContext))
+        ? await evalAsync(expression.consequent, mergedContext)
+        : await evalAsync(expression.alternate, mergedContext);
+
+    case "Identifier":
+      return mergedContext[expression.name];
+
+    case "Literal":
+      return expression.value;
+
+    case "MemberExpression":
+      return (await evaluateMemberAsync(expression, mergedContext))[1];
+
+    case "ThisExpression":
+      return mergedContext;
+
+    case "UnaryExpression":
+      return unops[expression.operator](
+        await evalAsync(expression.argument, mergedContext),
+      );
+
+    default:
+      return undefined;
+  }
+}
+
+export function compile(
+  expression: string | jsep.Expression,
+  options?: ExpressionEvaluationOptions,
+): (context: ExpressionContext) => unknown {
+  const ast = parse(expression);
+  return (context: ExpressionContext) =>
+    evaluateExpression(ast, context, options);
+}
+
+export function compileAsync(
+  expression: string | jsep.Expression,
+  options?: ExpressionEvaluationOptions,
+): (context: ExpressionContext) => Promise<unknown> {
+  const ast = parse(expression);
+  return (context: ExpressionContext) => evalAsync(ast, context, options);
+}
+
+export function addUnaryOp(operator: string, fn: UnaryCallback): void {
+  jsep.addUnaryOp(operator);
+  unops[operator] = fn;
+}
+
+export function addBinaryOp(
+  operator: string,
+  precedenceOrFn: number | BinaryCallback,
+  fn?: BinaryCallback,
+): void {
+  if (fn) {
+    jsep.addBinaryOp(operator, precedenceOrFn as number);
+    binops[operator] = fn;
+    return;
+  }
+
+  jsep.addBinaryOp(operator, DEFAULT_PRECEDENCE[operator] || 1);
+  binops[operator] = precedenceOrFn as BinaryCallback;
+}
+
+export function parse(expression: string | jsep.Expression): jsep.Expression {
+  return typeof expression === "string" ? jsep(expression) : expression;
+}
+
+export { evaluateExpression as eval };

--- a/modules/expressions/src/function-libraries.ts
+++ b/modules/expressions/src/function-libraries.ts
@@ -17,17 +17,52 @@ import {
   sin,
   tan,
   toDegrees,
-  toRadians,
-} from "@math.gl/core";
-import { Ellipsoid, isWGS84 } from "@math.gl/geospatial";
+  toRadians
+} from '@math.gl/core';
+import {Ellipsoid, isWGS84} from '@math.gl/geospatial';
 
+/**
+ * A function that can be exposed to evaluated expressions.
+ *
+ * @param args - Arguments supplied by a call expression.
+ * @returns The value made available to the expression.
+ */
 export type ExpressionFunction = (...args: any[]) => any;
+
+/**
+ * A named collection of functions that can be supplied to an expression
+ * evaluator through {@link ExpressionEvaluationOptions}.
+ */
 export type ExpressionFunctionLibrary = Record<string, ExpressionFunction>;
 
+/**
+ * Options shared by the synchronous and asynchronous expression evaluators.
+ */
 export type ExpressionEvaluationOptions = {
+  /**
+   * Function libraries to add to the evaluation context.
+   *
+   * Libraries are merged from left to right. Functions in later libraries
+   * replace functions with the same name in earlier libraries. Values in the
+   * expression context replace functions with the same name in any library.
+   */
   libraries?: ExpressionFunctionLibrary[];
 };
 
+/**
+ * General-purpose mathematical functions for expression evaluation.
+ *
+ * Includes JavaScript `Math` functions and math.gl helpers such as `clamp`,
+ * `lerp`, `normalizeAngle`, `safeMod`, `toDegrees`, and `toRadians`.
+ *
+ * @example
+ * ```ts
+ * const evaluate = compile("clamp(sin(angle), 0, 1)", {
+ *   libraries: [BASIC_MATH_FUNCTION_LIBRARY]
+ * });
+ * evaluate({angle: Math.PI / 2});
+ * ```
+ */
 export const BASIC_MATH_FUNCTION_LIBRARY: ExpressionFunctionLibrary = {
   abs: Math.abs,
   acos,
@@ -54,9 +89,24 @@ export const BASIC_MATH_FUNCTION_LIBRARY: ExpressionFunctionLibrary = {
   tan,
   toDegrees,
   toRadians,
-  trunc: Math.trunc,
+  trunc: Math.trunc
 };
 
+/**
+ * WGS84 ellipsoid functions for expression evaluation.
+ *
+ * Includes cartographic and Cartesian coordinate conversion, surface
+ * projection, local east-north-up frame generation, and WGS84 inspection.
+ * Angular arguments use radians unless the selected function states otherwise.
+ *
+ * @example
+ * ```ts
+ * const evaluate = compile("cartographicToCartesian(position)", {
+ *   libraries: [GEOSPATIAL_FUNCTION_LIBRARY]
+ * });
+ * evaluate({position: [0, 0, 0]});
+ * ```
+ */
 export const GEOSPATIAL_FUNCTION_LIBRARY: ExpressionFunctionLibrary = {
   cartesianToCartographic: (cartesian: number[], result?: number[]) =>
     Ellipsoid.WGS84.cartesianToCartographic(cartesian, result),
@@ -66,10 +116,8 @@ export const GEOSPATIAL_FUNCTION_LIBRARY: ExpressionFunctionLibrary = {
     Ellipsoid.WGS84.eastNorthUpToFixedFrame(origin, result),
   geodeticSurfaceNormal: (cartesian: number[], result?: number[]) =>
     Ellipsoid.WGS84.geodeticSurfaceNormal(cartesian, result),
-  geodeticSurfaceNormalCartographic: (
-    cartographic: number[],
-    result?: number[],
-  ) => Ellipsoid.WGS84.geodeticSurfaceNormalCartographic(cartographic, result),
+  geodeticSurfaceNormalCartographic: (cartographic: number[], result?: number[]) =>
+    Ellipsoid.WGS84.geodeticSurfaceNormalCartographic(cartographic, result),
   isWGS84,
   scaleToGeocentricSurface: (cartesian: number[], result?: number[]) =>
     Ellipsoid.WGS84.scaleToGeocentricSurface(cartesian, result),
@@ -80,12 +128,24 @@ export const GEOSPATIAL_FUNCTION_LIBRARY: ExpressionFunctionLibrary = {
   transformPositionFromScaledSpace: (position: number[], result?: number[]) =>
     Ellipsoid.WGS84.transformPositionFromScaledSpace(position, result),
   transformPositionToScaledSpace: (position: number[], result?: number[]) =>
-    Ellipsoid.WGS84.transformPositionToScaledSpace(position, result),
+    Ellipsoid.WGS84.transformPositionToScaledSpace(position, result)
 };
 
+/**
+ * Adds configured function libraries to an expression context.
+ *
+ * @param context - Values available to the expression.
+ * @param options - Function libraries to merge into the context.
+ * @returns The original context when no libraries are supplied, or a new
+ * context containing the libraries and context values.
+ *
+ * @remarks
+ * Libraries are merged from left to right, then overlaid with `context`.
+ * The input objects are not modified.
+ */
 export function mergeFunctionLibraries(
   context: Record<string, unknown>,
-  options?: ExpressionEvaluationOptions,
+  options?: ExpressionEvaluationOptions
 ): Record<string, unknown> {
   if (!options?.libraries?.length) {
     return context;

--- a/modules/expressions/src/function-libraries.ts
+++ b/modules/expressions/src/function-libraries.ts
@@ -1,0 +1,95 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return */
+
+import {
+  acos,
+  asin,
+  atan,
+  clamp,
+  cos,
+  degrees,
+  lerp,
+  normalizeAngle,
+  radians,
+  safeMod,
+  sin,
+  tan,
+  toDegrees,
+  toRadians,
+} from "@math.gl/core";
+import { Ellipsoid, isWGS84 } from "@math.gl/geospatial";
+
+export type ExpressionFunction = (...args: any[]) => any;
+export type ExpressionFunctionLibrary = Record<string, ExpressionFunction>;
+
+export type ExpressionEvaluationOptions = {
+  libraries?: ExpressionFunctionLibrary[];
+};
+
+export const BASIC_MATH_FUNCTION_LIBRARY: ExpressionFunctionLibrary = {
+  abs: Math.abs,
+  acos,
+  asin,
+  atan,
+  ceil: Math.ceil,
+  clamp,
+  cos,
+  degrees,
+  exp: Math.exp,
+  floor: Math.floor,
+  lerp,
+  log: Math.log,
+  max: Math.max,
+  min: Math.min,
+  normalizeAngle,
+  pow: Math.pow,
+  radians,
+  round: Math.round,
+  safeMod,
+  sign: Math.sign,
+  sin,
+  sqrt: Math.sqrt,
+  tan,
+  toDegrees,
+  toRadians,
+  trunc: Math.trunc,
+};
+
+export const GEOSPATIAL_FUNCTION_LIBRARY: ExpressionFunctionLibrary = {
+  cartesianToCartographic: (cartesian: number[], result?: number[]) =>
+    Ellipsoid.WGS84.cartesianToCartographic(cartesian, result),
+  cartographicToCartesian: (cartographic: number[], result?: number[]) =>
+    Ellipsoid.WGS84.cartographicToCartesian(cartographic, result),
+  eastNorthUpToFixedFrame: (origin: number[], result?: number[]) =>
+    Ellipsoid.WGS84.eastNorthUpToFixedFrame(origin, result),
+  geodeticSurfaceNormal: (cartesian: number[], result?: number[]) =>
+    Ellipsoid.WGS84.geodeticSurfaceNormal(cartesian, result),
+  geodeticSurfaceNormalCartographic: (
+    cartographic: number[],
+    result?: number[],
+  ) => Ellipsoid.WGS84.geodeticSurfaceNormalCartographic(cartographic, result),
+  isWGS84,
+  scaleToGeocentricSurface: (cartesian: number[], result?: number[]) =>
+    Ellipsoid.WGS84.scaleToGeocentricSurface(cartesian, result),
+  scaleToGeodeticSurface: (cartesian: number[], result?: number[]) =>
+    Ellipsoid.WGS84.scaleToGeodeticSurface(cartesian, result),
+  toDegrees,
+  toRadians,
+  transformPositionFromScaledSpace: (position: number[], result?: number[]) =>
+    Ellipsoid.WGS84.transformPositionFromScaledSpace(position, result),
+  transformPositionToScaledSpace: (position: number[], result?: number[]) =>
+    Ellipsoid.WGS84.transformPositionToScaledSpace(position, result),
+};
+
+export function mergeFunctionLibraries(
+  context: Record<string, unknown>,
+  options?: ExpressionEvaluationOptions,
+): Record<string, unknown> {
+  if (!options?.libraries?.length) {
+    return context;
+  }
+
+  return Object.assign({}, ...options.libraries, context);
+}

--- a/modules/expressions/src/get.ts
+++ b/modules/expressions/src/get.ts
@@ -4,12 +4,12 @@
 
 /**
  * Access properties of nested containers using dot-path notation.
- * Returns `undefined` if any container is not valid, instead of throwing.
+ *
+ * @param container - Object from which to read a value.
+ * @param compositeKey - Dot-separated property path.
+ * @returns The nested value, or `undefined` when the path cannot be resolved.
  */
-export function get(
-  container: Record<string, unknown>,
-  compositeKey: string,
-): unknown {
+export function get(container: Record<string, unknown>, compositeKey: string): unknown {
   let value: unknown = container;
 
   for (const key of getKeys(compositeKey)) {
@@ -19,16 +19,18 @@ export function get(
   return value;
 }
 
+/** Tests whether a value can be used for property access. */
 function isObject(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object";
+  return value !== null && typeof value === 'object';
 }
 
 const keyMap: Record<string, string[]> = {};
 
+/** Returns a cached list of property names for a dot-separated path. */
 function getKeys(compositeKey: string): string[] {
   let keyList = keyMap[compositeKey];
   if (!keyList) {
-    keyList = compositeKey.split(".");
+    keyList = compositeKey.split('.');
     keyMap[compositeKey] = keyList;
   }
   return keyList;

--- a/modules/expressions/src/get.ts
+++ b/modules/expressions/src/get.ts
@@ -1,0 +1,35 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/**
+ * Access properties of nested containers using dot-path notation.
+ * Returns `undefined` if any container is not valid, instead of throwing.
+ */
+export function get(
+  container: Record<string, unknown>,
+  compositeKey: string,
+): unknown {
+  let value: unknown = container;
+
+  for (const key of getKeys(compositeKey)) {
+    value = isObject(value) ? value[key] : undefined;
+  }
+
+  return value;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+const keyMap: Record<string, string[]> = {};
+
+function getKeys(compositeKey: string): string[] {
+  let keyList = keyMap[compositeKey];
+  if (!keyList) {
+    keyList = compositeKey.split(".");
+    keyMap[compositeKey] = keyList;
+  }
+  return keyList;
+}

--- a/modules/expressions/src/index.ts
+++ b/modules/expressions/src/index.ts
@@ -1,0 +1,28 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export type {
+  ExpressionEvaluationOptions,
+  ExpressionFunction,
+  ExpressionFunctionLibrary,
+} from "./function-libraries";
+export type { Expression, ExpressionContext } from "./expression-eval";
+export {
+  addBinaryOp,
+  addUnaryOp,
+  compile,
+  compileAsync,
+  eval,
+  evalAsync,
+  parse,
+} from "./expression-eval";
+export {
+  BASIC_MATH_FUNCTION_LIBRARY,
+  GEOSPATIAL_FUNCTION_LIBRARY,
+  mergeFunctionLibraries,
+} from "./function-libraries";
+export {
+  parseExpressionString,
+  type AccessorFunction,
+} from "./parse-expression-string";

--- a/modules/expressions/src/index.ts
+++ b/modules/expressions/src/index.ts
@@ -5,9 +5,9 @@
 export type {
   ExpressionEvaluationOptions,
   ExpressionFunction,
-  ExpressionFunctionLibrary,
-} from "./function-libraries";
-export type { Expression, ExpressionContext } from "./expression-eval";
+  ExpressionFunctionLibrary
+} from './function-libraries';
+export type {BinaryOperator, Expression, ExpressionContext, UnaryOperator} from './expression-eval';
 export {
   addBinaryOp,
   addUnaryOp,
@@ -15,14 +15,11 @@ export {
   compileAsync,
   eval,
   evalAsync,
-  parse,
-} from "./expression-eval";
+  parse
+} from './expression-eval';
 export {
   BASIC_MATH_FUNCTION_LIBRARY,
   GEOSPATIAL_FUNCTION_LIBRARY,
-  mergeFunctionLibraries,
-} from "./function-libraries";
-export {
-  parseExpressionString,
-  type AccessorFunction,
-} from "./parse-expression-string";
+  mergeFunctionLibraries
+} from './function-libraries';
+export {parseExpressionString, type AccessorFunction} from './parse-expression-string';

--- a/modules/expressions/src/parse-expression-string.ts
+++ b/modules/expressions/src/parse-expression-string.ts
@@ -2,19 +2,33 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type jsep from "jsep";
-import { eval as evaluate, parse } from "./expression-eval";
-import { get } from "./get";
+import type jsep from 'jsep';
+import {eval as evaluate, parse} from './expression-eval';
+import {get} from './get';
 
+/**
+ * An accessor compiled from a JSON-style expression string.
+ *
+ * @param row - Data object against which the expression is evaluated.
+ * @returns The value produced by the expression.
+ */
 export type AccessorFunction = (row: Record<string, unknown>) => unknown;
 
 const cachedExpressionMap: Record<string, AccessorFunction> = {
-  "-": (object) => object,
+  '-': (object) => object
 };
 
 /**
  * Compiles a JSON-style expression string into an accessor function.
- * `-` maps to the identity accessor and `a.b.c` maps to nested property access.
+ *
+ * @param propValue - Accessor expression to compile.
+ * @returns A cached accessor function.
+ * @throws If the expression is invalid or contains a function call.
+ *
+ * @remarks
+ * `-` maps to the identity accessor and `a.b.c` maps to nested property
+ * access. Function calls are rejected so accessors cannot execute functions
+ * supplied by input data.
  */
 export function parseExpressionString(propValue: string): AccessorFunction {
   if (propValue in cachedExpressionMap) {
@@ -23,7 +37,7 @@ export function parseExpressionString(propValue: string): AccessorFunction {
 
   const ast = parse(propValue);
   const func =
-    ast.type === "Identifier"
+    ast.type === 'Identifier'
       ? (row: Record<string, unknown>) => get(row, propValue)
       : compileAst(ast);
 
@@ -31,27 +45,26 @@ export function parseExpressionString(propValue: string): AccessorFunction {
   return func;
 }
 
+/** Validates and compiles a parsed accessor expression. */
 function compileAst(ast: jsep.Expression): AccessorFunction {
   traverse(ast, (node) => {
-    if (node.type === "CallExpression") {
-      throw new Error("Function calls not allowed in expression accessors");
+    if (node.type === 'CallExpression') {
+      throw new Error('Function calls not allowed in expression accessors');
     }
   });
 
   return (row: Record<string, unknown>) => evaluate(ast, row);
 }
 
+/** Visits each AST-like object in a parsed expression. */
 // eslint-disable-next-line complexity
-function traverse(
-  node: unknown,
-  visitor: (node: { type: string }) => void,
-): void {
+function traverse(node: unknown, visitor: (node: {type: string}) => void): void {
   if (Array.isArray(node)) {
     node.forEach((element) => traverse(element, visitor));
     return;
   }
 
-  if (node && typeof node === "object") {
+  if (node && typeof node === 'object') {
     if (isNodeLike(node)) {
       visitor(node);
     }
@@ -61,8 +74,7 @@ function traverse(
   }
 }
 
-function isNodeLike(node: object): node is { type: string } {
-  return (
-    "type" in node && typeof (node as { type?: unknown }).type === "string"
-  );
+/** Tests whether an object resembles a JSEP AST node. */
+function isNodeLike(node: object): node is {type: string} {
+  return 'type' in node && typeof (node as {type?: unknown}).type === 'string';
 }

--- a/modules/expressions/src/parse-expression-string.ts
+++ b/modules/expressions/src/parse-expression-string.ts
@@ -1,0 +1,68 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type jsep from "jsep";
+import { eval as evaluate, parse } from "./expression-eval";
+import { get } from "./get";
+
+export type AccessorFunction = (row: Record<string, unknown>) => unknown;
+
+const cachedExpressionMap: Record<string, AccessorFunction> = {
+  "-": (object) => object,
+};
+
+/**
+ * Compiles a JSON-style expression string into an accessor function.
+ * `-` maps to the identity accessor and `a.b.c` maps to nested property access.
+ */
+export function parseExpressionString(propValue: string): AccessorFunction {
+  if (propValue in cachedExpressionMap) {
+    return cachedExpressionMap[propValue];
+  }
+
+  const ast = parse(propValue);
+  const func =
+    ast.type === "Identifier"
+      ? (row: Record<string, unknown>) => get(row, propValue)
+      : compileAst(ast);
+
+  cachedExpressionMap[propValue] = func;
+  return func;
+}
+
+function compileAst(ast: jsep.Expression): AccessorFunction {
+  traverse(ast, (node) => {
+    if (node.type === "CallExpression") {
+      throw new Error("Function calls not allowed in expression accessors");
+    }
+  });
+
+  return (row: Record<string, unknown>) => evaluate(ast, row);
+}
+
+// eslint-disable-next-line complexity
+function traverse(
+  node: unknown,
+  visitor: (node: { type: string }) => void,
+): void {
+  if (Array.isArray(node)) {
+    node.forEach((element) => traverse(element, visitor));
+    return;
+  }
+
+  if (node && typeof node === "object") {
+    if (isNodeLike(node)) {
+      visitor(node);
+    }
+    for (const key in node) {
+      traverse((node as Record<string, unknown>)[key], visitor);
+    }
+  }
+}
+
+function isNodeLike(node: object): node is { type: string } {
+  return (
+    "type" in node && typeof (node as { type?: unknown }).type === "string"
+  );
+}

--- a/modules/expressions/test/expression-eval.spec.ts
+++ b/modules/expressions/test/expression-eval.spec.ts
@@ -1,0 +1,125 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from "tape-promise/tape";
+import {
+  BASIC_MATH_FUNCTION_LIBRARY,
+  GEOSPATIAL_FUNCTION_LIBRARY,
+  addBinaryOp,
+  compile,
+  compileAsync,
+  eval as evaluate,
+  evalAsync,
+  parse,
+  parseExpressionString,
+} from "@math.gl/expressions";
+
+test("@math.gl/expressions#eval", (t) => {
+  t.equal(
+    evaluate(parse("x * 2 + 1"), { x: 3 }),
+    7,
+    "evaluates arithmetic expressions",
+  );
+  t.equal(
+    evaluate(parse("foo.bar"), { foo: { bar: 5 } }),
+    5,
+    "resolves member expressions",
+  );
+  t.equal(
+    evaluate(parse("flag ? a : b"), { flag: false, a: 1, b: 2 }),
+    2,
+    "evaluates conditionals",
+  );
+  t.deepEqual(
+    evaluate(parse("[x, y, x + y]"), { x: 2, y: 4 }),
+    [2, 4, 6],
+    "evaluates arrays",
+  );
+  t.end();
+});
+
+test("@math.gl/expressions#compile", (t) => {
+  const accessor = compile("points[1].value + offset");
+  t.equal(
+    accessor({ points: [{ value: 1 }, { value: 4 }], offset: 3 }),
+    7,
+    "compiles expressions",
+  );
+  t.end();
+});
+
+test("@math.gl/expressions#compile with function libraries", (t) => {
+  const fn = compile("clamp(sin(angle), 0, 1)", {
+    libraries: [BASIC_MATH_FUNCTION_LIBRARY],
+  });
+  t.equal(
+    fn({ angle: Math.PI / 2 }),
+    1,
+    "uses the bundled basic math function library",
+  );
+  t.end();
+});
+
+test("@math.gl/expressions#compileAsync", async (t) => {
+  const fn = compileAsync("loader(value) + 1");
+  const result = await fn({
+    value: 4,
+    async loader(input: number) {
+      return await Promise.resolve(input * 2);
+    },
+  });
+  t.equal(result, 9, "supports async call evaluation");
+  t.end();
+});
+
+test("@math.gl/expressions#evalAsync", async (t) => {
+  const result = await evalAsync(parse("fetcher(value) * 2"), {
+    value: 5,
+    async fetcher(input: number) {
+      return await Promise.resolve(input + 1);
+    },
+  });
+  t.equal(result, 12, "evaluates async call expressions");
+  t.end();
+});
+
+test("@math.gl/expressions#eval with geospatial function library", (t) => {
+  const result = evaluate(
+    parse("cartographicToCartesian(position)"),
+    { position: [0, 0, 0] },
+    { libraries: [GEOSPATIAL_FUNCTION_LIBRARY] },
+  );
+  t.deepEqual(
+    result,
+    [6378137, 0, 0],
+    "uses the bundled geospatial function library",
+  );
+  t.end();
+});
+
+test("@math.gl/expressions#parseExpressionString", (t) => {
+  const identity = parseExpressionString("-");
+  const property = parseExpressionString("a.b.c");
+  const expression = parseExpressionString("value * 3");
+
+  t.deepEqual(
+    identity({ value: 1 }),
+    { value: 1 },
+    "supports identity accessors",
+  );
+  t.equal(property({ a: { b: { c: 9 } } }), 9, "supports dot-path accessors");
+  t.equal(expression({ value: 3 }), 9, "supports expression accessors");
+  t.throws(
+    () => parseExpressionString("fn(value)"),
+    /Function calls not allowed/,
+    "rejects function calls in accessors",
+  );
+  t.end();
+});
+
+test("@math.gl/expressions#addBinaryOp", (t) => {
+  addBinaryOp("**", 11, (a: number, b: number) => a ** b);
+  t.equal(evaluate(parse("2 ** 3"), {}), 8, "supports custom operators");
+  t.end();
+});

--- a/modules/expressions/test/expression-eval.spec.ts
+++ b/modules/expressions/test/expression-eval.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from "tape-promise/tape";
+import test from 'tape-promise/tape';
 import {
   BASIC_MATH_FUNCTION_LIBRARY,
   GEOSPATIAL_FUNCTION_LIBRARY,
@@ -12,114 +12,98 @@ import {
   eval as evaluate,
   evalAsync,
   parse,
-  parseExpressionString,
-} from "@math.gl/expressions";
+  parseExpressionString
+} from '@math.gl/expressions';
 
-test("@math.gl/expressions#eval", (t) => {
-  t.equal(
-    evaluate(parse("x * 2 + 1"), { x: 3 }),
-    7,
-    "evaluates arithmetic expressions",
-  );
-  t.equal(
-    evaluate(parse("foo.bar"), { foo: { bar: 5 } }),
-    5,
-    "resolves member expressions",
-  );
-  t.equal(
-    evaluate(parse("flag ? a : b"), { flag: false, a: 1, b: 2 }),
-    2,
-    "evaluates conditionals",
-  );
-  t.deepEqual(
-    evaluate(parse("[x, y, x + y]"), { x: 2, y: 4 }),
-    [2, 4, 6],
-    "evaluates arrays",
-  );
+test('@math.gl/expressions#eval', (t) => {
+  t.equal(evaluate(parse('x * 2 + 1'), {x: 3}), 7, 'evaluates arithmetic expressions');
+  t.equal(evaluate(parse('foo.bar'), {foo: {bar: 5}}), 5, 'resolves member expressions');
+  t.equal(evaluate(parse('flag ? a : b'), {flag: false, a: 1, b: 2}), 2, 'evaluates conditionals');
+  t.deepEqual(evaluate(parse('[x, y, x + y]'), {x: 2, y: 4}), [2, 4, 6], 'evaluates arrays');
   t.end();
 });
 
-test("@math.gl/expressions#compile", (t) => {
-  const accessor = compile("points[1].value + offset");
-  t.equal(
-    accessor({ points: [{ value: 1 }, { value: 4 }], offset: 3 }),
-    7,
-    "compiles expressions",
-  );
+test('@math.gl/expressions#compile', (t) => {
+  const accessor = compile('points[1].value + offset');
+  t.equal(accessor({points: [{value: 1}, {value: 4}], offset: 3}), 7, 'compiles expressions');
   t.end();
 });
 
-test("@math.gl/expressions#compile with function libraries", (t) => {
-  const fn = compile("clamp(sin(angle), 0, 1)", {
-    libraries: [BASIC_MATH_FUNCTION_LIBRARY],
+test('@math.gl/expressions#compile with function libraries', (t) => {
+  const fn = compile('clamp(sin(angle), 0, 1)', {
+    libraries: [BASIC_MATH_FUNCTION_LIBRARY]
   });
+  t.equal(fn({angle: Math.PI / 2}), 1, 'uses the bundled basic math function library');
+  t.end();
+});
+
+test('@math.gl/expressions#function library precedence', (t) => {
+  const firstLibrary = {transform: (value: number) => value + 1};
+  const secondLibrary = {transform: (value: number) => value * 2};
+  const fn = compile('transform(value)', {
+    libraries: [firstLibrary, secondLibrary]
+  });
+
+  t.equal(fn({value: 3}), 6, 'later libraries override earlier libraries');
   t.equal(
-    fn({ angle: Math.PI / 2 }),
-    1,
-    "uses the bundled basic math function library",
+    fn({value: 3, transform: (value: number) => value - 1}),
+    2,
+    'context values override function libraries'
   );
   t.end();
 });
 
-test("@math.gl/expressions#compileAsync", async (t) => {
-  const fn = compileAsync("loader(value) + 1");
+test('@math.gl/expressions#compileAsync', async (t) => {
+  const fn = compileAsync('loader(value) + 1');
   const result = await fn({
     value: 4,
     async loader(input: number) {
       return await Promise.resolve(input * 2);
-    },
+    }
   });
-  t.equal(result, 9, "supports async call evaluation");
+  t.equal(result, 9, 'supports async call evaluation');
   t.end();
 });
 
-test("@math.gl/expressions#evalAsync", async (t) => {
-  const result = await evalAsync(parse("fetcher(value) * 2"), {
+test('@math.gl/expressions#evalAsync', async (t) => {
+  const result = await evalAsync(parse('fetcher(value) * 2'), {
     value: 5,
     async fetcher(input: number) {
       return await Promise.resolve(input + 1);
-    },
+    }
   });
-  t.equal(result, 12, "evaluates async call expressions");
+  t.equal(result, 12, 'evaluates async call expressions');
   t.end();
 });
 
-test("@math.gl/expressions#eval with geospatial function library", (t) => {
+test('@math.gl/expressions#eval with geospatial function library', (t) => {
   const result = evaluate(
-    parse("cartographicToCartesian(position)"),
-    { position: [0, 0, 0] },
-    { libraries: [GEOSPATIAL_FUNCTION_LIBRARY] },
+    parse('cartographicToCartesian(position)'),
+    {position: [0, 0, 0]},
+    {libraries: [GEOSPATIAL_FUNCTION_LIBRARY]}
   );
-  t.deepEqual(
-    result,
-    [6378137, 0, 0],
-    "uses the bundled geospatial function library",
-  );
+  t.deepEqual(result, [6378137, 0, 0], 'uses the bundled geospatial function library');
   t.end();
 });
 
-test("@math.gl/expressions#parseExpressionString", (t) => {
-  const identity = parseExpressionString("-");
-  const property = parseExpressionString("a.b.c");
-  const expression = parseExpressionString("value * 3");
+test('@math.gl/expressions#parseExpressionString', (t) => {
+  const identity = parseExpressionString('-');
+  const property = parseExpressionString('a.b.c');
+  const expression = parseExpressionString('value * 3');
 
-  t.deepEqual(
-    identity({ value: 1 }),
-    { value: 1 },
-    "supports identity accessors",
-  );
-  t.equal(property({ a: { b: { c: 9 } } }), 9, "supports dot-path accessors");
-  t.equal(expression({ value: 3 }), 9, "supports expression accessors");
+  t.deepEqual(identity({value: 1}), {value: 1}, 'supports identity accessors');
+  t.equal(property({a: {b: {c: 9}}}), 9, 'supports dot-path accessors');
+  t.equal(expression({value: 3}), 9, 'supports expression accessors');
   t.throws(
-    () => parseExpressionString("fn(value)"),
+    () => parseExpressionString('fn(value)'),
     /Function calls not allowed/,
-    "rejects function calls in accessors",
+    'rejects function calls in accessors'
   );
   t.end();
 });
 
-test("@math.gl/expressions#addBinaryOp", (t) => {
-  addBinaryOp("**", 11, (a: number, b: number) => a ** b);
-  t.equal(evaluate(parse("2 ** 3"), {}), 8, "supports custom operators");
+test('@math.gl/expressions#addBinaryOp', (t) => {
+  addBinaryOp('**', 11, (a: number, b: number) => a ** b);
+  t.equal(evaluate(parse('2 ** 3'), {}), 8, 'supports custom operators');
   t.end();
 });

--- a/modules/expressions/test/index.ts
+++ b/modules/expressions/test/index.ts
@@ -1,0 +1,5 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import "./expression-eval.spec";

--- a/modules/expressions/test/index.ts
+++ b/modules/expressions/test/index.ts
@@ -2,4 +2,4 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import "./expression-eval.spec";
+import './expression-eval.spec';

--- a/modules/expressions/tsconfig.json
+++ b/modules/expressions/tsconfig.json
@@ -7,5 +7,5 @@
     "rootDir": "src",
     "outDir": "dist"
   },
-  "references": [{ "path": "../core" }, { "path": "../geospatial" }]
+  "references": [{"path": "../core"}, {"path": "../geospatial"}]
 }

--- a/modules/expressions/tsconfig.json
+++ b/modules/expressions/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [{ "path": "../core" }, { "path": "../geospatial" }]
+}

--- a/test/modules.spec.ts
+++ b/test/modules.spec.ts
@@ -1,13 +1,14 @@
-import '../modules/types/test';
-import '../modules/core/test';
-import '../modules/culling/test';
-import '../modules/geoid/test';
-import '../modules/geospatial/test';
-import '../modules/polygon/test';
-import '../modules/proj4/test';
-import '../modules/sun/test';
-import '../modules/web-mercator/test';
+import "../modules/types/test";
+import "../modules/core/test";
+import "../modules/expressions/test";
+import "../modules/culling/test";
+import "../modules/geoid/test";
+import "../modules/geospatial/test";
+import "../modules/polygon/test";
+import "../modules/proj4/test";
+import "../modules/sun/test";
+import "../modules/web-mercator/test";
 
-import '../modules/dggs-geohash/test';
-import '../modules/dggs-quadkey/test';
-import '../modules/dggs-s2/test';
+import "../modules/dggs-geohash/test";
+import "../modules/dggs-quadkey/test";
+import "../modules/dggs-s2/test";

--- a/test/modules.spec.ts
+++ b/test/modules.spec.ts
@@ -1,14 +1,14 @@
-import "../modules/types/test";
-import "../modules/core/test";
-import "../modules/expressions/test";
-import "../modules/culling/test";
-import "../modules/geoid/test";
-import "../modules/geospatial/test";
-import "../modules/polygon/test";
-import "../modules/proj4/test";
-import "../modules/sun/test";
-import "../modules/web-mercator/test";
+import '../modules/types/test';
+import '../modules/core/test';
+import '../modules/expressions/test';
+import '../modules/culling/test';
+import '../modules/geoid/test';
+import '../modules/geospatial/test';
+import '../modules/polygon/test';
+import '../modules/proj4/test';
+import '../modules/sun/test';
+import '../modules/web-mercator/test';
 
-import "../modules/dggs-geohash/test";
-import "../modules/dggs-quadkey/test";
-import "../modules/dggs-s2/test";
+import '../modules/dggs-geohash/test';
+import '../modules/dggs-quadkey/test';
+import '../modules/dggs-s2/test';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
     "noImplicitThis": true, // covered by strict
     "strictBindCallApply": true, // covered by strict
     "strictFunctionTypes": true, // covered by strict
-    "useUnknownInCatchVariables": true,  // covered by strict
+    "useUnknownInCatchVariables": true, // covered by strict
     // "strictNullChecks": true, // covered by strict
     // "strictPropertyInitialization": true, // covered by strict, requires strict null checks
 
@@ -43,6 +43,8 @@
     "paths": {
       "@math.gl/core/*": ["modules/core/src/*"],
       "@math.gl/core/test/*": ["modules/core/test/*"],
+      "@math.gl/expressions/*": ["modules/expressions/src/*"],
+      "@math.gl/expressions/test/*": ["modules/expressions/test/*"],
       "@math.gl/culling/*": ["modules/culling/src/*"],
       "@math.gl/culling/test/*": ["modules/culling/test/*"],
       "@math.gl/dggs-pgeohash/*": ["modules/dggs-pgeohash/src/*"],
@@ -80,11 +82,8 @@
       }
     ]
   },
-  "include":[
-    "modules/*/src",
-    "modules/*/test"
-  ],
-  "exclude":[
+  "include": ["modules/*/src", "modules/*/test"],
+  "exclude": [
     "modules/core/test",
     "modules/polygon/test",
     "modules/web-mercator/test",

--- a/yarn.lock
+++ b/yarn.lock
@@ -845,6 +845,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@math.gl/expressions@workspace:modules/expressions":
+  version: 0.0.0-use.local
+  resolution: "@math.gl/expressions@workspace:modules/expressions"
+  dependencies:
+    "@math.gl/core": "npm:4.2.0-alpha.3"
+    "@math.gl/geospatial": "npm:4.2.0-alpha.3"
+    jsep: "npm:^1.4.0"
+  languageName: unknown
+  linkType: soft
+
 "@math.gl/geoid@workspace:modules/geoid":
   version: 0.0.0-use.local
   resolution: "@math.gl/geoid@workspace:modules/geoid"
@@ -853,7 +863,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@math.gl/geospatial@workspace:modules/geospatial":
+"@math.gl/geospatial@npm:4.2.0-alpha.3, @math.gl/geospatial@workspace:modules/geospatial":
   version: 0.0.0-use.local
   resolution: "@math.gl/geospatial@workspace:modules/geospatial"
   dependencies:
@@ -6311,6 +6321,13 @@ __metadata:
     whatwg-url: "npm:^4.3.0"
     xml-name-validator: "npm:^2.0.1"
   checksum: 10c0/bcfce735902ad93fcd3a02feb5bd2b2e8f3ce17a7859978dd85f0874fb5cf0a06719db7b5d01a19ec5afbe469ed5da3d013e773aead56ddead9ce9cba7568913
+  languageName: node
+  linkType: hard
+
+"jsep@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "jsep@npm:1.4.0"
+  checksum: 10c0/fe60adf47e050e22eadced42514a51a15a3cf0e2d147896584486acd8ee670fc16641101b9aeb81f4aaba382043d29744b7aac41171e8106515b14f27e0c7116
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- add `@math.gl/expressions` as a first-class package based on the expression parser previously embedded in `@deck.gl/json`
- expose synchronous and asynchronous parse, evaluate, compile, and custom-operator APIs with complete TSDoc
- add configurable function libraries with importable basic math and WGS84 geospatial libraries
- document the module, API, v4.2 availability, and the attribution to @donmccurdy's deprecated `expression-eval` module
- register the package in monorepo TypeScript paths, docs navigation, package tests, and the v4.2 What's New notes

## Impact

Applications can reuse deck.gl's expression behavior without depending on `@deck.gl/json` internals. Function libraries provide an explicit, composable way to expose trusted math and geospatial operations to evaluated expressions, with documented merge precedence.

## Validation

- `yarn lint`
- `./node_modules/.bin/ocular-test node` (2,614 passing)
- `./node_modules/.bin/tsc -p modules/expressions/tsconfig.json --noEmit`
- `yarn build`