### PR TITLE
fix(core): correct Euler quaternion rotation order

### DIFF
--- a/modules/core/src/classes/euler.ts
+++ b/modules/core/src/classes/euler.ts
@@ -294,15 +294,15 @@ export class Euler extends MathArray {
       case RotationOrder.XYZ:
         return q.rotateX(this[0]).rotateY(this[1]).rotateZ(this[2]);
       case RotationOrder.YXZ:
-        return q.rotateY(this[0]).rotateX(this[1]).rotateZ(this[2]);
+        return q.rotateY(this[1]).rotateX(this[0]).rotateZ(this[2]);
       case RotationOrder.ZXY:
-        return q.rotateZ(this[0]).rotateX(this[1]).rotateY(this[2]);
+        return q.rotateZ(this[2]).rotateX(this[0]).rotateY(this[1]);
       case RotationOrder.ZYX:
-        return q.rotateZ(this[0]).rotateY(this[1]).rotateX(this[2]);
+        return q.rotateZ(this[2]).rotateY(this[1]).rotateX(this[0]);
       case RotationOrder.YZX:
-        return q.rotateY(this[0]).rotateZ(this[1]).rotateX(this[2]);
+        return q.rotateY(this[1]).rotateZ(this[2]).rotateX(this[0]);
       case RotationOrder.XZY:
-        return q.rotateX(this[0]).rotateZ(this[1]).rotateY(this[2]);
+        return q.rotateX(this[0]).rotateZ(this[2]).rotateY(this[1]);
       default:
         throw new Error(ERR_UNKNOWN_ORDER);
     }

--- a/modules/core/test/classes/euler.spec.ts
+++ b/modules/core/test/classes/euler.spec.ts
@@ -94,6 +94,27 @@ test('Euler#coverage', t => {
   t.end();
 });
 
+test('Euler#getQuaternion', t => {
+  const angles = [30 * DEGREE_TO_RADIANS, 45 * DEGREE_TO_RADIANS, 60 * DEGREE_TO_RADIANS];
+  const orders = [Euler.XYZ, Euler.YXZ, Euler.ZXY, Euler.ZYX, Euler.YZX, Euler.XZY];
+
+  for (const order of orders) {
+    const euler = new Euler(angles[0], angles[1], angles[2], order);
+    const rotationMatrix = new Matrix4();
+    euler.getRotationMatrix(rotationMatrix);
+    const quaternionMatrix = new Matrix4().fromQuaternion(euler.getQuaternion());
+
+    tapeEquals(
+      t,
+      quaternionMatrix,
+      rotationMatrix,
+      `Euler.getQuaternion matches getRotationMatrix for ${Euler.rotationOrder(order)}`
+    );
+  }
+
+  t.end();
+});
+
 test('Euler#toQuaternion', t => {
   const eulers = [
     new Euler(


### PR DESCRIPTION
## Summary

- use the x, y, and z Euler components for their corresponding rotation axes when constructing quaternions
- add regression coverage comparing Euler-to-matrix and Euler-to-quaternion-to-matrix conversions for all six supported rotation orders

## Root cause

`Euler.getQuaternion()` treated component indices as positions in the selected rotation-order sequence for every non-`XYZ` order. The rest of the Euler API, including `getRotationMatrix()`, stores the components as x-, y-, and z-axis angles. As a result, the two conversion paths produced different rotations.

## Impact

`Euler.getQuaternion()` now agrees with `Euler.getRotationMatrix()` regardless of rotation order. Callers can consistently construct an Euler as `(x, y, z, order)`.

## Validation

- `yarn test` — 2,714 passing Node and browser tests
- `yarn lint`
- `yarn build`

Fixes #63