### PR TITLE
chore: upgrade to Yarn 4.18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Enable Corepack / Yarn 4
         run: |
           corepack enable
-          corepack prepare yarn@4.13.0 --activate
+          corepack prepare yarn@4.18.0 --activate
           yarn -v
 
       - name: Cache Yarn Berry artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Enable Corepack / Yarn 4
         run: |
           corepack enable
-          corepack prepare yarn@4.13.0 --activate
+          corepack prepare yarn@4.18.0 --activate
           yarn -v
 
       - name: Cache Yarn Berry artifacts

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Enable Corepack / Yarn 4
         run: |
           corepack enable
-          corepack prepare yarn@4.13.0 --activate
+          corepack prepare yarn@4.18.0 --activate
           yarn -v
 
       - name: Cache Yarn Berry artifacts

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,8 @@
+approvedGitRepositories:
+  - "**"
+
+enableScripts: true
+
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 0

--- a/package.json
+++ b/package.json
@@ -48,5 +48,5 @@
   "pre-commit": [
     "test-pre-commit"
   ],
-  "packageManager": "yarn@4.13.0"
+  "packageManager": "yarn@4.18.0"
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10c0
 
 "@algolia/autocomplete-core@npm:1.17.4":
@@ -10290,14 +10290,14 @@ __metadata:
 
 "resolve@patch:resolve@npm%3A^1.1.6#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>":
   version: 1.22.8
-  resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=9bd1a5"
   dependencies:
     is-core-module: "npm:^2.13.0"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/0446f024439cd2e50c6c8fa8ba77eaa8370b4180f401a96abf3d1ebc770ac51c1955e12764cde449fde3fff480a61f84388e3505ecdbab778f4bef5f8212c729
+  checksum: 10c0/4bc6de64a713422234e0e773bff296767d77d6e545b98042ff90a796d356f2b131853f4fa1d54e2c415aa6efa6dc2eed5b3f501f63164f834619fda900e33b8e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10c0
 
 "@babel/code-frame@npm:^7.0.0":
@@ -9117,27 +9117,27 @@ __metadata:
 
 "resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
   version: 1.22.8
-  resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=9bd1a5"
   dependencies:
     is-core-module: "npm:^2.13.0"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/0446f024439cd2e50c6c8fa8ba77eaa8370b4180f401a96abf3d1ebc770ac51c1955e12764cde449fde3fff480a61f84388e3505ecdbab778f4bef5f8212c729
+  checksum: 10c0/4bc6de64a713422234e0e773bff296767d77d6e545b98042ff90a796d356f2b131853f4fa1d54e2c415aa6efa6dc2eed5b3f501f63164f834619fda900e33b8e
   languageName: node
   linkType: hard
 
 "resolve@patch:resolve@npm%3A^2.0.0-next.5#optional!builtin<compat/resolve>":
   version: 2.0.0-next.5
-  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.5#optional!builtin<compat/resolve>::version=2.0.0-next.5&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.5#optional!builtin<compat/resolve>::version=2.0.0-next.5&hash=9bd1a5"
   dependencies:
     is-core-module: "npm:^2.13.0"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/78ad6edb8309a2bfb720c2c1898f7907a37f858866ce11a5974643af1203a6a6e05b2fa9c53d8064a673a447b83d42569260c306d43628bff5bb101969708355
+  checksum: 10c0/9f2cb75a47ee17edca53b3a4e96883e82fe92dadc323a19868621b897da5136f7dd3189b7bac4d4e7715bb3b2fd5c1e8c5145ebccc7e0368b1546206f9644c12
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

- Upgrade the repository package manager from Yarn 4.13.0 to Yarn 4.18.0.
- Update the Corepack pins in the test, website, and release workflows.
- Migrate the root and website lockfiles to the current Yarn lockfile format.
- Preserve the previous install behavior for dependency scripts, Git dependencies, and the npm age gate.

## Why

Yarn 4.17.1 and newer fix compatibility-patch failures when installing TypeScript 7. This is the prerequisite for the follow-up TypeScript 7 upgrade.

## Impact

This changes the package-manager version and lockfile metadata only; application and library source code is unchanged.

## Checks

- Root immutable install
- Root build
- Biome lint
- Browser-headless test suite: 2,708 passing
- Website immutable install and production build