### PR TITLE
feat: add geometry-utils module

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ math.gl is **optimized for use with WebGL and WebGPU**, however it is not a GPU 
 - **Geospatial projections** - CRS definitions and support for a variety of geospatial projections **`@math.gl/crs`**, **`@math.gl/geospatial`**, **`@math.gl/geoid`**, **`@math.gl/proj4`**, **`@math.gl/web-mercator`**
 - **Geospatial utilities** - Cutting polygons and calculating sun position and direction **`@math.gl/polygon`**, **`@math.gl/sun`**
 - **Discrete Global Grids** - Standardized interfaces to a number of the major discrete global grids. **`@math.gl/dggs-geohash`**, **`@math.gl/dggs-quadkey`**, **`@math.gl/dggs-s2`**
-- **3D math** - 3D primitives and culling: **`@math.gl/geometry`**, **`@math.gl/culling`**
+- **3D math** - 3D primitives, geometry processing and culling: **`@math.gl/geometry`**, **`@math.gl/geometry-utils`**, **`@math.gl/culling`**
 
 ## Modules
 
@@ -45,6 +45,7 @@ math.gl is a toolbox that offers a suite of composable modules.
 | ------------------------------------------ | ------------------------------------ | ------------------------------------------ |
 |                                            | **`@math.gl/geometry`**              | CPU primitive meshes and tessellation.     |
 | ![culling](./images/culling.png 'culling') | **`@math.gl/culling`**               | Bounding volumes and intersection testing. |
+|                                            | **`@math.gl/geometry-utils`**         | Typed-array geometry processing utilities. |
 
 <br/>
 In addition, math.gl provides a few deprecated legacy modules, to avoid breaking older applications.

--- a/docs/modules/geometry-utils/README.md
+++ b/docs/modules/geometry-utils/README.md
@@ -1,0 +1,38 @@
+# @math.gl/geometry-utils
+
+Utilities for processing renderer-independent geometry stored in typed arrays. The module is
+designed for loaders and applications that need to inspect, normalize, or decode geometry without
+depending on a WebGL or WebGPU runtime.
+
+## Installation
+
+```bash
+npm install @math.gl/geometry-utils
+```
+
+## Usage
+
+```typescript
+import {GL, computeVertexNormals, octDecode} from '@math.gl/geometry-utils';
+import {Vector3} from '@math.gl/core';
+
+const normals = computeVertexNormals({
+  mode: GL.TRIANGLES,
+  attributes: {
+    POSITION: {value: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]), size: 3}
+  }
+});
+
+const decodedNormal = octDecode(128, 128, new Vector3());
+```
+
+## API
+
+- Geometry inspection and traversal: `isGeometry`, `makeAttributeIterator`,
+  `makePrimitiveIterator`, `computeVertexNormals`
+- Typed arrays and component types: `GL`, `GL_TYPE`, `GLType`, `concatTypedArrays`
+- Packed attributes: `encodeRGB565`, `decodeRGB565`, octahedral vector encoding, texture-coordinate
+  compression, and ZigZag delta decoding
+- Coordinate helpers: `emod`
+
+The initial API is based on the geometry utilities previously maintained in `@loaders.gl/math`.

--- a/docs/modules/geometry-utils/api-reference/geometry-utils.md
+++ b/docs/modules/geometry-utils/api-reference/geometry-utils.md
@@ -1,0 +1,32 @@
+# Geometry utilities
+
+## Geometry types
+
+`Geometry` is the minimal indexed or non-indexed geometry shape accepted by this module.
+Attributes may store typed arrays in either `value` or legacy `values` fields.
+
+## Primitive iteration
+
+`makeAttributeIterator(values, size)` iterates over fixed-size typed-array elements.
+
+`makePrimitiveIterator(geometry)` iterates over points, lines, or triangles and dereferences optional
+indices. It supports point, line-list, line-strip, line-loop, triangle-list, triangle-strip, and
+triangle-fan modes.
+
+## Vertex normals
+
+`computeVertexNormals(geometry)` calculates smooth, area-weighted normals for indexed or non-indexed
+triangle geometry. Triangle strips and triangle fans are supported.
+
+## Component types and typed arrays
+
+`GLType` converts between WebGL-compatible component constants and typed-array constructors.
+`concatTypedArrays(arrays)` concatenates the visible bytes of typed-array views.
+
+## Packed attributes
+
+`encodeRGB565` and `decodeRGB565` convert 8-bit RGB colors to and from RGB565.
+
+The `oct*` functions encode and decode normalized vectors using octahedral encoding.
+`compressTextureCoordinates` and `decompressTextureCoordinates` pack normalized UV coordinates.
+`zigZagDeltaDecode` decodes quantized delta buffers in place.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -112,6 +112,14 @@
       },
       {
         "type": "category",
+        "label": "@math.gl/geometry-utils",
+        "items": [
+          "modules/geometry-utils/README",
+          "modules/geometry-utils/api-reference/geometry-utils"
+        ]
+      },
+      {
+        "type": "category",
         "label": "@math.gl/geoid",
         "items": [
           "modules/geoid/README",

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -56,6 +56,7 @@ Highlights:
 - glTF 2.1 box, capsule, cylinder, plane and sphere analytic shapes in `@math.gl/culling`.
 - New expression evaluator module
 - New standards-based CRS definitions module and modernized proj4 support.
+- New typed-array geometry utilities module.
 - Functionality additions to improve 3D Tiles support in loaders.gl.
 - Stronger type guarantees for math classes via the new sized array types.
 
@@ -94,6 +95,12 @@ Highlights:
 **`@math.gl/culling`**
 
 - Adds analytic glTF shape queries for clipping/culling, rays, transforms and enclosing bounds.
+
+**`@math.gl/geometry-utils`** (NEW MODULE)
+
+- Promotes the renderer-independent geometry helpers previously maintained in `@loaders.gl/math`.
+- Adds typed geometry traversal, vertex-normal generation, component-type conversion, packed RGB565
+  colors, octahedral attribute compression, and typed-array utilities.
 
 ## v4.1
 

--- a/modules/geometry-utils/README.md
+++ b/modules/geometry-utils/README.md
@@ -1,0 +1,8 @@
+# @math.gl/geometry-utils
+
+[math.gl](https://math.gl/docs) is a suite of math modules for 3D applications.
+
+This module contains dependency-light utilities for typed-array geometry, primitive iteration,
+vertex normals, packed colors, and compressed attributes.
+
+For documentation please visit the [website](https://math.gl).

--- a/modules/geometry-utils/package.json
+++ b/modules/geometry-utils/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@math.gl/geometry-utils",
+  "description": "Typed-array geometry processing and attribute compression utilities",
+  "license": "MIT",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "version": "4.2.0-alpha.3",
+  "keywords": [
+    "webgl",
+    "webgpu",
+    "geometry",
+    "typed array",
+    "attribute compression"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/math.gl.git"
+  },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "dependencies": {
+    "@math.gl/core": "4.2.0-alpha.3",
+    "@math.gl/types": "4.2.0-alpha.3"
+  }
+}

--- a/modules/geometry-utils/src/attribute-compression.ts
+++ b/modules/geometry-utils/src/attribute-compression.ts
@@ -1,0 +1,232 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+// Derived from Cesium under the Apache 2.0 license.
+// https://github.com/CesiumGS/cesium/blob/main/LICENSE.md
+
+import {Vector2, Vector3, assert, clamp, _MathUtils} from '@math.gl/core';
+
+type Vector4 = {x: number; y: number; z: number; w: number};
+
+const RIGHT_SHIFT = 1 / 256;
+const LEFT_SHIFT = 256;
+const scratchVector2 = new Vector2();
+const scratchVector3 = new Vector3();
+const scratchEncodeVector2 = new Vector2();
+const octEncodeScratch = new Vector2();
+const uint8ForceArray = new Uint8Array(1);
+
+function forceUint8(value: number): number {
+  uint8ForceArray[0] = value;
+  return uint8ForceArray[0];
+}
+
+function fromSNorm(value: number, rangeMaximum = 255): number {
+  return (clamp(value, 0, rangeMaximum) / rangeMaximum) * 2 - 1;
+}
+
+function toSNorm(value: number, rangeMaximum = 255): number {
+  return Math.round((clamp(value, -1, 1) * 0.5 + 0.5) * rangeMaximum);
+}
+
+function signNotZero(value: number): number {
+  return value < 0 ? -1 : 1;
+}
+
+/**
+ * Encodes a normalized vector into two SNORM values following octahedral encoding.
+ *
+ * @param vector Normalized vector to encode.
+ * @param rangeMaximum Maximum value of the SNORM range.
+ * @param result Target for the two encoded components.
+ */
+export function octEncodeInRange(vector: Vector3, rangeMaximum: number, result: Vector2): Vector2 {
+  assert(vector);
+  assert(result);
+  scratchVector3.from(vector);
+  assert(Math.abs(scratchVector3.magnitudeSquared() - 1) <= _MathUtils.EPSILON6);
+
+  const denominator = Math.abs(vector.x) + Math.abs(vector.y) + Math.abs(vector.z);
+  result.x = vector.x / denominator;
+  result.y = vector.y / denominator;
+
+  if (vector.z < 0) {
+    const x = result.x;
+    const y = result.y;
+    result.x = (1 - Math.abs(y)) * signNotZero(x);
+    result.y = (1 - Math.abs(x)) * signNotZero(y);
+  }
+
+  result.x = toSNorm(result.x, rangeMaximum);
+  result.y = toSNorm(result.y, rangeMaximum);
+  return result;
+}
+
+/** Encodes a normalized vector into two 8-bit octahedral components. */
+export function octEncode(vector: Vector3, result: Vector2): Vector2 {
+  return octEncodeInRange(vector, 255, result);
+}
+
+/** Encodes a normalized vector into four 8-bit octahedral components. */
+export function octEncodeToVector4(vector: Vector3, result: Vector4): Vector4 {
+  octEncodeInRange(vector, 65535, octEncodeScratch);
+  result.x = forceUint8(octEncodeScratch.x * RIGHT_SHIFT);
+  result.y = forceUint8(octEncodeScratch.x);
+  result.z = forceUint8(octEncodeScratch.y * RIGHT_SHIFT);
+  result.w = forceUint8(octEncodeScratch.y);
+  return result;
+}
+
+/**
+ * Decodes two SNORM octahedral components into a normalized vector.
+ *
+ * @param x First encoded component.
+ * @param y Second encoded component.
+ * @param rangeMaximum Maximum value of the SNORM range.
+ * @param result Target for the decoded vector.
+ */
+export function octDecodeInRange(
+  x: number,
+  y: number,
+  rangeMaximum: number,
+  result: Vector3
+): Vector3 {
+  assert(result);
+  if (x < 0 || x > rangeMaximum || y < 0 || y > rangeMaximum) {
+    throw new Error(`x and y must be unsigned normalized integers between 0 and ${rangeMaximum}`);
+  }
+
+  result.x = fromSNorm(x, rangeMaximum);
+  result.y = fromSNorm(y, rangeMaximum);
+  result.z = 1 - (Math.abs(result.x) + Math.abs(result.y));
+
+  if (result.z < 0) {
+    const oldX = result.x;
+    result.x = (1 - Math.abs(result.y)) * signNotZero(oldX);
+    result.y = (1 - Math.abs(oldX)) * signNotZero(result.y);
+  }
+  return result.normalize();
+}
+
+/** Decodes two 8-bit octahedral components into a normalized vector. */
+export function octDecode(x: number, y: number, result: Vector3): Vector3 {
+  return octDecodeInRange(x, y, 255, result);
+}
+
+/** Decodes four 8-bit octahedral components into a normalized vector. */
+export function octDecodeFromVector4(encoded: Vector4, result: Vector3): Vector3 {
+  assert(encoded);
+  assert(result);
+  const {x, y, z, w} = encoded;
+  if (x < 0 || x > 255 || y < 0 || y > 255 || z < 0 || z > 255 || w < 0 || w > 255) {
+    throw new Error('x, y, z, and w must be unsigned normalized integers between 0 and 255');
+  }
+  return octDecodeInRange(x * LEFT_SHIFT + y, z * LEFT_SHIFT + w, 65535, result);
+}
+
+/** Packs an octahedrally encoded two-component vector into one number. */
+export function octPackFloat(encoded: Vector2): number {
+  scratchVector2.from(encoded);
+  return 256 * scratchVector2.x + scratchVector2.y;
+}
+
+/** Encodes a normalized vector into an octahedral representation packed into one number. */
+export function octEncodeFloat(vector: Vector3): number {
+  octEncode(vector, scratchEncodeVector2);
+  return octPackFloat(scratchEncodeVector2);
+}
+
+/** Decodes an octahedral representation packed into one number. */
+export function octDecodeFloat(value: number, result: Vector3): Vector3 {
+  assert(Number.isFinite(value));
+  const temporary = value / 256;
+  const x = Math.floor(temporary);
+  const y = (temporary - x) * 256;
+  return octDecode(x, y, result);
+}
+
+/** Packs three normalized vectors into two numeric octahedral values. */
+export function octPack(
+  vector1: Vector3,
+  vector2: Vector3,
+  vector3: Vector3,
+  result: Vector2
+): Vector2 {
+  assert(vector1);
+  assert(vector2);
+  assert(vector3);
+  assert(result);
+  const encoded1 = octEncodeFloat(vector1);
+  const encoded2 = octEncodeFloat(vector2);
+  const encoded3 = octEncode(vector3, scratchEncodeVector2);
+  result.x = 65536 * encoded3.x + encoded1;
+  result.y = 65536 * encoded3.y + encoded2;
+  return result;
+}
+
+/** Decodes three normalized vectors packed by {@link octPack}. */
+export function octUnpack(
+  packed: Vector2,
+  vector1: Vector3,
+  vector2: Vector3,
+  vector3: Vector3
+): void {
+  let temporary = packed.x / 65536;
+  const x = Math.floor(temporary);
+  const encodedFloat1 = (temporary - x) * 65536;
+  temporary = packed.y / 65536;
+  const y = Math.floor(temporary);
+  const encodedFloat2 = (temporary - y) * 65536;
+  octDecodeFloat(encodedFloat1, vector1);
+  octDecodeFloat(encodedFloat2, vector2);
+  octDecode(x, y, vector3);
+}
+
+/** Packs two normalized texture coordinates into one number with 12 bits per component. */
+export function compressTextureCoordinates(textureCoordinates: Vector2): number {
+  const x = (textureCoordinates.x * 4095) | 0;
+  const y = (textureCoordinates.y * 4095) | 0;
+  return 4096 * x + y;
+}
+
+/** Decompresses texture coordinates packed by {@link compressTextureCoordinates}. */
+export function decompressTextureCoordinates(compressed: number, result: Vector2): Vector2 {
+  const temporary = compressed / 4096;
+  const x = Math.floor(temporary);
+  result.x = x / 4095;
+  result.y = (compressed - x * 4096) / 4095;
+  return result;
+}
+
+/** Decodes delta- and ZigZag-encoded vertex buffers in place. */
+export function zigZagDeltaDecode(
+  uBuffer: Uint16Array,
+  vBuffer: Uint16Array,
+  heightBuffer?: Uint16Array | number[]
+): void {
+  assert(uBuffer);
+  assert(vBuffer);
+  assert(uBuffer.length === vBuffer.length);
+  if (heightBuffer) {
+    assert(uBuffer.length === heightBuffer.length);
+  }
+
+  let u = 0;
+  let v = 0;
+  let height = 0;
+  for (let index = 0; index < uBuffer.length; index++) {
+    u += zigZagDecode(uBuffer[index]);
+    v += zigZagDecode(vBuffer[index]);
+    uBuffer[index] = u;
+    vBuffer[index] = v;
+    if (heightBuffer) {
+      height += zigZagDecode(heightBuffer[index]);
+      heightBuffer[index] = height;
+    }
+  }
+}
+
+function zigZagDecode(value: number): number {
+  return (value >> 1) ^ -(value & 1);
+}

--- a/modules/geometry-utils/src/attribute-iterator.ts
+++ b/modules/geometry-utils/src/attribute-iterator.ts
@@ -1,0 +1,28 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {TypedArray, TypedArrayConstructor} from '@math.gl/types';
+
+/**
+ * Iterates over the fixed-size elements of a typed array.
+ *
+ * For performance, each iteration reuses the same typed-array view-sized value.
+ */
+export function* makeAttributeIterator(values: TypedArray, size: number): Iterable<TypedArray> {
+  if (!Number.isInteger(size) || size <= 0) {
+    throw new Error('Attribute size must be a positive integer');
+  }
+  if (values.length % size !== 0) {
+    throw new Error('Attribute length must be divisible by its size');
+  }
+
+  const ArrayType = values.constructor as TypedArrayConstructor;
+  const element = new ArrayType(size);
+  for (let index = 0; index < values.length; index += size) {
+    for (let componentIndex = 0; componentIndex < size; componentIndex++) {
+      element[componentIndex] = values[index + componentIndex]!;
+    }
+    yield element;
+  }
+}

--- a/modules/geometry-utils/src/compute-vertex-normals.ts
+++ b/modules/geometry-utils/src/compute-vertex-normals.ts
@@ -1,0 +1,63 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Vector3} from '@math.gl/core';
+import {GL} from './constants';
+import type {Geometry} from './geometry';
+import {getAttributeValues, getPositionAttribute} from './geometry';
+import {makePrimitiveIterator} from './primitive-iterator';
+
+/** Computes smooth, area-weighted vertex normals for a triangle geometry. */
+export function computeVertexNormals(geometry: Geometry): Float32Array {
+  if (
+    geometry.mode !== GL.TRIANGLES &&
+    geometry.mode !== GL.TRIANGLE_STRIP &&
+    geometry.mode !== GL.TRIANGLE_FAN
+  ) {
+    throw new Error('Triangle geometry is required');
+  }
+
+  const position = getPositionAttribute(geometry);
+  const positions = getAttributeValues(position);
+  const positionSize = position.size || 3;
+  if (positionSize < 3) {
+    throw new Error('Position attributes must have at least three components');
+  }
+
+  const vertexCount = positions.length / positionSize;
+  const normals = new Float32Array(vertexCount * 3);
+  const vectorA = new Vector3();
+  const vectorB = new Vector3();
+  const vectorC = new Vector3();
+  const edgeCB = new Vector3();
+  const edgeAB = new Vector3();
+
+  for (const primitive of makePrimitiveIterator(geometry)) {
+    const {i1, i2, i3} = primitive;
+    if (i2 === undefined || i3 === undefined) {
+      continue;
+    }
+    vectorA.fromArray(positions, i1 * positionSize);
+    vectorB.fromArray(positions, i2 * positionSize);
+    vectorC.fromArray(positions, i3 * positionSize);
+    const faceNormal = edgeCB
+      .subVectors(vectorC, vectorB)
+      .cross(edgeAB.subVectors(vectorA, vectorB));
+
+    for (const vertexIndex of [i1, i2, i3]) {
+      normals[vertexIndex * 3] += faceNormal.x;
+      normals[vertexIndex * 3 + 1] += faceNormal.y;
+      normals[vertexIndex * 3 + 2] += faceNormal.z;
+    }
+  }
+
+  const normal = new Vector3();
+  for (let vertexIndex = 0; vertexIndex < vertexCount; vertexIndex++) {
+    normal.fromArray(normals, vertexIndex * 3);
+    if (normal.magnitudeSquared() > 0) {
+      normal.normalize().toArray(normals, vertexIndex * 3);
+    }
+  }
+  return normals;
+}

--- a/modules/geometry-utils/src/constants.ts
+++ b/modules/geometry-utils/src/constants.ts
@@ -1,0 +1,42 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Portable point, line, and triangle primitive types. */
+export const GL_PRIMITIVE = {
+  POINTS: 0x0000,
+  LINES: 0x0001,
+  TRIANGLES: 0x0004
+} as const;
+
+/** WebGL-compatible primitive topology constants. */
+export const GL_PRIMITIVE_MODE = {
+  POINTS: 0x0000,
+  LINES: 0x0001,
+  LINE_LOOP: 0x0002,
+  LINE_STRIP: 0x0003,
+  TRIANGLES: 0x0004,
+  TRIANGLE_STRIP: 0x0005,
+  TRIANGLE_FAN: 0x0006
+} as const;
+
+/** WebGL-compatible vertex component type constants. */
+export const GL_TYPE = {
+  BYTE: 5120,
+  UNSIGNED_BYTE: 5121,
+  SHORT: 5122,
+  UNSIGNED_SHORT: 5123,
+  INT: 5124,
+  UNSIGNED_INT: 5125,
+  FLOAT: 5126,
+  DOUBLE: 5130,
+  UNSIGNED_SHORT_4_4_4_4: 32819,
+  UNSIGNED_SHORT_5_5_5_1: 32820,
+  UNSIGNED_SHORT_5_6_5: 33635
+} as const;
+
+/** WebGL-compatible constants used by geometry utilities. */
+export const GL = {
+  ...GL_PRIMITIVE_MODE,
+  ...GL_TYPE
+} as const;

--- a/modules/geometry-utils/src/coordinates.ts
+++ b/modules/geometry-utils/src/coordinates.ts
@@ -1,0 +1,8 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Wraps a number into the half-open range `[0, 1)`. */
+export function emod(value: number): number {
+  return ((value % 1) + 1) % 1;
+}

--- a/modules/geometry-utils/src/geometry.ts
+++ b/modules/geometry-utils/src/geometry.ts
@@ -1,0 +1,49 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {TypedArray} from '@math.gl/types';
+
+/** A typed geometry attribute with either loaders.gl-style `value` or legacy `values` storage. */
+export type GeometryAttribute = {
+  value?: TypedArray;
+  values?: TypedArray;
+  size?: number;
+};
+
+/** Minimal geometry shape understood by the geometry utilities. */
+export type Geometry = {
+  mode: number;
+  indices?: GeometryAttribute | TypedArray;
+  attributes: Record<string, GeometryAttribute>;
+};
+
+/** Returns whether a value has the minimal geometry shape. */
+export function isGeometry(value: unknown): value is Geometry {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const geometry = value as Partial<Geometry>;
+  return typeof geometry.mode === 'number' && Boolean(geometry.attributes);
+}
+
+/** Returns the typed array stored in a geometry attribute. */
+export function getAttributeValues(attribute: GeometryAttribute | TypedArray): TypedArray {
+  if (ArrayBuffer.isView(attribute)) {
+    return attribute as TypedArray;
+  }
+  const values = attribute.value || attribute.values;
+  if (!values) {
+    throw new Error('Geometry attribute does not contain typed-array values');
+  }
+  return values;
+}
+
+/** Returns a geometry's position attribute. */
+export function getPositionAttribute(geometry: Geometry): GeometryAttribute {
+  const position = geometry.attributes['POSITION'] || geometry.attributes['positions'];
+  if (!position) {
+    throw new Error('Geometry does not contain a position attribute');
+  }
+  return position;
+}

--- a/modules/geometry-utils/src/gl-type.ts
+++ b/modules/geometry-utils/src/gl-type.ts
@@ -30,6 +30,9 @@ export default class GLType {
   /** Returns the WebGL component constant for a typed array or typed-array constructor. */
   static fromTypedArray(arrayOrType: TypedArray | TypedArrayConstructor): number {
     const arrayType = ArrayBuffer.isView(arrayOrType) ? arrayOrType.constructor : arrayOrType;
+    if (arrayType === Uint8ClampedArray) {
+      return GL_TYPE.UNSIGNED_BYTE;
+    }
     for (const [glType, candidateArrayType] of Object.entries(GL_TYPE_TO_ARRAY_TYPE)) {
       if (candidateArrayType === arrayType) {
         return Number(glType);

--- a/modules/geometry-utils/src/gl-type.ts
+++ b/modules/geometry-utils/src/gl-type.ts
@@ -1,0 +1,84 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {TypedArray, TypedArrayConstructor} from '@math.gl/types';
+import {GL_TYPE} from './constants';
+
+const GL_TYPE_TO_ARRAY_TYPE: Record<number, TypedArrayConstructor> = {
+  [GL_TYPE.DOUBLE]: Float64Array,
+  [GL_TYPE.FLOAT]: Float32Array,
+  [GL_TYPE.UNSIGNED_SHORT]: Uint16Array,
+  [GL_TYPE.UNSIGNED_INT]: Uint32Array,
+  [GL_TYPE.UNSIGNED_BYTE]: Uint8Array,
+  [GL_TYPE.BYTE]: Int8Array,
+  [GL_TYPE.SHORT]: Int16Array,
+  [GL_TYPE.INT]: Int32Array,
+  [GL_TYPE.UNSIGNED_SHORT_4_4_4_4]: Uint16Array,
+  [GL_TYPE.UNSIGNED_SHORT_5_5_5_1]: Uint16Array,
+  [GL_TYPE.UNSIGNED_SHORT_5_6_5]: Uint16Array
+};
+
+const NAME_TO_GL_TYPE: Record<string, number> = Object.fromEntries(
+  Object.entries(GL_TYPE).map(([name, glType]) => [name, glType])
+);
+
+const TYPE_CONVERSION_ERROR = 'Failed to convert GL type';
+
+/** Converts between WebGL component constants and JavaScript typed arrays. */
+export default class GLType {
+  /** Returns the WebGL component constant for a typed array or typed-array constructor. */
+  static fromTypedArray(arrayOrType: TypedArray | TypedArrayConstructor): number {
+    const arrayType = ArrayBuffer.isView(arrayOrType) ? arrayOrType.constructor : arrayOrType;
+    for (const [glType, candidateArrayType] of Object.entries(GL_TYPE_TO_ARRAY_TYPE)) {
+      if (candidateArrayType === arrayType) {
+        return Number(glType);
+      }
+    }
+    throw new Error(TYPE_CONVERSION_ERROR);
+  }
+
+  /** Returns a WebGL component constant from its uppercase name. */
+  static fromName(name: string): number {
+    const glType = NAME_TO_GL_TYPE[name];
+    if (glType === undefined) {
+      throw new Error(TYPE_CONVERSION_ERROR);
+    }
+    return glType;
+  }
+
+  /** Returns the typed-array constructor for a WebGL component constant. */
+  static getArrayType(glType: number): TypedArrayConstructor {
+    const ArrayType = GL_TYPE_TO_ARRAY_TYPE[glType];
+    if (!ArrayType) {
+      throw new Error(TYPE_CONVERSION_ERROR);
+    }
+    return ArrayType;
+  }
+
+  /** Returns the size in bytes of one element of a WebGL component type. */
+  static getByteSize(glType: number): number {
+    return GLType.getArrayType(glType).BYTES_PER_ELEMENT;
+  }
+
+  /** Returns whether a value is a supported WebGL component type. */
+  static validate(glType: number): boolean {
+    return Boolean(GL_TYPE_TO_ARRAY_TYPE[glType]);
+  }
+
+  /** Creates a typed view over an ArrayBuffer or an existing ArrayBuffer view. */
+  static createTypedArray(
+    glType: number,
+    buffer: ArrayBufferLike | ArrayBufferView,
+    byteOffset = 0,
+    length?: number
+  ): TypedArray {
+    const ArrayType = GLType.getArrayType(glType);
+    const arrayBuffer = ArrayBuffer.isView(buffer) ? buffer.buffer : buffer;
+    const viewByteOffset = ArrayBuffer.isView(buffer) ? buffer.byteOffset : 0;
+    const resolvedByteOffset = viewByteOffset + byteOffset;
+    const resolvedLength =
+      length ?? Math.floor((buffer.byteLength - byteOffset) / ArrayType.BYTES_PER_ELEMENT);
+    return new ArrayType(arrayBuffer as ArrayBuffer, resolvedByteOffset, resolvedLength);
+  }
+}

--- a/modules/geometry-utils/src/index.ts
+++ b/modules/geometry-utils/src/index.ts
@@ -1,0 +1,38 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export type {TypedArray, TypedArrayConstructor} from '@math.gl/types';
+
+export {GL, GL_TYPE, GL_PRIMITIVE, GL_PRIMITIVE_MODE} from './constants';
+export {default as GLType} from './gl-type';
+
+export type {Geometry, GeometryAttribute} from './geometry';
+export {isGeometry} from './geometry';
+
+export type {Primitive} from './primitive-iterator';
+export {makeAttributeIterator} from './attribute-iterator';
+export {makePrimitiveIterator} from './primitive-iterator';
+export {computeVertexNormals} from './compute-vertex-normals';
+
+export {encodeRGB565, decodeRGB565} from './rgb565';
+export {concatTypedArrays} from './typed-array-utils';
+
+export {
+  octEncodeInRange,
+  octEncode,
+  octEncodeToVector4,
+  octDecodeInRange,
+  octDecode,
+  octDecodeFromVector4,
+  octPackFloat,
+  octEncodeFloat,
+  octDecodeFloat,
+  octPack,
+  octUnpack,
+  compressTextureCoordinates,
+  decompressTextureCoordinates,
+  zigZagDeltaDecode
+} from './attribute-compression';
+
+export {emod} from './coordinates';

--- a/modules/geometry-utils/src/primitive-iterator.ts
+++ b/modules/geometry-utils/src/primitive-iterator.ts
@@ -1,0 +1,145 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {TypedArray} from '@math.gl/types';
+import {GL} from './constants';
+import type {Geometry} from './geometry';
+import {getAttributeValues, getPositionAttribute, isGeometry} from './geometry';
+
+/** One dereferenced point, line, or triangle primitive. */
+export type Primitive = {
+  attributes: object;
+  type: number;
+  i1: number;
+  i2?: number;
+  i3?: number;
+  primitiveIndex: number;
+};
+
+/**
+ * Iterates through a geometry's primitives and dereferences optional indices.
+ *
+ * The legacy argument form `(indices, attributes, mode, start, end)` is also supported.
+ */
+export function* makePrimitiveIterator(
+  geometryOrIndices?: Geometry | TypedArray | {value?: TypedArray; values?: TypedArray},
+  attributes: object = {},
+  mode?: number,
+  start = 0,
+  end?: number
+): Iterable<Primitive> {
+  let indices: TypedArray | undefined;
+  if (isGeometry(geometryOrIndices)) {
+    const geometry = geometryOrIndices;
+    indices = geometry.indices ? getAttributeValues(geometry.indices) : undefined;
+    attributes = geometry.attributes;
+    mode = geometry.mode;
+    if (end === undefined) {
+      const position = getPositionAttribute(geometry);
+      end = indices?.length ?? getAttributeValues(position).length / (position.size || 3);
+    }
+  } else if (geometryOrIndices) {
+    indices = getAttributeValues(geometryOrIndices);
+  }
+
+  if (mode === undefined) {
+    throw new Error('Primitive mode is required');
+  }
+  end ??= indices?.length ?? start;
+
+  const dereference = (index: number): number => Number(indices ? indices[index] : index);
+  let primitiveIndex = 0;
+
+  switch (mode) {
+    case GL.POINTS:
+      for (let index = start; index < end; index++) {
+        yield {
+          attributes,
+          type: GL.POINTS,
+          i1: dereference(index),
+          primitiveIndex: primitiveIndex++
+        };
+      }
+      return;
+
+    case GL.LINES:
+      for (let index = start; index + 1 < end; index += 2) {
+        yield {
+          attributes,
+          type: GL.LINES,
+          i1: dereference(index),
+          i2: dereference(index + 1),
+          primitiveIndex: primitiveIndex++
+        };
+      }
+      return;
+
+    case GL.LINE_STRIP:
+      for (let index = start; index + 1 < end; index++) {
+        yield {
+          attributes,
+          type: GL.LINES,
+          i1: dereference(index),
+          i2: dereference(index + 1),
+          primitiveIndex: primitiveIndex++
+        };
+      }
+      return;
+
+    case GL.LINE_LOOP:
+      for (let index = start; index < end; index++) {
+        yield {
+          attributes,
+          type: GL.LINES,
+          i1: dereference(index),
+          i2: dereference(index + 1 < end ? index + 1 : start),
+          primitiveIndex: primitiveIndex++
+        };
+      }
+      return;
+
+    case GL.TRIANGLES:
+      for (let index = start; index + 2 < end; index += 3) {
+        yield {
+          attributes,
+          type: GL.TRIANGLES,
+          i1: dereference(index),
+          i2: dereference(index + 1),
+          i3: dereference(index + 2),
+          primitiveIndex: primitiveIndex++
+        };
+      }
+      return;
+
+    case GL.TRIANGLE_STRIP:
+      for (let index = start; index + 2 < end; index++) {
+        const odd = (index - start) % 2 === 1;
+        yield {
+          attributes,
+          type: GL.TRIANGLES,
+          i1: dereference(odd ? index + 1 : index),
+          i2: dereference(odd ? index : index + 1),
+          i3: dereference(index + 2),
+          primitiveIndex: primitiveIndex++
+        };
+      }
+      return;
+
+    case GL.TRIANGLE_FAN:
+      for (let index = start + 1; index + 1 < end; index++) {
+        yield {
+          attributes,
+          type: GL.TRIANGLES,
+          i1: dereference(start),
+          i2: dereference(index),
+          i3: dereference(index + 1),
+          primitiveIndex: primitiveIndex++
+        };
+      }
+      return;
+
+    default:
+      throw new Error(`Unknown primitive mode ${mode}`);
+  }
+}

--- a/modules/geometry-utils/src/rgb565.ts
+++ b/modules/geometry-utils/src/rgb565.ts
@@ -1,0 +1,26 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Decodes a packed RGB565 value into 8-bit RGB components. */
+export function decodeRGB565(rgb565: number, target: number[] = [0, 0, 0]): number[] {
+  const red = (rgb565 >> 11) & 31;
+  const green = (rgb565 >> 5) & 63;
+  const blue = rgb565 & 31;
+  target[0] = (red << 3) | (red >> 2);
+  target[1] = (green << 2) | (green >> 4);
+  target[2] = (blue << 3) | (blue >> 2);
+  return target;
+}
+
+/** Encodes 8-bit RGB components into a packed RGB565 value. */
+export function encodeRGB565(rgb: ArrayLike<number>): number {
+  const red = Math.round(clampByte(rgb[0] ?? 0) * (31 / 255));
+  const green = Math.round(clampByte(rgb[1] ?? 0) * (63 / 255));
+  const blue = Math.round(clampByte(rgb[2] ?? 0) * (31 / 255));
+  return (red << 11) | (green << 5) | blue;
+}
+
+function clampByte(value: number): number {
+  return Math.max(0, Math.min(255, value));
+}

--- a/modules/geometry-utils/src/typed-array-utils.ts
+++ b/modules/geometry-utils/src/typed-array-utils.ts
@@ -1,0 +1,16 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Concatenates the visible bytes of multiple typed-array or DataView instances. */
+export function concatTypedArrays(arrays: readonly ArrayBufferView[] = []): Uint8Array {
+  const byteLength = arrays.reduce((length, array) => length + array.byteLength, 0);
+  const result = new Uint8Array(byteLength);
+  let byteOffset = 0;
+  for (const array of arrays) {
+    const bytes = new Uint8Array(array.buffer, array.byteOffset, array.byteLength);
+    result.set(bytes, byteOffset);
+    byteOffset += bytes.byteLength;
+  }
+  return result;
+}

--- a/modules/geometry-utils/test/geometry-utils.spec.ts
+++ b/modules/geometry-utils/test/geometry-utils.spec.ts
@@ -25,6 +25,8 @@ import {expect, test} from 'vitest';
 
 test('GLType converts component types and preserves view offsets', () => {
   expect(GLType.fromTypedArray(new Uint16Array(1))).toBe(GL.UNSIGNED_SHORT);
+  expect(GLType.fromTypedArray(new Uint8ClampedArray([0, 255]))).toBe(GL.UNSIGNED_BYTE);
+  expect(GLType.fromTypedArray(Uint8ClampedArray)).toBe(GL.UNSIGNED_BYTE);
   expect(GLType.fromName('FLOAT')).toBe(GL.FLOAT);
   expect(GLType.getByteSize(GL.DOUBLE)).toBe(8);
   expect(GLType.validate(-1)).toBeFalsy();

--- a/modules/geometry-utils/test/geometry-utils.spec.ts
+++ b/modules/geometry-utils/test/geometry-utils.spec.ts
@@ -1,0 +1,118 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Vector2, Vector3, Vector4} from '@math.gl/core';
+import {
+  GL,
+  GLType,
+  computeVertexNormals,
+  compressTextureCoordinates,
+  concatTypedArrays,
+  decodeRGB565,
+  decompressTextureCoordinates,
+  emod,
+  encodeRGB565,
+  makeAttributeIterator,
+  makePrimitiveIterator,
+  octDecode,
+  octDecodeFromVector4,
+  octEncode,
+  octEncodeToVector4,
+  zigZagDeltaDecode
+} from '@math.gl/geometry-utils';
+import {expect, test} from 'vitest';
+
+test('GLType converts component types and preserves view offsets', () => {
+  expect(GLType.fromTypedArray(new Uint16Array(1))).toBe(GL.UNSIGNED_SHORT);
+  expect(GLType.fromName('FLOAT')).toBe(GL.FLOAT);
+  expect(GLType.getByteSize(GL.DOUBLE)).toBe(8);
+  expect(GLType.validate(-1)).toBeFalsy();
+
+  const source = new Uint8Array([10, 20, 30, 40]).subarray(1, 3);
+  expect(Array.from(GLType.createTypedArray(GL.UNSIGNED_BYTE, source))).toEqual([20, 30]);
+});
+
+test('makeAttributeIterator iterates fixed-size elements', () => {
+  const iterator = makeAttributeIterator(new Float32Array([1, 2, 3, 4]), 2);
+  expect(Array.from(iterator, value => Array.from(value))).toEqual([
+    [1, 2],
+    [3, 4]
+  ]);
+});
+
+test('makePrimitiveIterator expands indexed loops and preserves strip winding', () => {
+  const loop = Array.from(
+    makePrimitiveIterator(new Uint16Array([3, 1, 4]), {}, GL.LINE_LOOP),
+    primitive => [primitive.i1, primitive.i2]
+  );
+  expect(loop).toEqual([
+    [3, 1],
+    [1, 4],
+    [4, 3]
+  ]);
+
+  const strip = Array.from(
+    makePrimitiveIterator(undefined, {}, GL.TRIANGLE_STRIP, 0, 4),
+    primitive => [primitive.i1, primitive.i2, primitive.i3]
+  );
+  expect(strip).toEqual([
+    [0, 1, 2],
+    [2, 1, 3]
+  ]);
+});
+
+test('computeVertexNormals supports indexed geometry', () => {
+  const normals = computeVertexNormals({
+    mode: GL.TRIANGLES,
+    indices: new Uint16Array([0, 1, 2, 0, 2, 3]),
+    attributes: {
+      POSITION: {value: new Float32Array([0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0]), size: 3}
+    }
+  });
+  expect(Array.from(normals)).toEqual([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1]);
+});
+
+test('RGB565 encodes and decodes canonical colors', () => {
+  expect(encodeRGB565([255, 0, 0])).toBe(0xf800);
+  expect(encodeRGB565([0, 255, 0])).toBe(0x07e0);
+  expect(encodeRGB565([0, 0, 255])).toBe(0x001f);
+  expect(decodeRGB565(0xffff)).toEqual([255, 255, 255]);
+});
+
+test('concatTypedArrays copies only visible view bytes', () => {
+  const first = new Uint8Array([0, 1, 2, 3]).subarray(1, 3);
+  const second = new Uint16Array([0x0504]);
+  expect(Array.from(concatTypedArrays([first, second]))).toEqual([1, 2, 4, 5]);
+});
+
+test('octahedral encoding round-trips vectors', () => {
+  const source = new Vector3(1, 1, 1).normalize();
+  const encoded = octEncode(source, new Vector2());
+  const decoded = octDecode(encoded.x, encoded.y, new Vector3());
+  expect(decoded.distance(source)).toBeLessThan(0.01);
+
+  const encoded4 = octEncodeToVector4(source, new Vector4());
+  const decoded4 = octDecodeFromVector4(encoded4, new Vector3());
+  expect(decoded4.distance(source)).toBeLessThan(0.0001);
+});
+
+test('texture coordinate and ZigZag delta compression round-trip', () => {
+  const textureCoordinates = new Vector2(0.25, 0.75);
+  const decompressed = decompressTextureCoordinates(
+    compressTextureCoordinates(textureCoordinates),
+    new Vector2()
+  );
+  expect(decompressed.distance(textureCoordinates)).toBeLessThan(0.001);
+
+  const u = new Uint16Array([2, 2, 1]);
+  const v = new Uint16Array([4, 0, 3]);
+  zigZagDeltaDecode(u, v);
+  expect(Array.from(u)).toEqual([1, 2, 1]);
+  expect(Array.from(v)).toEqual([2, 2, 0]);
+});
+
+test('emod wraps positive and negative values', () => {
+  expect(emod(1.25)).toBe(0.25);
+  expect(emod(-0.25)).toBe(0.75);
+});

--- a/modules/geometry-utils/tsconfig.json
+++ b/modules/geometry-utils/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [{"path": "../core"}, {"path": "../types"}]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -65,6 +65,8 @@
       "@math.gl/geoid/test/*": ["./modules/geoid/test/*"],
       "@math.gl/geospatial/*": ["./modules/geospatial/src/*"],
       "@math.gl/geospatial/test/*": ["./modules/geospatial/test/*"],
+      "@math.gl/geometry-utils/*": ["./modules/geometry-utils/src/*"],
+      "@math.gl/geometry-utils/test/*": ["./modules/geometry-utils/test/*"],
       "@math.gl/polygon/*": ["./modules/polygon/src/*"],
       "@math.gl/polygon/test/*": ["./modules/polygon/test/*"],
       "@math.gl/proj4/*": ["./modules/proj4/src/*"],

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -6,6 +6,7 @@
       "@math.gl/core": ["./modules/core/src/index.ts"],
       "@math.gl/culling": ["./modules/culling/src/index.ts"],
       "@math.gl/geometry": ["./modules/geometry/src/index.ts"],
+      "@math.gl/geometry-utils": ["./modules/geometry-utils/src/index.ts"],
       "@math.gl/dggs-geohash": ["./modules/dggs-geohash/src/index.ts"],
       "@math.gl/dggs-quadkey": ["./modules/dggs-quadkey/src/index.ts"],
       "@math.gl/dggs-s2": ["./modules/dggs-s2/src/index.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,6 +884,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@math.gl/geometry-utils@workspace:modules/geometry-utils":
+  version: 0.0.0-use.local
+  resolution: "@math.gl/geometry-utils@workspace:modules/geometry-utils"
+  dependencies:
+    "@math.gl/core": "npm:4.2.0-alpha.3"
+    "@math.gl/types": "npm:4.2.0-alpha.3"
+  languageName: unknown
+  linkType: soft
+
 "@math.gl/geometry@workspace:modules/geometry":
   version: 0.0.0-use.local
   resolution: "@math.gl/geometry@workspace:modules/geometry"


### PR DESCRIPTION
## Goals

- Establish `@math.gl/geometry-utils` as the shared home for renderer-independent geometry helpers currently maintained in `@loaders.gl/math`.
- Give loaders.gl and luma.gl a small typed-array geometry layer that has no WebGL or WebGPU runtime dependency.

## Changes

- Add a publishable `@math.gl/geometry-utils` workspace with the public `@loaders.gl/math` surface: GL component constants, typed-array conversion, geometry detection and traversal, vertex-normal generation, RGB565, octahedral attribute compression, texture-coordinate compression, ZigZag delta decoding, typed-array concatenation, and `emod`.
- Add typed `Geometry`, `GeometryAttribute`, and `Primitive` contracts compatible with loaders.gl mesh attributes.
- Harden the promoted implementations around typed-array subview offsets, point-mode detection, line-loop and triangle-strip/fan traversal, indexed normal accumulation, and RGB565 channel packing.
- Add Node/browser coverage and module/API documentation.
- Register the workspace in TypeScript paths, documentation navigation, release notes, and the lockfile.

## Validation

- `yarn build`
- `yarn test-node` — 729 passed, 129 skipped
- `yarn test-headless` — 730 passed, 128 skipped
- `yarn lint fix`