### PR TITLE
chore: upgrade to TypeScript 7

### DIFF
--- a/modules/web-mercator/tsconfig.json
+++ b/modules/web-mercator/tsconfig.json
@@ -9,6 +9,7 @@
     "outDir": "dist"
   },
   "references": [
-    {"path": "../types"}
+    {"path": "../types"},
+    {"path": "../core"}
   ]
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "bootstrap": "yarn && ocular-bootstrap && npm run build",
-    "build": "ocular-clean && time ocular-build",
+    "build": "ocular-clean && time node scripts/build.js",
     "cover": "ocular-test cover",
     "lint": "yarn workspace @math.gl/devtools-extensions lint",
     "metrics": "ocular-metrics",
@@ -25,23 +25,24 @@
     "test-pre-commit": "yarn lint && ocular-test node"
   },
   "devDependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.0",
     "@math.gl/devtools-extensions": "workspace:*",
     "@probe.gl/bench": "^4.0.0",
     "@turf/destination": "^6.0.1",
     "@types/tape-promise": "^4.0.1",
+    "@typescript/native": "npm:typescript@7.0.2",
     "@vis.gl/dev-tools": "^1.0.2",
-    "@vis.gl/ts-plugins": "^1.0.2",
+    "esbuild": "^0.16.7",
     "pre-commit": "^1.2.2",
     "puppeteer": "^22.0.0",
-    "tap-spec": "^5.0.0"
+    "tap-spec": "^5.0.0",
+    "typescript": "npm:@typescript/typescript6@6.0.2"
   },
   "resolutions_notes": {
-    "typescript": "Control the version of TypeScript to avoid breaking changes",
     "ts-patch": "Keep the TS transformer patch layer compatible with the selected TypeScript version",
     "tape": "New versions mess up numeric equality tests"
   },
   "resolutions": {
-    "typescript": "6.0.2",
     "ts-patch": "3.3.0",
     "tape": "4.5.0"
   },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,83 @@
+import {spawnSync} from 'node:child_process';
+import {readdir, readFile} from 'node:fs/promises';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import esbuild from 'esbuild';
+import {rewriteModuleSpecifiers} from './rewrite-module-specifiers.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const modulesRoot = path.join(repoRoot, 'modules');
+const modulePackages = [];
+
+for (const entry of await readdir(modulesRoot, {withFileTypes: true})) {
+  if (!entry.isDirectory()) {
+    continue;
+  }
+
+  const moduleDirectory = path.join(modulesRoot, entry.name);
+  try {
+    const packageJson = JSON.parse(
+      await readFile(path.join(moduleDirectory, 'package.json'), 'utf8')
+    );
+    modulePackages.push({moduleDirectory, packageJson});
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
+const moduleDirectories = modulePackages.map(({moduleDirectory}) => moduleDirectory);
+const projects = moduleDirectories.map(moduleDirectory =>
+  path.relative(repoRoot, path.join(moduleDirectory, 'tsconfig.json'))
+);
+
+const result = spawnSync('tsc', ['--build', ...projects], {
+  cwd: repoRoot,
+  stdio: 'inherit'
+});
+
+if (result.error) {
+  throw result.error;
+}
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}
+
+await rewriteModuleSpecifiers(moduleDirectories);
+
+for (const {moduleDirectory, packageJson} of modulePackages) {
+  const entryPoints = getCommonJSEntryPoints(packageJson.exports);
+
+  for (const entryPoint of entryPoints) {
+    await esbuild.build({
+      entryPoints: [path.resolve(moduleDirectory, entryPoint.input)],
+      outfile: path.resolve(moduleDirectory, entryPoint.output),
+      bundle: true,
+      format: 'cjs',
+      target: 'node16',
+      packages: 'external',
+      sourcemap: true,
+      logLevel: 'info'
+    });
+  }
+}
+
+function getCommonJSEntryPoints(exportsField) {
+  const entryPoints = [];
+  visitExport(exportsField);
+  return entryPoints;
+
+  function visitExport(value) {
+    if (!value || typeof value !== 'object') {
+      return;
+    }
+    if (typeof value.import === 'string' && typeof value.require === 'string') {
+      entryPoints.push({input: value.import, output: value.require});
+      return;
+    }
+    for (const nestedValue of Object.values(value)) {
+      visitExport(nestedValue);
+    }
+  }
+}

--- a/scripts/rewrite-module-specifiers.js
+++ b/scripts/rewrite-module-specifiers.js
@@ -1,0 +1,187 @@
+import {decode, encode} from '@jridgewell/sourcemap-codec';
+import {access, readdir, readFile, writeFile} from 'node:fs/promises';
+import path from 'node:path';
+import ts from 'typescript';
+
+/**
+ * Adds runtime extensions to relative module specifiers after TypeScript emit.
+ *
+ * The native TypeScript 7 compiler does not load JavaScript custom transformers.
+ * Keeping this narrow transformation outside the compiler lets source files retain
+ * extensionless imports while still producing standards-compliant Node ESM.
+ */
+export async function rewriteModuleSpecifiers(moduleDirectories) {
+  let rewrittenFileCount = 0;
+  let rewrittenSpecifierCount = 0;
+
+  for (const moduleDirectory of moduleDirectories) {
+    const distDirectory = path.join(moduleDirectory, 'dist');
+    const outputFiles = await findOutputFiles(distDirectory);
+
+    for (const outputFile of outputFiles) {
+      const result = await rewriteOutputFile(outputFile);
+      if (result > 0) {
+        rewrittenFileCount++;
+        rewrittenSpecifierCount += result;
+      }
+    }
+  }
+
+  console.log(
+    `Rewrote ${rewrittenSpecifierCount} relative module specifiers in ` +
+      `${rewrittenFileCount} emitted files.`
+  );
+}
+
+async function rewriteOutputFile(outputFile) {
+  const source = await readFile(outputFile, 'utf8');
+  const sourceFile = ts.createSourceFile(outputFile, source, ts.ScriptTarget.Latest, true);
+  const isDeclaration = outputFile.endsWith('.d.ts');
+  const insertionsByPosition = new Map();
+  const pendingSpecifiers = [];
+
+  visit(sourceFile);
+
+  for (const {literal, specifier} of pendingSpecifiers) {
+    const suffix = await resolveOutputSuffix(outputFile, specifier, isDeclaration);
+    insertionsByPosition.set(literal.end - 1, suffix);
+  }
+
+  const insertions = [...insertionsByPosition]
+    .map(([position, text]) => {
+      const location = sourceFile.getLineAndCharacterOfPosition(position);
+      return {position, text, line: location.line, column: location.character};
+    })
+    .sort((left, right) => right.position - left.position);
+
+  if (insertions.length === 0) {
+    return 0;
+  }
+
+  let rewrittenSource = source;
+  for (const insertion of insertions) {
+    rewrittenSource =
+      rewrittenSource.slice(0, insertion.position) +
+      insertion.text +
+      rewrittenSource.slice(insertion.position);
+  }
+
+  await writeFile(outputFile, rewrittenSource);
+  await shiftSourceMap(outputFile, insertions);
+  return insertions.length;
+
+  function visit(node) {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      record(node.moduleSpecifier);
+    } else if (
+      ts.isCallExpression(node) &&
+      (node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(node.expression) && node.expression.text === 'require'))
+    ) {
+      record(node.arguments[0]);
+    } else if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument)
+    ) {
+      record(node.argument.literal);
+    } else if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference)
+    ) {
+      record(node.moduleReference.expression);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  function record(literal) {
+    if (!literal || !ts.isStringLiteralLike(literal)) {
+      return;
+    }
+    const specifier = literal.text;
+    if (
+      (specifier.startsWith('./') || specifier.startsWith('../')) &&
+      path.posix.extname(specifier) === ''
+    ) {
+      pendingSpecifiers.push({literal, specifier});
+    }
+  }
+}
+
+async function resolveOutputSuffix(outputFile, specifier, isDeclaration) {
+  const target = path.resolve(path.dirname(outputFile), specifier);
+  const fileExtension = isDeclaration ? '.d.ts' : '.js';
+  const candidates = [
+    {target: `${target}${fileExtension}`, suffix: '.js'},
+    {target: path.join(target, `index${fileExtension}`), suffix: '/index.js'}
+  ];
+  const matches = [];
+
+  for (const candidate of candidates) {
+    if (await pathExists(candidate.target)) {
+      matches.push(candidate);
+    }
+  }
+
+  if (matches.length !== 1) {
+    const reason = matches.length === 0 ? 'does not resolve' : 'is ambiguous';
+    throw new Error(
+      `${path.relative(process.cwd(), outputFile)}: ${specifier} ${reason} in emitted output`
+    );
+  }
+  return matches[0].suffix;
+}
+
+async function shiftSourceMap(outputFile, insertions) {
+  const sourceMapFile = `${outputFile}.map`;
+  if (!(await pathExists(sourceMapFile))) {
+    return;
+  }
+
+  const sourceMap = JSON.parse(await readFile(sourceMapFile, 'utf8'));
+  const decodedMappings = decode(sourceMap.mappings);
+  const insertionsByLine = new Map();
+
+  for (const insertion of insertions) {
+    const lineInsertions = insertionsByLine.get(insertion.line) || [];
+    lineInsertions.push({column: insertion.column, length: insertion.text.length});
+    insertionsByLine.set(insertion.line, lineInsertions);
+  }
+
+  for (const [line, lineInsertions] of insertionsByLine) {
+    lineInsertions.sort((left, right) => left.column - right.column);
+    for (const segment of decodedMappings[line] || []) {
+      const originalColumn = segment[0];
+      for (const insertion of lineInsertions) {
+        if (insertion.column <= originalColumn) {
+          segment[0] += insertion.length;
+        }
+      }
+    }
+  }
+
+  sourceMap.mappings = encode(decodedMappings);
+  await writeFile(sourceMapFile, JSON.stringify(sourceMap));
+}
+
+async function findOutputFiles(directory) {
+  const outputFiles = [];
+
+  for (const entry of await readdir(directory, {withFileTypes: true})) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      outputFiles.push(...(await findOutputFiles(entryPath)));
+    } else if (entry.name.endsWith('.js') || entry.name.endsWith('.d.ts')) {
+      outputFiles.push(entryPath);
+    }
+  }
+  return outputFiles.sort();
+}
+
+async function pathExists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/test/node.ts
+++ b/test/node.ts
@@ -4,3 +4,4 @@ configure({debug: true});
 
 import '../modules/web-mercator/test/spec/versus-mapbox/mapbox-node-polyfill';
 import './modules.spec';
+import './rewrite-module-specifiers.spec';

--- a/test/rewrite-module-specifiers.spec.ts
+++ b/test/rewrite-module-specifiers.spec.ts
@@ -1,0 +1,94 @@
+import {decode, encode} from '@jridgewell/sourcemap-codec';
+import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {pathToFileURL} from 'node:url';
+import test from 'tape-promise/tape';
+import {rewriteModuleSpecifiers} from '../scripts/rewrite-module-specifiers.js';
+
+test('rewriteModuleSpecifiers rewrites output and preserves source maps', async t => {
+  const temporaryDirectory = await mkdtemp(path.join(tmpdir(), 'mathgl-module-specifiers-'));
+  const moduleDirectory = path.join(temporaryDirectory, 'module');
+  const distDirectory = path.join(moduleDirectory, 'dist');
+
+  try {
+    await mkdir(distDirectory, {recursive: true});
+    await writeFile(path.join(moduleDirectory, 'package.json'), '{"type":"module"}');
+    await writeFile(path.join(distDirectory, 'value.js'), 'export const value = 42;\n');
+    await writeFile(
+      path.join(distDirectory, 'value.d.ts'),
+      'export declare const value: number;\n'
+    );
+
+    const output = "export {value} from './value';\n";
+    const semicolonColumn = output.indexOf(';');
+    const sourceMap = {
+      version: 3,
+      file: 'index.js',
+      sources: ['../src/index.ts'],
+      names: [],
+      mappings: encode([
+        [
+          [0, 0, 0, 0],
+          [semicolonColumn, 0, 0, semicolonColumn]
+        ]
+      ])
+    };
+
+    await writeFile(path.join(distDirectory, 'index.js'), output);
+    await writeFile(path.join(distDirectory, 'index.js.map'), JSON.stringify(sourceMap));
+    await writeFile(path.join(distDirectory, 'index.d.ts'), output);
+    await writeFile(path.join(distDirectory, 'index.d.ts.map'), JSON.stringify(sourceMap));
+
+    await rewriteModuleSpecifiers([moduleDirectory]);
+
+    t.equal(
+      await readFile(path.join(distDirectory, 'index.js'), 'utf8'),
+      "export {value} from './value.js';\n",
+      'rewrites JavaScript output'
+    );
+    t.equal(
+      await readFile(path.join(distDirectory, 'index.d.ts'), 'utf8'),
+      "export {value} from './value.js';\n",
+      'rewrites declaration output'
+    );
+
+    const rewrittenMap = JSON.parse(
+      await readFile(path.join(distDirectory, 'index.js.map'), 'utf8')
+    );
+    const generatedColumns = decode(rewrittenMap.mappings)[0].map(segment => segment[0]);
+    t.deepEqual(
+      generatedColumns,
+      [0, semicolonColumn + 3],
+      'shifts mappings after the inserted extension'
+    );
+
+    const loadedModule = await import(pathToFileURL(path.join(distDirectory, 'index.js')).href);
+    t.equal(loadedModule.value, 42, 'rewritten ESM loads in Node');
+  } finally {
+    await rm(temporaryDirectory, {recursive: true, force: true});
+  }
+});
+
+test('rewriteModuleSpecifiers rejects unresolved output', async t => {
+  const temporaryDirectory = await mkdtemp(path.join(tmpdir(), 'mathgl-module-specifiers-'));
+  const moduleDirectory = path.join(temporaryDirectory, 'module');
+  const distDirectory = path.join(moduleDirectory, 'dist');
+
+  try {
+    await mkdir(distDirectory, {recursive: true});
+    await writeFile(path.join(distDirectory, 'index.js'), "export {missing} from './missing';\n");
+
+    try {
+      await rewriteModuleSpecifiers([moduleDirectory]);
+      t.fail('accepted an unresolved specifier');
+    } catch (error) {
+      t.ok(
+        error instanceof Error && error.message.includes('./missing does not resolve'),
+        'reports the unresolved emitted specifier'
+      );
+    }
+  } finally {
+    await rm(temporaryDirectory, {recursive: true, force: true});
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,9 @@
     "allowSyntheticDefaultImports": true,
     "rootDir": ".",
     "useDefineForClassFields": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
 
     // BEGIN TYPE CHECK SETTINGS
     "skipLibCheck": true,
@@ -45,46 +48,48 @@
     // END TYPE CHECK SETTINGS
 
     "paths": {
+      "@math.gl/core": ["./modules/core/src/index.ts"],
       "@math.gl/core/*": ["./modules/core/src/*"],
       "@math.gl/core/test/*": ["./modules/core/test/*"],
+      "@math.gl/culling": ["./modules/culling/src/index.ts"],
       "@math.gl/culling/*": ["./modules/culling/src/*"],
       "@math.gl/culling/test/*": ["./modules/culling/test/*"],
-      "@math.gl/dggs-pgeohash/*": ["./modules/dggs-pgeohash/src/*"],
-      "@math.gl/dggs-pgeohash/test/*": ["./modules/dggs-pgeohash/test/*"],
+      "@math.gl/dggs-geohash": ["./modules/dggs-geohash/src/index.ts"],
+      "@math.gl/dggs-geohash/*": ["./modules/dggs-geohash/src/*"],
+      "@math.gl/dggs-geohash/test/*": ["./modules/dggs-geohash/test/*"],
+      "@math.gl/dggs-s2": ["./modules/dggs-s2/src/index.ts"],
       "@math.gl/dggs-s2/*": ["./modules/dggs-s2/src/*"],
       "@math.gl/dggs-s2/test/*": ["./modules/dggs-s2/test/*"],
+      "@math.gl/dggs-quadkey": ["./modules/dggs-quadkey/src/index.ts"],
       "@math.gl/dggs-quadkey/*": ["./modules/dggs-quadkey/src/*"],
       "@math.gl/dggs-quadkey/test/*": ["./modules/dggs-quadkey/test/*"],
+      "@math.gl/expressions": ["./modules/expressions/src/index.ts"],
       "@math.gl/expressions/*": ["./modules/expressions/src/*"],
       "@math.gl/expressions/test/*": ["./modules/expressions/test/*"],
+      "@math.gl/geoid": ["./modules/geoid/src/index.ts"],
       "@math.gl/geoid/*": ["./modules/geoid/src/*"],
       "@math.gl/geoid/test/*": ["./modules/geoid/test/*"],
+      "@math.gl/geospatial": ["./modules/geospatial/src/index.ts"],
       "@math.gl/geospatial/*": ["./modules/geospatial/src/*"],
       "@math.gl/geospatial/test/*": ["./modules/geospatial/test/*"],
+      "@math.gl/polygon": ["./modules/polygon/src/index.ts"],
       "@math.gl/polygon/*": ["./modules/polygon/src/*"],
       "@math.gl/polygon/test/*": ["./modules/polygon/test/*"],
+      "@math.gl/proj4": ["./modules/proj4/src/index.ts"],
       "@math.gl/proj4/*": ["./modules/proj4/src/*"],
       "@math.gl/proj4/test/*": ["./modules/proj4/test/*"],
+      "@math.gl/sun": ["./modules/sun/src/index.ts"],
       "@math.gl/sun/*": ["./modules/sun/src/*"],
       "@math.gl/sun/test/*": ["./modules/sun/test/*"],
+      "@math.gl/types": ["./modules/types/src/index.ts"],
       "@math.gl/types/*": ["./modules/types/src/*"],
       "@math.gl/types/test/*": ["./modules/types/test/*"],
+      "@math.gl/web-mercator": ["./modules/web-mercator/src/index.ts"],
       "@math.gl/web-mercator/*": ["./modules/web-mercator/src/*"],
       "@math.gl/web-mercator/test/*": ["./modules/web-mercator/test/*"],
+      "math.gl": ["./modules/main/src/index.ts"],
       "test/*": ["./test/*"]
-    },
-    "plugins": [
-      {
-        "transform": "@vis.gl/ts-plugins/ts-transform-append-extension",
-        "extensions": [".js"],
-        "after": true
-      },
-      {
-        "transform": "@vis.gl/ts-plugins/ts-transform-append-extension",
-        "extensions": [".js"],
-        "afterDeclarations": true
-      }
-    ]
+    }
   },
   "include": ["modules/*/src", "modules/*/test", "examples/expressions"],
   "exclude": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -784,6 +784,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/sourcemap-codec@npm:^1.5.0":
+  version: 1.5.5
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
+  checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
+  languageName: node
+  linkType: hard
+
 "@jridgewell/trace-mapping@npm:0.3.9":
   version: 0.3.9
   resolution: "@jridgewell/trace-mapping@npm:0.3.9"
@@ -880,13 +887,6 @@ __metadata:
     yargs: "npm:17.7.2"
     yargs-parser: "npm:21.1.1"
   checksum: 10c0/be58b0fcaf9e02abc69ed9b95cb81acfc919c1f01bb430d3c4d5b532d8f6fadff1a8504386f8ddf7a68ded0a70c6ad2b4ed63c3c756ee5f1deee138bd5632355
-  languageName: node
-  linkType: hard
-
-"@luma.gl/constants@npm:^9.0.0":
-  version: 9.0.27
-  resolution: "@luma.gl/constants@npm:9.0.27"
-  checksum: 10c0/3c7c1c56373c4c2bccf2c12cdd5cb3ae9ade2b6040d66ebef2dd45c7cb564ecdd9555f6f03690d736dbe337f25500863baa9468226f96618b3e930e3ecf8adf0
   languageName: node
   linkType: hard
 
@@ -2173,6 +2173,227 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript/native@npm:typescript@7.0.2":
+  version: 7.0.2
+  resolution: "typescript@npm:7.0.2"
+  dependencies:
+    "@typescript/typescript-aix-ppc64": "npm:7.0.2"
+    "@typescript/typescript-darwin-arm64": "npm:7.0.2"
+    "@typescript/typescript-darwin-x64": "npm:7.0.2"
+    "@typescript/typescript-freebsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-freebsd-x64": "npm:7.0.2"
+    "@typescript/typescript-linux-arm": "npm:7.0.2"
+    "@typescript/typescript-linux-arm64": "npm:7.0.2"
+    "@typescript/typescript-linux-loong64": "npm:7.0.2"
+    "@typescript/typescript-linux-mips64el": "npm:7.0.2"
+    "@typescript/typescript-linux-ppc64": "npm:7.0.2"
+    "@typescript/typescript-linux-riscv64": "npm:7.0.2"
+    "@typescript/typescript-linux-s390x": "npm:7.0.2"
+    "@typescript/typescript-linux-x64": "npm:7.0.2"
+    "@typescript/typescript-netbsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-netbsd-x64": "npm:7.0.2"
+    "@typescript/typescript-openbsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-openbsd-x64": "npm:7.0.2"
+    "@typescript/typescript-sunos-x64": "npm:7.0.2"
+    "@typescript/typescript-win32-arm64": "npm:7.0.2"
+    "@typescript/typescript-win32-x64": "npm:7.0.2"
+  dependenciesMeta:
+    "@typescript/typescript-aix-ppc64":
+      optional: true
+    "@typescript/typescript-darwin-arm64":
+      optional: true
+    "@typescript/typescript-darwin-x64":
+      optional: true
+    "@typescript/typescript-freebsd-arm64":
+      optional: true
+    "@typescript/typescript-freebsd-x64":
+      optional: true
+    "@typescript/typescript-linux-arm":
+      optional: true
+    "@typescript/typescript-linux-arm64":
+      optional: true
+    "@typescript/typescript-linux-loong64":
+      optional: true
+    "@typescript/typescript-linux-mips64el":
+      optional: true
+    "@typescript/typescript-linux-ppc64":
+      optional: true
+    "@typescript/typescript-linux-riscv64":
+      optional: true
+    "@typescript/typescript-linux-s390x":
+      optional: true
+    "@typescript/typescript-linux-x64":
+      optional: true
+    "@typescript/typescript-netbsd-arm64":
+      optional: true
+    "@typescript/typescript-netbsd-x64":
+      optional: true
+    "@typescript/typescript-openbsd-arm64":
+      optional: true
+    "@typescript/typescript-openbsd-x64":
+      optional: true
+    "@typescript/typescript-sunos-x64":
+      optional: true
+    "@typescript/typescript-win32-arm64":
+      optional: true
+    "@typescript/typescript-win32-x64":
+      optional: true
+  bin:
+    tsc: bin/tsc
+  checksum: 10c0/3dcee51ec8c332492325bcdbf7df48b66668751f127e622ae7d41b6c716eb19184424a45e14f7750f50f340232388b69e6287859155f06a5ce2df76f12cb31cf
+  languageName: node
+  linkType: hard
+
+"@typescript/old@npm:typescript@^6, typescript@npm:^6.0.2":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-aix-ppc64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-aix-ppc64@npm:7.0.2"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-darwin-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-darwin-arm64@npm:7.0.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-darwin-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-darwin-x64@npm:7.0.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-freebsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-freebsd-arm64@npm:7.0.2"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-freebsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-freebsd-x64@npm:7.0.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-arm64@npm:7.0.2"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-arm@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-arm@npm:7.0.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-loong64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-loong64@npm:7.0.2"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-mips64el@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-mips64el@npm:7.0.2"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-ppc64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-ppc64@npm:7.0.2"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-riscv64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-riscv64@npm:7.0.2"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-s390x@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-s390x@npm:7.0.2"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-x64@npm:7.0.2"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-netbsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-netbsd-arm64@npm:7.0.2"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-netbsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-netbsd-x64@npm:7.0.2"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-openbsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-openbsd-arm64@npm:7.0.2"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-openbsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-openbsd-x64@npm:7.0.2"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-sunos-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-sunos-x64@npm:7.0.2"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-win32-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-win32-arm64@npm:7.0.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-win32-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-win32-x64@npm:7.0.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@ungap/structured-clone@npm:^1.2.0":
   version: 1.2.0
   resolution: "@ungap/structured-clone@npm:1.2.0"
@@ -2224,18 +2445,6 @@ __metadata:
     ocular-publish: scripts/publish.js
     ocular-test: scripts/test.js
   checksum: 10c0/692d8d5c2d77932b2c8e0b500b09c266633090154a5bdb6cf990f40494ea8a3772b35b29530b8424e5d18faa4898f1769e0daebffab80aec4e5b8f2317d55b48
-  languageName: node
-  linkType: hard
-
-"@vis.gl/ts-plugins@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@vis.gl/ts-plugins@npm:1.0.2"
-  dependencies:
-    "@luma.gl/constants": "npm:^9.0.0"
-    minimatch: "npm:^3.0.0"
-    ts-patch: "npm:^3.1.2"
-    typescript: "npm:^5.2.2"
-  checksum: 10c0/995a27df25124f10971edaf2cbd547664b90270357b4f59bfa23e32e2dd1f973a4cb3048a00bf7a108f38a78c107fb7af5c3e231aac647be07537ff6cf90eff7
   languageName: node
   linkType: hard
 
@@ -7063,15 +7272,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "math.gl-monorepo@workspace:."
   dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.0"
     "@math.gl/devtools-extensions": "workspace:*"
     "@probe.gl/bench": "npm:^4.0.0"
     "@turf/destination": "npm:^6.0.1"
     "@types/tape-promise": "npm:^4.0.1"
+    "@typescript/native": "npm:typescript@7.0.2"
     "@vis.gl/dev-tools": "npm:^1.0.2"
-    "@vis.gl/ts-plugins": "npm:^1.0.2"
+    esbuild: "npm:^0.16.7"
     pre-commit: "npm:^1.2.2"
     puppeteer: "npm:^22.0.0"
     tap-spec: "npm:^5.0.0"
+    typescript: "npm:@typescript/typescript6@6.0.2"
   languageName: unknown
   linkType: soft
 
@@ -10555,23 +10767,55 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:6.0.2":
-  version: 6.0.2
-  resolution: "typescript@npm:6.0.2"
+"typescript@npm:>=3 < 6, typescript@npm:^5.2.2, typescript@npm:^5.5.0":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/4b860b0bf87cc0fee0f66d8ef2640b5a8a8a8c74d1129adb82e389e5f97124383823c47946bef8a73ede371461143a3aa8544399d2133c7b2e4f07e81860af7f
+  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>":
+"typescript@npm:@typescript/typescript6@6.0.2":
   version: 6.0.2
-  resolution: "typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>::version=6.0.2&hash=5786d5"
+  resolution: "@typescript/typescript6@npm:6.0.2"
+  dependencies:
+    "@typescript/old": "npm:typescript@^6"
+  bin:
+    tsc6: bin/tsc6
+  checksum: 10c0/0c6e5c1c3a61b79f2bc61506feb82f8ce54275b2af1aebc3dd9310d7f57b1de2aca40256d018cf736c524152ae4a731f5810ff7cd028d565158d53368e681af2
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A>=3 < 6#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.2.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.5.0#optional!builtin<compat/typescript>":
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/49f0b84fc6ca55653e77752b8a61beabc09ee3dae5d965c31596225aa6ef213c5727b1d2e895b900416dc603854ba0872ac4a812c2a4ed6793a601f9c675de02
+  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A@typescript/typescript6@6.0.2#optional!builtin<compat/typescript>":
+  version: 6.0.2
+  resolution: "typescript@patch:@typescript/typescript6@npm%3A6.0.2#optional!builtin<compat/typescript>::version=6.0.2&hash=5786d5"
+  dependencies:
+    "@typescript/old": "npm:typescript@^6"
+  bin:
+    tsc6: bin/tsc6
+  checksum: 10c0/ba91bd03aaf52617b757d8f186f5559587159f7984cc188f51435cf0cd36b7fc750825409db62d7f62ab22e292c41422e2c25b4b763b6a05e1dbde8c2ba93c3f
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^6.0.2#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- upgrade the build to TypeScript 7.0.2 via `@typescript/native`
- replace `ocular-build` with a small explicit build pipeline
- preserve extensionless imports in every TypeScript source file
- rewrite only emitted relative module specifiers so the published ESM and declarations remain Node-compatible
- continue generating the CommonJS entry points with esbuild

## Why the build pipeline needs a workaround

The previous build depended on `@vis.gl/ts-plugins` through `ts-patch`. Its append-extension transformer ran inside the JavaScript TypeScript compiler and changed relative module specifiers in both JavaScript and declaration output.

TypeScript 7 uses the native compiler. That compiler cannot be patched by `ts-patch` and does not load the JavaScript custom transformers used by `@vis.gl/ts-plugins`, so the old `ocular-build` path cannot perform this repository's required emit transformation.

An earlier version of this PR worked around that limitation by spelling emitted `.js` extensions in the `.ts` source. That couples source authoring to one output format and creates unnecessary risk for tests, bundlers, and future build targets. This revision removes all of that source churn: `modules/*/src` is byte-for-byte unchanged from `master`, and TypeScript uses `moduleResolution: "bundler"` to continue resolving the existing extensionless imports.

## Post-emission solution

The new build has three explicit stages:

1. TypeScript 7 performs project-reference type checking and emits ESM JavaScript, declarations, and their source maps.
2. A standalone, syntax-aware postprocessor updates relative module specifiers in the emitted `.js` and `.d.ts` files.
3. esbuild generates the package CommonJS entry points from the corrected ESM output.

The postprocessor deliberately does not use textual search-and-replace. It uses the retained TypeScript 6 compatibility package only as a JavaScript parser, walks module-specifier syntax nodes (static imports/exports, dynamic imports, `require`, import types, and import-equals), and ignores comments, ordinary strings, package imports, and specifiers that already have extensions.

For every extensionless relative specifier, it checks the emitted filesystem before changing anything:

- a direct emitted file becomes `./target.js`
- an emitted directory index becomes `./target/index.js`
- a missing target fails the build
- multiple possible targets fail the build as ambiguous

The same transformation is applied to declaration files. When a suffix is inserted, the corresponding JavaScript or declaration source-map mappings are shifted by the exact inserted column count, preserving mapping accuracy. TypeScript 6 is therefore a narrow parser/tooling compatibility dependency; TypeScript 7 remains the compiler used for checking and emission.

This keeps the workaround isolated at the boundary where the runtime requirement actually exists: generated package artifacts, not authored TypeScript.

## Validation

- `yarn install --immutable`
- `yarn build`
  - rewrote 323 relative specifiers across 111 emitted files
- verified 204 emitted `.js`/`.d.ts` files contain no extensionless relative module specifiers
- decoded and validated ordering in 219 generated source maps
- loaded all 30 ESM and CommonJS package entry points
- `yarn lint`
- `yarn test node`: 2,719 passing
- `yarn test ci`: full browser suite passing
- verified `modules/*/src` has no diff from `master`

The rewriter also has focused coverage for JavaScript output, declaration output, source-map adjustment, Node ESM loading, and failure on an unresolved emitted specifier.