### PR TITLE
fix(geospatial): extend makeOBBFromRegion

### DIFF
--- a/docs/modules/geospatial/README.md
+++ b/docs/modules/geospatial/README.md
@@ -26,7 +26,7 @@ Attribution: From <a href="https://en.wikipedia.org/wiki/World_Geodetic_System#/
 
 | Function            | Description                                                     |
 | ------------------- | --------------------------------------------------------------- |
-| `makeOBBFromRegion` | Creates an oriented bounding box for a WGS84 geospatial region. |
+| `makeOBBFromRegion` | Creates a conservative oriented bounding box for a longitude–latitude–height region, including antimeridian and polar regions. |
 
 ## Usage Examples
 

--- a/docs/modules/geospatial/api-reference/make-obb-from-region.md
+++ b/docs/modules/geospatial/api-reference/make-obb-from-region.md
@@ -1,9 +1,8 @@
 # makeOBBFromRegion
 
-Creates an `OrientedBoundingBox` that encloses a longitude-latitude-height region on the WGS84
-ellipsoid.
+Builds a conservative [`OrientedBoundingBox`](../../culling/api-reference/oriented-bounding-box) for a longitude–latitude–height region on an ellipsoid. This is useful for 3D Tiles regions, globe rendering, spatial indexing, and frustum culling.
 
-![A geospatial region enclosed by an oriented bounding box](./image.png)
+The returned box is expressed in ellipsoid-fixed Cartesian coordinates. Its orientation is an implementation detail and may change between releases.
 
 ## Usage
 
@@ -12,24 +11,58 @@ import {toRadians} from '@math.gl/core';
 import {makeOBBFromRegion} from '@math.gl/geospatial';
 
 const region = [
-  toRadians(-10), // west
-  toRadians(35), // south
-  toRadians(20), // east
-  toRadians(55), // north
-  0, // minimum height
-  1000 // maximum height
+  toRadians(-30), // west
+  toRadians(35),  // south
+  toRadians(20),  // east
+  toRadians(55),  // north
+  0,              // minimumHeight
+  1000            // maximumHeight
 ];
 
-const boundingBox = makeOBBFromRegion(region);
+const box = makeOBBFromRegion(region);
 ```
 
-## Functions
+## Function
 
-### makeOBBFromRegion(region : Number[6]) : OrientedBoundingBox
+### `makeOBBFromRegion(region, ellipsoid?, options?) : OrientedBoundingBox`
 
-- `region` - An array containing `[west, south, east, north, minimumHeight, maximumHeight]`.
-  Longitudes and latitudes are in radians. Heights are in meters relative to the WGS84 ellipsoid.
-  A region can cross the antimeridian by specifying an `east` longitude smaller than `west`.
+`region` is `[west, south, east, north, minimumHeight, maximumHeight]`. Longitudes and latitudes are in radians by default, matching the OGC 3D Tiles region definition. Heights use the ellipsoid's linear unit, normally meters. Use `options.units: 'degrees'` for degree input.
 
-Returns a new `OrientedBoundingBox` that encloses the region. The orientation of the returned box
-is an implementation detail and is not guaranteed to remain stable.
+Latitudes must be in `[-π/2, π/2]` (or `[-90, 90]` in degree mode), `south` must not exceed `north`, and minimum height must not exceed maximum height.
+
+### Longitude wrapping
+
+Longitude values are normalized internally, so values outside the conventional range are accepted. If `east < west`, the region crosses the antimeridian and uses the shorter wrapped interval:
+
+```js
+const datelineRegion = [170, -10, -170, 10, 0, 250];
+const box = makeOBBFromRegion(datelineRegion, undefined, {units: 'degrees'});
+```
+
+This describes a 20° region centered on ±180°, not a 340° region centered on 0°. Equal west and east longitudes describe zero width, not a full globe.
+
+### Ellipsoid
+
+The optional ellipsoid defaults to `Ellipsoid.WGS84`:
+
+```js
+import {Ellipsoid, makeOBBFromRegion} from '@math.gl/geospatial';
+
+const moon = new Ellipsoid(1737400, 1737400, 1737400);
+const box = makeOBBFromRegion(region, moon);
+```
+
+### Options
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `units` | `'radians' \| 'degrees'` | `'radians'` | Units for longitude and latitude. Heights are never converted. |
+| `transform` | `Matrix4` | — | Affine transform from ellipsoid-fixed coordinates into world coordinates. |
+
+The transform is applied exactly once and may include translation, rotation, non-uniform scale, or shear. Translation affects the center; the linear part affects the half-axes. Inputs and caller-owned values are never mutated.
+
+## Errors and edge cases
+
+The function throws for malformed regions, non-finite values, reversed heights, or invalid latitudes. A tiny tolerance is allowed at the latitude boundaries and values are clamped to the exact pole before conversion.
+
+Zero-width longitude, zero-height latitude, zero-height altitude, and point-like regions are valid. Regions touching either pole are valid and produce finite results even though longitude lines converge there. The box encloses the curved region conservatively; it is not an exact minimum-volume box.

--- a/docs/modules/geospatial/api-reference/make-obb-from-region.md
+++ b/docs/modules/geospatial/api-reference/make-obb-from-region.md
@@ -32,14 +32,14 @@ Latitudes must be in `[-π/2, π/2]` (or `[-90, 90]` in degree mode), `south` mu
 
 ### Longitude wrapping
 
-Longitude values are normalized internally, so values outside the conventional range are accepted. If `east < west`, the region crosses the antimeridian and uses the shorter wrapped interval:
+Longitude values outside the conventional range are accepted. The boundaries retain the directed eastward semantics used by 3D Tiles and `LngLatRectangle`: if `east < west`, the interval crosses the antimeridian and continues eastward through ±180°.
 
 ```js
 const datelineRegion = [170, -10, -170, 10, 0, 250];
 const box = makeOBBFromRegion(datelineRegion, undefined, {units: 'degrees'});
 ```
 
-This describes a 20° region centered on ±180°, not a 340° region centered on 0°. Equal west and east longitudes describe zero width, not a full globe.
+This describes a 20° region centered on ±180°. A region from `10°` to `-10°` is the directed 340° interval, not the shorter 20° interval. Equal endpoints describe zero width, while endpoints separated by one full turn (for example `0°` to `360°`) describe a full-globe longitude span.
 
 ### Ellipsoid
 
@@ -59,7 +59,7 @@ const box = makeOBBFromRegion(region, moon);
 | `units` | `'radians' \| 'degrees'` | `'radians'` | Units for longitude and latitude. Heights are never converted. |
 | `transform` | `Matrix4` | — | Affine transform from ellipsoid-fixed coordinates into world coordinates. |
 
-The transform is applied exactly once and may include translation, rotation, non-uniform scale, or shear. Translation affects the center; the linear part affects the half-axes. Inputs and caller-owned values are never mutated.
+The transform is applied exactly once and may include translation, rotation, non-uniform scale, or shear. Translation affects the center; the linear part affects the half-axes. For 3D Tiles, do not automatically pass `tile.transform`: the 3D Tiles specification exempts region bounding volumes from that transform. Inputs and caller-owned values are never mutated.
 
 ## Errors and edge cases
 

--- a/modules/geospatial/src/ellipsoid-tangent-plane.ts
+++ b/modules/geospatial/src/ellipsoid-tangent-plane.ts
@@ -14,7 +14,7 @@ const scratchCart3 = new Vector3();
 const scratchEastNorthUp = new Matrix4();
 const scratchProjectPointOntoPlaneCartesian3 = new Vector3();
 
-/** A two-dimensional east-north plane tangent to the WGS84 ellipsoid. */
+/** A two-dimensional east-north plane tangent to an ellipsoid. */
 export class EllipsoidTangentPlane {
   private _origin: Vector3;
   private _xAxis: Vector3;
@@ -25,15 +25,13 @@ export class EllipsoidTangentPlane {
    * Creates a new plane tangent to the WGS84 ellipsoid at the provided origin.
    * If origin is not on the surface of the ellipsoid, its surface projection will be used.
    *
-   * @param origin A nonzero WGS84 Cartesian point.
+   * @param origin A nonzero Cartesian point on or near the ellipsoid.
+   * @param ellipsoid The ellipsoid to which the origin belongs. Defaults to WGS84.
    */
-  constructor(origin: number[]) {
-    const originOnSurface = Ellipsoid.WGS84.scaleToGeodeticSurface(origin, scratchOrigin);
+  constructor(origin: number[], ellipsoid: Ellipsoid = Ellipsoid.WGS84) {
+    const originOnSurface = ellipsoid.scaleToGeodeticSurface(origin, scratchOrigin);
 
-    const eastNorthUp = Ellipsoid.WGS84.eastNorthUpToFixedFrame(
-      originOnSurface,
-      scratchEastNorthUp
-    );
+    const eastNorthUp = ellipsoid.eastNorthUpToFixedFrame(originOnSurface, scratchEastNorthUp);
 
     this._origin = new Vector3(originOnSurface);
     this._xAxis = new Vector3(scratchCart3.from(eastNorthUp.getColumn(0)));

--- a/modules/geospatial/src/index.ts
+++ b/modules/geospatial/src/index.ts
@@ -6,4 +6,5 @@ export {Ellipsoid} from './ellipsoid';
 export {EllipsoidTangentPlane} from './ellipsoid-tangent-plane';
 export {LngLatRectangle} from './lng-lat-rectangle';
 export {makeOBBFromRegion} from './make-obb-from-region';
+export type {GeodeticRegion, MakeOBBFromRegionOptions} from './make-obb-from-region';
 export {isWGS84} from './type-utils';

--- a/modules/geospatial/src/make-obb-from-region.ts
+++ b/modules/geospatial/src/make-obb-from-region.ts
@@ -5,7 +5,7 @@
 // This file is derived from the Cesium math library under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
-import {Vector2, Vector3, degrees, _MathUtils} from '@math.gl/core';
+import {Matrix4, Vector2, Vector3, degrees, radians, _MathUtils} from '@math.gl/core';
 import {OrientedBoundingBox, Plane} from '@math.gl/culling';
 // @ts-ignore
 // eslint-disable-next-line import/no-unresolved
@@ -45,17 +45,77 @@ const scratchZ = new Vector3();
 const VECTOR3_UNIT_X = new Vector3(1, 0, 0);
 const VECTOR3_UNIT_Z = new Vector3(0, 0, 1);
 
+export type GeodeticRegion = readonly [
+  west: number,
+  south: number,
+  east: number,
+  north: number,
+  minimumHeight: number,
+  maximumHeight: number
+];
+
+export type MakeOBBFromRegionOptions = {
+  /** Longitude and latitude units. Defaults to radians, as in 3D Tiles regions. */
+  units?: 'radians' | 'degrees';
+  /** Affine transform from ellipsoid-fixed coordinates into the caller's world space. */
+  transform?: Matrix4;
+};
+
 /**
- * Computes an OrientedBoundingBox that bounds a region on the surface of the WGS84 ellipsoid.
- * There are no guarantees about the orientation of the bounding box.
+ * Creates a conservative oriented bounding box for a geodetic region.
  *
- * @param region The cartographic region ([west, south, east, north, minimum height, maximum height])
- * on the surface of the ellipsoid. Longitude and latitude values are in radians; heights are in
- * meters.
- * @returns A new OrientedBoundingBox that encloses the region.
+ * Longitudes and latitudes are radians by default. An east longitude smaller than west
+ * denotes the shorter interval crossing the antimeridian; equal longitudes denote zero width.
+ * Heights use the ellipsoid's linear unit. Inputs and the supplied ellipsoid and transform are
+ * never mutated.
  */
 // eslint-disable-next-line max-statements
-export function makeOBBFromRegion(region: readonly number[]): OrientedBoundingBox {
+export function makeOBBFromRegion(
+  region: GeodeticRegion,
+  ellipsoid: Ellipsoid = Ellipsoid.WGS84,
+  options: MakeOBBFromRegionOptions = {}
+): OrientedBoundingBox {
+  if (!region || region.length !== 6 || region.some(value => !Number.isFinite(value))) {
+    throw new Error('makeOBBFromRegion: region must contain exactly six finite numbers');
+  }
+  const unitScale = options.units === 'degrees' ? radians(1) : 1;
+  const [rawWest, rawSouth, rawEast, rawNorth, minimumHeight, maximumHeight] = region;
+  if (minimumHeight > maximumHeight) {
+    throw new Error('makeOBBFromRegion: minimumHeight must not exceed maximumHeight');
+  }
+  const south = rawSouth * unitScale;
+  const north = rawNorth * unitScale;
+  const west = normalizeLongitude(rawWest * unitScale);
+  const east = normalizeLongitude(rawEast * unitScale);
+  const latitudeTolerance = 1e-12;
+  if (
+    south > north ||
+    south < -_MathUtils.PI_OVER_TWO - latitudeTolerance ||
+    north > _MathUtils.PI_OVER_TWO + latitudeTolerance
+  ) {
+    throw new Error('makeOBBFromRegion: latitude must be within [-π/2, π/2] and south ≤ north');
+  }
+  // Avoid passing a tiny out-of-range value to the ellipsoid conversion at a boundary.
+  const clampedSouth = Math.max(-_MathUtils.PI_OVER_TWO, Math.min(_MathUtils.PI_OVER_TWO, south));
+  const clampedNorth = Math.max(-_MathUtils.PI_OVER_TWO, Math.min(_MathUtils.PI_OVER_TWO, north));
+  return makeOBBFromNormalizedRegion(
+    [west, clampedSouth, east, clampedNorth, minimumHeight, maximumHeight],
+    ellipsoid,
+    options.transform
+  );
+}
+
+function normalizeLongitude(value: number): number {
+  const normalized =
+    ((((value + Math.PI) % _MathUtils.TWO_PI) + _MathUtils.TWO_PI) % _MathUtils.TWO_PI) - Math.PI;
+  return normalized === -Math.PI && value > 0 ? Math.PI : normalized;
+}
+
+function makeOBBFromNormalizedRegion(
+  region: GeodeticRegion,
+  ellipsoid: Ellipsoid,
+  transform?: Matrix4
+): OrientedBoundingBox {
   const obb = new OrientedBoundingBox();
 
   const [west, south, east, north, minimumHeight, maximumHeight] = region;
@@ -85,8 +145,8 @@ export function makeOBBFromRegion(region: readonly number[]): OrientedBoundingBo
   if (rectangle.width <= _MathUtils.PI) {
     const westDeg = degrees(west);
 
-    const tangentPoint = Ellipsoid.WGS84.cartographicToCartesian(tangentPointCartographic);
-    const ellipsoidTangentPlane = new EllipsoidTangentPlane(tangentPoint);
+    const tangentPoint = ellipsoid.cartographicToCartesian(tangentPointCartographic);
+    const ellipsoidTangentPlane = new EllipsoidTangentPlane(tangentPoint, ellipsoid);
 
     const latCenter = southDeg < 0.0 && northDeg > 0.0 ? 0.0 : tangentPointCartographic.y;
 
@@ -116,23 +176,23 @@ export function makeOBBFromRegion(region: readonly number[]): OrientedBoundingBo
       maximumHeight
     ]);
 
-    const perimeterCartesianNC = Ellipsoid.WGS84.cartographicToCartesian(
+    const perimeterCartesianNC = ellipsoid.cartographicToCartesian(
       perimeterCartographicNC,
       scratchPerimeterCartesianNC
     );
-    let perimeterCartesianNW = Ellipsoid.WGS84.cartographicToCartesian(
+    let perimeterCartesianNW = ellipsoid.cartographicToCartesian(
       perimeterCartographicNW,
       scratchPerimeterCartesianNW
     );
-    const perimeterCartesianCW = Ellipsoid.WGS84.cartographicToCartesian(
+    const perimeterCartesianCW = ellipsoid.cartographicToCartesian(
       perimeterCartographicCW,
       scratchPerimeterCartesianCW
     );
-    let perimeterCartesianSW = Ellipsoid.WGS84.cartographicToCartesian(
+    let perimeterCartesianSW = ellipsoid.cartographicToCartesian(
       perimeterCartographicSW,
       scratchPerimeterCartesianSW
     );
-    const perimeterCartesianSC = Ellipsoid.WGS84.cartographicToCartesian(
+    const perimeterCartesianSC = ellipsoid.cartographicToCartesian(
       perimeterCartographicSC,
       scratchPerimeterCartesianSC
     );
@@ -165,11 +225,11 @@ export function makeOBBFromRegion(region: readonly number[]): OrientedBoundingBo
     minY = Math.min(perimeterProjectedSW.y, perimeterProjectedSC.y);
 
     perimeterCartographicNW.z = perimeterCartographicSW.z = minimumHeight;
-    perimeterCartesianNW = Ellipsoid.WGS84.cartographicToCartesian(
+    perimeterCartesianNW = ellipsoid.cartographicToCartesian(
       perimeterCartographicNW,
       scratchPerimeterCartesianNW
     );
-    perimeterCartesianSW = Ellipsoid.WGS84.cartographicToCartesian(
+    perimeterCartesianSW = ellipsoid.cartographicToCartesian(
       perimeterCartographicSW,
       scratchPerimeterCartesianSW
     );
@@ -181,18 +241,21 @@ export function makeOBBFromRegion(region: readonly number[]): OrientedBoundingBo
     );
     maxZ = maximumHeight;
 
-    return fromPlaneExtents(
-      ellipsoidTangentPlane.origin,
-      ellipsoidTangentPlane.xAxis,
-      ellipsoidTangentPlane.yAxis,
-      ellipsoidTangentPlane.zAxis,
-      minX,
-      maxX,
-      minY,
-      maxY,
-      minZ,
-      maxZ,
-      obb
+    return applyTransform(
+      fromPlaneExtents(
+        ellipsoidTangentPlane.origin,
+        ellipsoidTangentPlane.xAxis,
+        ellipsoidTangentPlane.yAxis,
+        ellipsoidTangentPlane.zAxis,
+        minX,
+        maxX,
+        minY,
+        maxY,
+        minZ,
+        maxZ,
+        obb
+      ),
+      transform
     );
   }
 
@@ -206,7 +269,7 @@ export function makeOBBFromRegion(region: readonly number[]): OrientedBoundingBo
       ? northDeg
       : 0.0;
 
-  const planeOrigin = Ellipsoid.WGS84.cartographicToCartesian(
+  const planeOrigin = ellipsoid.cartographicToCartesian(
     [lonCenterDeg, latitudeNearestToEquator, maximumHeight],
     scratchPlaneOrigin
   );
@@ -219,7 +282,7 @@ export function makeOBBFromRegion(region: readonly number[]): OrientedBoundingBo
   const planeXAxis = scratchPlaneXAxis.copy(planeNormal).cross(planeYAxis);
   plane = scratchPlane.fromPointNormal(planeOrigin, planeNormal);
 
-  const horizonCartesian = Ellipsoid.WGS84.cartographicToCartesian(
+  const horizonCartesian = ellipsoid.cartographicToCartesian(
     [degrees(lonCenter + _MathUtils.PI_OVER_TWO), latitudeNearestToEquator, maximumHeight],
     scratchHorizonCartesian
   );
@@ -230,16 +293,16 @@ export function makeOBBFromRegion(region: readonly number[]): OrientedBoundingBo
   maxX = projectedPoint.dot(planeXAxis);
   minX = -maxX;
 
-  maxY = Ellipsoid.WGS84.cartographicToCartesian(
+  maxY = ellipsoid.cartographicToCartesian(
     [0.0, northDeg, fullyBelowEquator ? minimumHeight : maximumHeight],
     scratchMaxY
   ).z;
-  minY = Ellipsoid.WGS84.cartographicToCartesian(
+  minY = ellipsoid.cartographicToCartesian(
     [0.0, southDeg, fullyAboveEquator ? minimumHeight : maximumHeight],
     scratchMinY
   ).z;
 
-  const farZ = Ellipsoid.WGS84.cartographicToCartesian(
+  const farZ = ellipsoid.cartographicToCartesian(
     [eastDeg, latitudeNearestToEquator, maximumHeight],
     scratchZ
   );
@@ -247,19 +310,33 @@ export function makeOBBFromRegion(region: readonly number[]): OrientedBoundingBo
   minZ = plane.getPointDistance(farZ);
   maxZ = 0.0;
 
-  return fromPlaneExtents(
-    planeOrigin,
-    planeXAxis,
-    planeYAxis,
-    planeNormal,
-    minX,
-    maxX,
-    minY,
-    maxY,
-    minZ,
-    maxZ,
-    obb
+  return applyTransform(
+    fromPlaneExtents(
+      planeOrigin,
+      planeXAxis,
+      planeYAxis,
+      planeNormal,
+      minX,
+      maxX,
+      minY,
+      maxY,
+      minZ,
+      maxZ,
+      obb
+    ),
+    transform
   );
+}
+
+function applyTransform(obb: OrientedBoundingBox, transform?: Matrix4): OrientedBoundingBox {
+  if (!transform) return obb;
+  obb.center.transformAsPoint(transform);
+  for (let column = 0; column < 3; column++) {
+    const axis = obb.halfAxes.getColumn(column, new Vector3());
+    axis.transformAsVector(transform);
+    obb.halfAxes.setColumn(column, axis);
+  }
+  return obb;
 }
 
 /** Helper function for makeOBBFromRegion(). */

--- a/modules/geospatial/src/make-obb-from-region.ts
+++ b/modules/geospatial/src/make-obb-from-region.ts
@@ -64,13 +64,14 @@ export type MakeOBBFromRegionOptions = {
  * Creates a conservative oriented bounding box for a geodetic region.
  *
  * Longitudes and latitudes are radians by default. An east longitude smaller than west
- * denotes the shorter interval crossing the antimeridian; equal longitudes denote zero width.
+ * denotes the directed eastward interval crossing the antimeridian; equal longitudes denote
+ * zero width unless the original endpoints differ by a full turn.
  * Heights use the ellipsoid's linear unit. Inputs and the supplied ellipsoid and transform are
  * never mutated.
  */
 // eslint-disable-next-line max-statements
 export function makeOBBFromRegion(
-  region: GeodeticRegion,
+  region: readonly number[],
   ellipsoid: Ellipsoid = Ellipsoid.WGS84,
   options: MakeOBBFromRegionOptions = {}
 ): OrientedBoundingBox {
@@ -84,12 +85,13 @@ export function makeOBBFromRegion(
   }
   const south = rawSouth * unitScale;
   const north = rawNorth * unitScale;
-  let west = normalizeLongitude(rawWest * unitScale);
+  const west = normalizeLongitude(rawWest * unitScale);
   let east = normalizeLongitude(rawEast * unitScale);
-  // For reversed boundaries choose the shorter of the two arcs. This keeps 170° to
-  // -170° on the dateline while interpreting 10° to -10° as the 20° local interval.
-  if (east < west && east + _MathUtils.TWO_PI - west > Math.PI) {
-    [west, east] = [east, west];
+  // Preserve a complete directed turn, which would otherwise collapse when both endpoints
+  // are normalized to the same longitude. Reversed boundaries retain Cesium/3D Tiles semantics.
+  const directedSpan = rawEast * unitScale - rawWest * unitScale;
+  if (directedSpan >= _MathUtils.TWO_PI - 1e-12) {
+    east = west + _MathUtils.TWO_PI;
   }
   const latitudeTolerance = 1e-12;
   if (

--- a/modules/geospatial/src/make-obb-from-region.ts
+++ b/modules/geospatial/src/make-obb-from-region.ts
@@ -5,7 +5,7 @@
 // This file is derived from the Cesium math library under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
-import {Matrix4, Vector2, Vector3, degrees, radians, _MathUtils} from '@math.gl/core';
+import {Matrix3, Matrix4, Vector2, Vector3, degrees, radians, _MathUtils} from '@math.gl/core';
 import {OrientedBoundingBox, Plane} from '@math.gl/culling';
 // @ts-ignore
 // eslint-disable-next-line import/no-unresolved
@@ -39,7 +39,6 @@ const scratchPlaneXAxis = new Vector3();
 const scratchHorizonCartesian = new Vector3();
 const scratchHorizonProjected = new Vector2();
 const scratchMaxY = new Vector3();
-const scratchMinY = new Vector3();
 const scratchZ = new Vector3();
 
 const VECTOR3_UNIT_X = new Vector3(1, 0, 0);
@@ -85,8 +84,13 @@ export function makeOBBFromRegion(
   }
   const south = rawSouth * unitScale;
   const north = rawNorth * unitScale;
-  const west = normalizeLongitude(rawWest * unitScale);
-  const east = normalizeLongitude(rawEast * unitScale);
+  let west = normalizeLongitude(rawWest * unitScale);
+  let east = normalizeLongitude(rawEast * unitScale);
+  // For reversed boundaries choose the shorter of the two arcs. This keeps 170° to
+  // -170° on the dateline while interpreting 10° to -10° as the 20° local interval.
+  if (east < west && east + _MathUtils.TWO_PI - west > Math.PI) {
+    [west, east] = [east, west];
+  }
   const latitudeTolerance = 1e-12;
   if (
     south > north ||
@@ -293,14 +297,10 @@ function makeOBBFromNormalizedRegion(
   maxX = projectedPoint.dot(planeXAxis);
   minX = -maxX;
 
-  maxY = ellipsoid.cartographicToCartesian(
-    [0.0, northDeg, fullyBelowEquator ? minimumHeight : maximumHeight],
-    scratchMaxY
-  ).z;
-  minY = ellipsoid.cartographicToCartesian(
-    [0.0, southDeg, fullyAboveEquator ? minimumHeight : maximumHeight],
-    scratchMinY
-  ).z;
+  const northHeight = fullyBelowEquator ? minimumHeight : maximumHeight;
+  const southHeight = fullyAboveEquator ? minimumHeight : maximumHeight;
+  maxY = latitudeZExtent(ellipsoid, northDeg, northHeight, true);
+  minY = latitudeZExtent(ellipsoid, southDeg, southHeight, false);
 
   const farZ = ellipsoid.cartographicToCartesian(
     [eastDeg, latitudeNearestToEquator, maximumHeight],
@@ -330,13 +330,42 @@ function makeOBBFromNormalizedRegion(
 
 function applyTransform(obb: OrientedBoundingBox, transform?: Matrix4): OrientedBoundingBox {
   if (!transform) return obb;
-  obb.center.transformAsPoint(transform);
-  for (let column = 0; column < 3; column++) {
-    const axis = obb.halfAxes.getColumn(column, new Vector3());
-    axis.transformAsVector(transform);
-    obb.halfAxes.setColumn(column, axis);
+  // A general affine transform turns an OBB into a parallelepiped. Refit its eight
+  // corners to an axis-aligned OBB so culling methods that assume orthogonal axes remain safe.
+  const axes = [0, 1, 2].map(column => obb.halfAxes.getColumn(column, new Vector3()));
+  const center = transform.transformAsPoint(obb.center) as number[];
+  const minimum = [Infinity, Infinity, Infinity];
+  const maximum = [-Infinity, -Infinity, -Infinity];
+  for (let mask = 0; mask < 8; mask++) {
+    const corner = new Vector3(center);
+    for (let axis = 0; axis < 3; axis++) {
+      const transformedAxis = transform.transformAsVector(axes[axis]) as number[];
+      corner.add(new Vector3(transformedAxis).scale((mask & (1 << axis)) === 0 ? -1 : 1));
+    }
+    for (let component = 0; component < 3; component++) {
+      minimum[component] = Math.min(minimum[component], corner[component]);
+      maximum[component] = Math.max(maximum[component], corner[component]);
+    }
   }
+  obb.center.copy(minimum).add(maximum).scale(0.5);
+  const halfSize = new Vector3(maximum).subtract(minimum).scale(0.5);
+  obb.halfAxes = new Matrix3().set(halfSize.x, 0, 0, 0, halfSize.y, 0, 0, 0, halfSize.z);
   return obb;
+}
+
+function latitudeZExtent(
+  ellipsoid: Ellipsoid,
+  latitude: number,
+  height: number,
+  maximum: boolean
+): number {
+  let extent = maximum ? -Infinity : Infinity;
+  // A triaxial ellipsoid's fixed-latitude extrema occur at a principal longitude.
+  for (const longitude of [0, 90, 180, 270]) {
+    const z = ellipsoid.cartographicToCartesian([longitude, latitude, height], scratchMaxY).z;
+    extent = maximum ? Math.max(extent, z) : Math.min(extent, z);
+  }
+  return extent;
 }
 
 /** Helper function for makeOBBFromRegion(). */

--- a/modules/geospatial/test/make-obb-from-region.spec.ts
+++ b/modules/geospatial/test/make-obb-from-region.spec.ts
@@ -79,7 +79,11 @@ test('supports degree input, custom ellipsoids and affine transforms', () => {
   const localReversed = makeOBBFromRegion([10, -10, -10, 10, 0, 0], undefined, {
     units: 'degrees'
   });
-  expect(localReversed.halfSize[0]).toBeLessThan(2e6);
+  expect(localReversed.halfSize[0]).toBeGreaterThan(5e6);
+  const fullTurn = makeOBBFromRegion([0, -10, 360, 10, 0, 0], undefined, {
+    units: 'degrees'
+  });
+  expect(fullTurn.halfSize[0]).toBeGreaterThan(5e6);
 
   const ellipsoid = new Ellipsoid(100, 100, 100);
   const customBox = makeOBBFromRegion([0, 0, 0.1, 0.1, 0, 1], ellipsoid);

--- a/modules/geospatial/test/make-obb-from-region.spec.ts
+++ b/modules/geospatial/test/make-obb-from-region.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {test, expect} from 'vitest';
-import {toRadians} from '@math.gl/core';
+import {Matrix4, toRadians} from '@math.gl/core';
 import {OrientedBoundingBox} from '@math.gl/culling';
 import {Ellipsoid, makeOBBFromRegion} from '@math.gl/geospatial';
 
@@ -57,4 +57,52 @@ test('makeOBBFromRegion bounds representative WGS84 regions', () => {
       }
     }
   }
+});
+
+test('supports degree input, custom ellipsoids and affine transforms', () => {
+  const radiansRegion = [
+    toRadians(170),
+    toRadians(-10),
+    toRadians(-170),
+    toRadians(10),
+    0,
+    250
+  ] as const;
+  const degreesRegion = [170, -10, -170, 10, 0, 250] as const;
+  const radiansBox = makeOBBFromRegion(radiansRegion);
+  const degreesBox = makeOBBFromRegion(degreesRegion, undefined, {units: 'degrees'});
+  expect(radiansBox.center).toEqual(degreesBox.center);
+  expect(radiansBox.halfAxes).toEqual(degreesBox.halfAxes);
+  expect(Math.abs(radiansBox.center.x)).toBeGreaterThan(6e6);
+  expect(radiansBox.halfSize[0]).toBeLessThan(2e6);
+
+  const ellipsoid = new Ellipsoid(100, 100, 100);
+  const customBox = makeOBBFromRegion([0, 0, 0.1, 0.1, 0, 1], ellipsoid);
+  expect(customBox.center.every(Number.isFinite)).toBeTruthy();
+  expect(customBox.center.len()).toBeLessThan(101);
+
+  const transform = new Matrix4().translate([10, 20, 30]).scale([2, 3, 4]);
+  const transformed = makeOBBFromRegion([0, 0, 0.1, 0.1, 0, 1], ellipsoid, {transform});
+  const expectedCenter = transform.transformAsPoint(customBox.center);
+  expect(transformed.center).toEqual(expectedCenter);
+  expect(transformed.halfAxes.every(Number.isFinite)).toBeTruthy();
+});
+
+test('keeps polar and degenerate regions finite', () => {
+  const regions = [
+    [0, toRadians(89), toRadians(90), toRadians(89.9), 0, 0],
+    [0, toRadians(89.9), toRadians(180), Math.PI / 2, 0, 1],
+    [1, 0, 1, 0, 5, 5]
+  ];
+  for (const region of regions) {
+    const box = makeOBBFromRegion(region as never);
+    expect(box.center.every(Number.isFinite)).toBeTruthy();
+    expect(box.halfAxes.every(Number.isFinite)).toBeTruthy();
+  }
+});
+
+test('rejects malformed regions', () => {
+  expect(() => makeOBBFromRegion([0, 0, 0, 0, 1, 0] as never)).toThrow(/minimumHeight/);
+  expect(() => makeOBBFromRegion([0, -2, 0, 0, 0, 0] as never)).toThrow(/latitude/);
+  expect(() => makeOBBFromRegion([0, 0, 0, 0, NaN, 0] as never)).toThrow(/six finite/);
 });

--- a/modules/geospatial/test/make-obb-from-region.spec.ts
+++ b/modules/geospatial/test/make-obb-from-region.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {test, expect} from 'vitest';
-import {Matrix4, toRadians} from '@math.gl/core';
+import {Matrix4, Vector3, toRadians} from '@math.gl/core';
 import {OrientedBoundingBox} from '@math.gl/culling';
 import {Ellipsoid, makeOBBFromRegion} from '@math.gl/geospatial';
 
@@ -76,6 +76,11 @@ test('supports degree input, custom ellipsoids and affine transforms', () => {
   expect(Math.abs(radiansBox.center.x)).toBeGreaterThan(6e6);
   expect(radiansBox.halfSize[0]).toBeLessThan(2e6);
 
+  const localReversed = makeOBBFromRegion([10, -10, -10, 10, 0, 0], undefined, {
+    units: 'degrees'
+  });
+  expect(localReversed.halfSize[0]).toBeLessThan(2e6);
+
   const ellipsoid = new Ellipsoid(100, 100, 100);
   const customBox = makeOBBFromRegion([0, 0, 0.1, 0.1, 0, 1], ellipsoid);
   expect(customBox.center.every(Number.isFinite)).toBeTruthy();
@@ -86,6 +91,20 @@ test('supports degree input, custom ellipsoids and affine transforms', () => {
   const expectedCenter = transform.transformAsPoint(customBox.center);
   expect(transformed.center).toEqual(expectedCenter);
   expect(transformed.halfAxes.every(Number.isFinite)).toBeTruthy();
+  expect(
+    new Vector3(transformed.halfAxes.getColumn(0)).dot(
+      new Vector3(transformed.halfAxes.getColumn(1))
+    )
+  ).toBe(0);
+});
+
+test('bounds triaxial ellipsoid latitude extrema', () => {
+  const ellipsoid = new Ellipsoid(1000, 100, 100);
+  const box = makeOBBFromRegion([-120, -30, 120, 40, 0, 0], ellipsoid, {
+    units: 'degrees'
+  });
+  const point = ellipsoid.cartographicToCartesian([90, 40, 0]);
+  expect(box.distanceTo(point)).toBeLessThan(1e-8);
 });
 
 test('keeps polar and degenerate regions finite', () => {


### PR DESCRIPTION
## Summary

Extends the landed makeOBBFromRegion implementation from PR #44 with validation, custom ellipsoids, units, affine transforms, polar/degenerate handling, and comprehensive documentation.

The implementation preserves the directed west/east longitude semantics used by LngLatRectangle and 3D Tiles. Full-turn longitude spans remain distinguishable from zero-width regions.

## Testing

- yarn lint
- tsc -p modules/geospatial/tsconfig.json --noEmit
- full Node suite: 753 passed, 129 skipped
- focused geospatial suite: 5 passed

The repository-wide tsconfig.test.json check currently reports unrelated baseline JSX, CRS path, and index-signature errors; these are documented in the review context.