### PR TITLE
feat(crs): add WKT and PROJ syntax codecs

### DIFF
--- a/docs/modules/crs/README.md
+++ b/docs/modules/crs/README.md
@@ -1,7 +1,7 @@
 # CRS Definitions
 
-`@math.gl/crs` provides lightweight, proj4-independent TypeScript definitions for coordinate
-reference systems. It has no runtime dependencies.
+`@math.gl/crs` provides lightweight, proj4-independent TypeScript definitions and syntax codecs
+for coordinate reference systems. It has no runtime dependencies and is browser-safe.
 
 ## Installation
 
@@ -35,8 +35,8 @@ const projjson: PROJJSONCRS = {
 ```
 
 The string aliases (`CRSIdentifier`, `WKTCRSDefinition`, and `PROJStringDefinition`) document
-intent but are all structurally `string`. This package does not infer or validate a string's
-syntax.
+intent but are all structurally `string`. Call the appropriate parser when syntax needs to be
+inspected or validated.
 
 ## PROJJSON and WKT
 
@@ -44,9 +44,44 @@ syntax.
 project. It is not independently an OGC or ISO standard; it is designed as a lossless JSON encoding
 of OGC WKT2:2019 / ISO 19162:2019 and is referenced by OGC standards.
 
-Strict PROJJSON v0.7 is the canonical semantic object model in `@math.gl/crs`. WKT remains a string
-serialization. Software that semantically parses WKT2 should normalize it to `PROJJSONCRS`. WKT1
-and vendor dialects remain opaque strings because lossless PROJJSON normalization is not guaranteed.
+Strict PROJJSON v0.7 is the canonical semantic object model in `@math.gl/crs`. The WKT and PROJ
+ASTs are syntax models: they preserve ordering, duplicates, number lexemes, delimiter choice, and
+unknown extensions without claiming semantic equivalence or universal PROJJSON conversion.
+
+## WKT syntax
+
+`parseWKTCRS` parses WKT1 and WKT2 serializations, including common GDAL and ESRI extensions, into
+a discriminated `WKTCRSAst`. Parsing is tolerant by default. `validateWKTCRS` can check a WKT1,
+WKT2:2015, or WKT2:2019 profile, and `strict: true` makes parsing reject validation issues.
+
+```ts
+import {encodeWKTCRS, parseWKTCRS, validateWKTCRS} from '@math.gl/crs';
+
+const ast = parseWKTCRS('GEOGCRS["WGS 84",ID["EPSG",4326]]');
+const issues = validateWKTCRS(ast, {profile: 'wkt2:2019'});
+const compact = encodeWKTCRS(ast);
+const pretty = encodeWKTCRS(ast, {format: 'pretty'});
+```
+
+The parser preserves keyword spelling, bracket or parenthesis delimiters, value order, repeated
+elements, unknown nodes, and the source lexeme for each number. `WKTCRSSyntaxError` reports a
+zero-based source offset and one-based line and column.
+
+## PROJ string syntax
+
+`parsePROJString` parses ordinary definitions and pipelines into an ordered `PROJStringAst`.
+Duplicate parameters, flags, quoted values, global pipeline parameters, and `step` separators are
+preserved. `encodePROJString` emits canonical leading `+` signs and normalized whitespace.
+
+```ts
+import {encodePROJString, parsePROJString} from '@math.gl/crs';
+
+const ast = parsePROJString('+proj=pipeline +ellps=GRS80 +step +proj=unitconvert +xy_in=deg');
+const text = encodePROJString(ast);
+```
+
+Shell command-line syntax and PROJ resource or init-file parsing are intentionally outside the
+scope of this codec.
 
 ## API
 
@@ -56,7 +91,12 @@ and vendor dialects remain opaque strings because lossless PROJJSON normalizatio
 - `PROJJSONCRSByType<T>` — the discriminated subset for one or more top-level types.
 - `PROJJSON_SCHEMA_VERSION` — `'0.7'`.
 - `PROJJSON_SCHEMA_URL` — the canonical official schema URL.
+- `WKTCRSAst`, `WKTCRSNode`, `WKTCRSValue` — value-preserving WKT syntax tree types.
+- `parseWKTCRS`, `encodeWKTCRS`, `validateWKTCRS` — WKT syntax codec and profile validation.
+- `PROJStringAst`, `PROJParameter` — ordered PROJ syntax tree types.
+- `parsePROJString`, `encodePROJString` — ordinary definition and pipeline syntax codec.
 
 The official MIT-licensed schema is vendored unchanged and can be imported or resolved through
-`@math.gl/crs/projjson.schema.json`. It is the runtime validation source of truth. The package does
-not add a second Zod schema or a runtime validator API.
+`@math.gl/crs/projjson.schema.json`. It is the PROJJSON runtime validation source of truth. The
+package does not add a second Zod schema. It also does not perform coordinate transformations,
+authority-registry lookup, semantic CRS comparison, or WKT/PROJ-to-PROJJSON conversion.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -75,6 +75,8 @@ Highlights:
 - Uses strict PROJJSON v0.7 as its semantic CRS object model and exports types generated from the official schema.
 - Exposes the vendored official PROJJSON v0.7 schema for runtime validation by applications.
 - Represents authority codes, PROJ strings, and WKT definitions as serialized strings.
+- Adds value-preserving WKT1/WKT2 syntax parsing, profile validation, and compact or pretty encoding.
+- Adds ordered PROJ definition and pipeline syntax parsing and encoding.
 
 **`@math.gl/proj4`**
 

--- a/modules/crs/README.md
+++ b/modules/crs/README.md
@@ -5,9 +5,11 @@ Proj4-independent coordinate reference system definitions shared by math.gl inte
 PROJJSON is an OSGeo/PROJ specification, not an independently published OGC or ISO standard. It
 is designed as a lossless JSON encoding of OGC WKT2:2019 / ISO 19162:2019 and is referenced by OGC
 standards. This package uses strict PROJJSON v0.7 as its semantic CRS object model. Authority codes,
-PROJ strings, WKT2, WKT1, and vendor WKT dialects remain string serializations.
+PROJ strings, WKT2, WKT1, and vendor WKT dialects remain string serializations. WKT and PROJ
+syntax trees preserve the serializations without claiming semantic conversion to PROJJSON.
 
 ```ts
+import {parsePROJString, parseWKTCRS} from '@math.gl/crs';
 import type {CRSDefinition, PROJJSONCRS} from '@math.gl/crs';
 
 const authorityCode: CRSDefinition = 'EPSG:4326';
@@ -24,11 +26,15 @@ const projjson: PROJJSONCRS = {
     }
   }
 };
+
+const wkt = parseWKTCRS('GEOGCRS["WGS 84",ID["EPSG",4326]]');
+const proj = parsePROJString('+proj=longlat +datum=WGS84 +no_defs');
 ```
 
 The official PROJJSON v0.7 JSON Schema is vendored unchanged under its MIT license and exported as
 `@math.gl/crs/projjson.schema.json`. It is the source of truth for the checked-in generated
-TypeScript declarations. This package has no runtime dependencies and does not include a parser,
-converter, runtime validator, or Zod schema.
+TypeScript declarations. This package has no runtime dependencies. Its runtime APIs parse, encode,
+and validate serialization syntax only: they do not perform registry lookup, semantic equivalence,
+coordinate transformation, or general conversion between WKT, PROJ, and PROJJSON.
 
 See the [PROJJSON specification](https://proj.org/en/stable/specifications/projjson.html).

--- a/modules/crs/src/index.ts
+++ b/modules/crs/src/index.ts
@@ -16,3 +16,31 @@ export type {
   PROJStringDefinition,
   WKTCRSDefinition
 } from './crs';
+export type {
+  EncodeWKTCRSOptions,
+  ParseWKTCRSOptions,
+  ValidateWKTCRSOptions,
+  WKTCRSAst,
+  WKTCRSDelimiter,
+  WKTCRSEnumeration,
+  WKTCRSNode,
+  WKTCRSNumber,
+  WKTCRSProfile,
+  WKTCRSString,
+  WKTCRSValidationIssue,
+  WKTCRSValidationIssueCode,
+  WKTCRSValue
+} from './wkt-crs';
+export {
+  encodeWKTCRS,
+  parseWKTCRS,
+  validateWKTCRS,
+  WKTCRSSyntaxError,
+  WKTCRSValidationError
+} from './wkt-crs';
+export type {EncodePROJStringOptions, PROJParameter, PROJStringAst} from './proj-string';
+export {
+  encodePROJString,
+  parsePROJString,
+  PROJStringSyntaxError
+} from './proj-string';

--- a/modules/crs/src/proj-string.ts
+++ b/modules/crs/src/proj-string.ts
@@ -1,0 +1,191 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** One ordered parameter or flag in a PROJ string. */
+export type PROJParameter = {
+  readonly type: 'parameter';
+  readonly name: string;
+  /** Decoded parameter value. Omitted for flags such as `+no_defs`. */
+  readonly value?: string;
+  /** Original value lexeme, including quotes, retained for value-preserving encoding. */
+  readonly rawValue?: string;
+};
+
+/** Syntax tree for one PROJ string. */
+export type PROJStringAst = {
+  readonly type: 'proj-string';
+  readonly parameters: readonly PROJParameter[];
+};
+
+/** Options for encoding a PROJ syntax tree. */
+export type EncodePROJStringOptions = {
+  /** Compact output uses spaces; multiline output emits one parameter per line. */
+  format?: 'compact' | 'multiline';
+};
+
+/** Syntax error containing a source offset and one-based line and column. */
+export class PROJStringSyntaxError extends SyntaxError {
+  readonly offset: number;
+  readonly line: number;
+  readonly column: number;
+
+  /** Create a PROJ string syntax error at a source location. */
+  constructor(message: string, source: string, offset: number) {
+    const location = getSourceLocation(source, offset);
+    super(`${message} at ${location.line}:${location.column}`);
+    this.name = 'PROJStringSyntaxError';
+    this.offset = offset;
+    this.line = location.line;
+    this.column = location.column;
+  }
+}
+
+/** Parse an ordered PROJ definition or pipeline without interpreting parameter semantics. */
+export function parsePROJString(text: string): PROJStringAst {
+  const tokens = tokenizePROJString(text);
+  if (tokens.length === 0) {
+    throw new PROJStringSyntaxError('PROJ string is empty', text, 0);
+  }
+
+  const parameters = tokens.map(token => parseParameter(token.raw, token.offset, text));
+  return {type: 'proj-string', parameters};
+}
+
+/** Encode an ordered PROJ definition using canonical leading plus signs. */
+export function encodePROJString(ast: PROJStringAst, options?: EncodePROJStringOptions): string {
+  if (!ast || ast.type !== 'proj-string' || !Array.isArray(ast.parameters)) {
+    throw new TypeError('encodePROJString expects a PROJStringAst');
+  }
+  const separator = options?.format === 'multiline' ? '\n' : ' ';
+  return ast.parameters
+    .map(parameter => {
+      if (!parameter.name || /[\s+=]/.test(parameter.name)) {
+        throw new TypeError(`Invalid PROJ parameter name: ${parameter.name}`);
+      }
+      if (parameter.rawValue !== undefined) {
+        return `+${parameter.name}=${parameter.rawValue}`;
+      }
+      if (parameter.value !== undefined) {
+        return `+${parameter.name}=${encodeParameterValue(parameter.value)}`;
+      }
+      return `+${parameter.name}`;
+    })
+    .join(separator);
+}
+
+function parseParameter(rawToken: string, offset: number, source: string): PROJParameter {
+  const token = rawToken.startsWith('+') ? rawToken.slice(1) : rawToken;
+  if (!token) {
+    throw new PROJStringSyntaxError("Expected a parameter after '+'", source, offset);
+  }
+  const equalsIndex = token.indexOf('=');
+  const name = equalsIndex < 0 ? token : token.slice(0, equalsIndex);
+  if (!name || /[\s+=]/.test(name)) {
+    throw new PROJStringSyntaxError(`Invalid PROJ parameter name '${name}'`, source, offset);
+  }
+  if (equalsIndex < 0) {
+    return {type: 'parameter', name};
+  }
+
+  const rawValue = token.slice(equalsIndex + 1);
+  const value = decodeParameterValue(rawValue, source, offset + equalsIndex + 1);
+  return {type: 'parameter', name, value, rawValue};
+}
+
+function tokenizePROJString(source: string): {raw: string; offset: number}[] {
+  const tokens: {raw: string; offset: number}[] = [];
+  let offset = 0;
+  while (offset < source.length) {
+    while (offset < source.length && /\s/.test(source[offset])) {
+      offset++;
+    }
+    if (offset >= source.length) {
+      break;
+    }
+    const start = offset;
+    let quote: '"' | "'" | null = null;
+    let escaped = false;
+    while (offset < source.length) {
+      const character = source[offset];
+      if (escaped) {
+        escaped = false;
+        offset++;
+        continue;
+      }
+      if (character === '\\' && quote) {
+        escaped = true;
+        offset++;
+        continue;
+      }
+      if (quote) {
+        if (character === quote) {
+          quote = null;
+        }
+        offset++;
+        continue;
+      }
+      if (character === '"' || character === "'") {
+        quote = character;
+        offset++;
+        continue;
+      }
+      if (/\s/.test(character)) {
+        break;
+      }
+      offset++;
+    }
+    if (quote) {
+      throw new PROJStringSyntaxError('Unterminated quoted PROJ value', source, start);
+    }
+    tokens.push({raw: source.slice(start, offset), offset: start});
+  }
+  return tokens;
+}
+
+function decodeParameterValue(rawValue: string, source: string, offset: number): string {
+  if (!rawValue) {
+    return '';
+  }
+  const first = rawValue[0];
+  if (first !== '"' && first !== "'") {
+    if (rawValue.includes('"') || rawValue.includes("'")) {
+      throw new PROJStringSyntaxError('Quote must begin a PROJ parameter value', source, offset);
+    }
+    return rawValue;
+  }
+  if (rawValue[rawValue.length - 1] !== first) {
+    throw new PROJStringSyntaxError('Unterminated quoted PROJ value', source, offset);
+  }
+  let value = '';
+  for (let index = 1; index < rawValue.length - 1; index++) {
+    const character = rawValue[index];
+    if (character === '\\' && index + 1 < rawValue.length - 1) {
+      value += rawValue[++index];
+    } else {
+      value += character;
+    }
+  }
+  return value;
+}
+
+function encodeParameterValue(value: string): string {
+  if (value && !/\s/.test(value) && !/["']/.test(value)) {
+    return value;
+  }
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function getSourceLocation(source: string, offset: number): {line: number; column: number} {
+  let line = 1;
+  let column = 1;
+  for (let index = 0; index < offset && index < source.length; index++) {
+    if (source[index] === '\n') {
+      line++;
+      column = 1;
+    } else {
+      column++;
+    }
+  }
+  return {line, column};
+}

--- a/modules/crs/src/proj-string.ts
+++ b/modules/crs/src/proj-string.ts
@@ -57,6 +57,9 @@ export function encodePROJString(ast: PROJStringAst, options?: EncodePROJStringO
   if (!ast || ast.type !== 'proj-string' || !Array.isArray(ast.parameters)) {
     throw new TypeError('encodePROJString expects a PROJStringAst');
   }
+  if (ast.parameters.length === 0) {
+    throw new TypeError('encodePROJString expects at least one parameter');
+  }
   const separator = options?.format === 'multiline' ? '\n' : ' ';
   return ast.parameters
     .map(parameter => {
@@ -64,6 +67,7 @@ export function encodePROJString(ast: PROJStringAst, options?: EncodePROJStringO
         throw new TypeError(`Invalid PROJ parameter name: ${parameter.name}`);
       }
       if (parameter.rawValue !== undefined) {
+        validateRawParameterValue(parameter.rawValue);
         return `+${parameter.name}=${parameter.rawValue}`;
       }
       if (parameter.value !== undefined) {
@@ -72,6 +76,40 @@ export function encodePROJString(ast: PROJStringAst, options?: EncodePROJStringO
       return `+${parameter.name}`;
     })
     .join(separator);
+}
+
+function validateRawParameterValue(rawValue: string): void {
+  if (typeof rawValue !== 'string') {
+    throw new TypeError('Invalid PROJ raw parameter value');
+  }
+  if (!rawValue) {
+    return;
+  }
+  const first = rawValue[0];
+  if (first !== '"' && first !== "'") {
+    if (/\s|["']/.test(rawValue)) {
+      throw new TypeError(`Invalid PROJ raw parameter value: ${rawValue}`);
+    }
+    return;
+  }
+  let escaped = false;
+  for (let index = 1; index < rawValue.length; index++) {
+    const character = rawValue[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (character === first && index !== rawValue.length - 1) {
+      throw new TypeError(`Invalid PROJ raw parameter value: ${rawValue}`);
+    }
+  }
+  if (escaped || rawValue[rawValue.length - 1] !== first) {
+    throw new TypeError(`Invalid PROJ raw parameter value: ${rawValue}`);
+  }
 }
 
 function parseParameter(rawToken: string, offset: number, source: string): PROJParameter {

--- a/modules/crs/src/wkt-crs.ts
+++ b/modules/crs/src/wkt-crs.ts
@@ -73,7 +73,8 @@ export type WKTCRSValidationIssueCode =
   | 'invalid-root'
   | 'unknown-keyword'
   | 'mixed-delimiters'
-  | 'empty-node';
+  | 'empty-node'
+  | 'invalid-value';
 
 /** One profile validation issue in a WKT syntax tree. */
 export type WKTCRSValidationIssue = {
@@ -113,15 +114,19 @@ export class WKTCRSValidationError extends Error {
   }
 }
 
-const NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[Ee][+-]?\d+)?/;
+const NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[Ee][+-]?\d+)?$/;
 const KEYWORD_PATTERN = /^[A-Za-z][A-Za-z0-9_]*/;
 
 const WKT1_ROOT_KEYWORDS = new Set([
   'COMPD_CS',
+  'CONCAT_MT',
   'FITTED_CS',
   'GEOCCS',
   'GEOGCS',
+  'INVERSE_MT',
   'LOCAL_CS',
+  'PARAM_MT',
+  'PASSTHROUGH_MT',
   'PROJCS',
   'VERT_CS'
 ]);
@@ -145,33 +150,36 @@ const WKT1_KEYWORDS = new Set([
   'VERT_DATUM'
 ]);
 
-const WKT2_ROOT_KEYWORDS = new Set([
+const WKT2_2015_ROOT_KEYWORDS = new Set([
   'BOUNDCRS',
   'COMPOUNDCRS',
-  'CONCATENATEDOPERATION',
-  'COORDINATEMETADATA',
   'COORDINATEOPERATION',
-  'DERIVEDPROJCRS',
   'ENGCRS',
   'ENGINEERINGCRS',
   'GEODCRS',
   'GEODETICCRS',
-  'GEOGCRS',
-  'GEOGRAPHICCRS',
   'PARAMETRICCRS',
-  'POINTMOTIONOPERATION',
   'PROJCRS',
   'PROJECTEDCRS',
-  'TEMPORALCRS',
   'TIMECRS',
   'VERTCRS',
   'VERTICALCRS'
 ]);
 
+const WKT2_2019_ROOT_KEYWORDS = new Set([
+  ...WKT2_2015_ROOT_KEYWORDS,
+  'CONCATENATEDOPERATION',
+  'COORDINATEMETADATA',
+  'DERIVEDPROJCRS',
+  'GEOGCRS',
+  'GEOGRAPHICCRS',
+  'POINTMOTIONOPERATION'
+]);
+
 // WKT is intentionally represented as a generic syntax tree. This set supports strict profile
 // checking without restricting tolerant parsing of vendor extensions.
 const WKT2_KEYWORDS = new Set([
-  ...WKT2_ROOT_KEYWORDS,
+  ...WKT2_2019_ROOT_KEYWORDS,
   'ABRIDGEDTRANSFORMATION',
   'ANCHOR',
   'ANGLEUNIT',
@@ -218,26 +226,60 @@ const WKT2_KEYWORDS = new Set([
   'PARAMETRICUNIT',
   'PDATUM',
   'PRIMEM',
+  'PRIMEMERIDIAN',
   'REMARK',
   'SCALEUNIT',
   'SCOPE',
   'SOURCECRS',
   'STEP',
   'TARGETCRS',
-  'TCRS',
   'TDATUM',
-  'TEMPORALDATUM',
+  'TEMPORALQUANTITY',
   'TIMEEXTENT',
   'TIMEORIGIN',
   'TIMEUNIT',
+  'TIMEDATUM',
+  'TRIAXIAL',
   'TRF',
   'URI',
   'USAGE',
   'VDATUM',
   'VERSION',
   'VERTICALDATUM',
+  'VERTICALEXTENT',
+  'VELOCITYGRID',
   'VRF'
 ]);
+
+const WKT2_2019_ADDITION_KEYWORDS = new Set([
+  'BASEGEOGCRS',
+  'CALENDAR',
+  'CONCATENATEDOPERATION',
+  'COORDEPOCH',
+  'COORDINATEMETADATA',
+  'DERIVEDPROJCRS',
+  'DYNAMIC',
+  'ENSEMBLE',
+  'ENSEMBLEACCURACY',
+  'EPOCH',
+  'FRAMEEPOCH',
+  'GEOGCRS',
+  'GEOGRAPHICCRS',
+  'GEOIDMODEL',
+  'MEMBER',
+  'MODEL',
+  'POINTMOTIONOPERATION',
+  'STEP',
+  'TEMPORALQUANTITY',
+  'TRF',
+  'TRIAXIAL',
+  'VELOCITYGRID',
+  'VRF'
+]);
+
+const WKT2_2015_KEYWORDS = new Set(
+  [...WKT2_KEYWORDS].filter(keyword => !WKT2_2019_ADDITION_KEYWORDS.has(keyword))
+);
 
 /** Parse WKT1, WKT2, or a compatible vendor WKT serialization. */
 export function parseWKTCRS(text: string, options?: ParseWKTCRSOptions): WKTCRSAst {
@@ -267,6 +309,7 @@ export function encodeWKTCRS(ast: WKTCRSAst, options?: EncodeWKTCRSOptions): str
   if (!Number.isInteger(indent) || indent < 0) {
     throw new RangeError('WKT indentation must be a non-negative integer');
   }
+  validateEncodableNode(ast.root);
   return encodeNode(ast.root, format, indent, 0);
 }
 
@@ -283,9 +326,15 @@ export function validateWKTCRS(
   const rootKeywords =
     profile === 'wkt1' || profile === 'gdal' || profile === 'esri'
       ? WKT1_ROOT_KEYWORDS
-      : WKT2_ROOT_KEYWORDS;
+      : profile === 'wkt2:2015'
+        ? WKT2_2015_ROOT_KEYWORDS
+        : WKT2_2019_ROOT_KEYWORDS;
   const knownKeywords =
-    profile === 'wkt1' || profile === 'gdal' || profile === 'esri' ? WKT1_KEYWORDS : WKT2_KEYWORDS;
+    profile === 'wkt1' || profile === 'gdal' || profile === 'esri'
+      ? WKT1_KEYWORDS
+      : profile === 'wkt2:2015'
+        ? WKT2_2015_KEYWORDS
+        : WKT2_KEYWORDS;
   const issues: WKTCRSValidationIssue[] = [];
   const rootKeyword = ast.root.keyword.toUpperCase();
 
@@ -320,6 +369,15 @@ export function validateWKTCRS(
       issues.push({
         code: 'empty-node',
         message: `${node.node.keyword} must contain at least one value`,
+        path: node.path,
+        keyword: node.node.keyword
+      });
+    }
+    const grammarMessage = validateNodeValues(node.node);
+    if (grammarMessage) {
+      issues.push({
+        code: 'invalid-value',
+        message: grammarMessage,
         path: node.path,
         keyword: node.node.keyword
       });
@@ -401,22 +459,23 @@ class WKTParser {
       return this.parseString();
     }
 
-    const numberMatch = this.source.slice(this.offset).match(NUMBER_PATTERN);
-    if (numberMatch) {
-      const raw = numberMatch[0];
-      this.offset += raw.length;
-      return {type: 'number', value: Number(raw), raw};
+    const start = this.offset;
+    while (this.offset < this.source.length && !/[\s,\[\]()]/.test(this.source[this.offset])) {
+      this.offset++;
     }
-
-    const keywordMatch = this.source.slice(this.offset).match(KEYWORD_PATTERN);
-    if (!keywordMatch) {
+    if (start === this.offset) {
       this.fail('Expected a WKT value');
     }
-    const value = keywordMatch[0];
-    this.offset += value.length;
+    const value = this.source.slice(start, this.offset);
     this.skipWhitespace();
     if (this.source[this.offset] === '[' || this.source[this.offset] === '(') {
+      if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(value)) {
+        this.fail(`Invalid WKT keyword '${value}'`);
+      }
       return this.parseNodeAfterKeyword(value);
+    }
+    if (NUMBER_PATTERN.test(value)) {
+      return {type: 'number', value: Number(value), raw: value};
     }
     return {type: 'enumeration', value};
   }
@@ -503,6 +562,47 @@ function encodeValue(
       return value.raw;
     case 'enumeration':
       return value.value;
+    default:
+      throw new TypeError('Invalid WKT value type');
+  }
+}
+
+function validateEncodableNode(node: WKTCRSNode): void {
+  if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(node.keyword)) {
+    throw new TypeError(`Invalid WKT keyword: ${node.keyword}`);
+  }
+  if (node.delimiter !== 'bracket' && node.delimiter !== 'parenthesis') {
+    throw new TypeError(`Invalid WKT delimiter: ${node.delimiter}`);
+  }
+  if (!Array.isArray(node.values)) {
+    throw new TypeError(`Invalid WKT values for ${node.keyword}`);
+  }
+  for (const value of node.values) {
+    if (!value || typeof value !== 'object') {
+      throw new TypeError(`Invalid WKT value in ${node.keyword}`);
+    }
+    switch (value.type) {
+      case 'node':
+        validateEncodableNode(value);
+        break;
+      case 'string':
+        if (typeof value.value !== 'string') {
+          throw new TypeError(`Invalid WKT string in ${node.keyword}`);
+        }
+        break;
+      case 'number':
+        if (typeof value.raw !== 'string' || !NUMBER_PATTERN.test(value.raw)) {
+          throw new TypeError(`Invalid WKT number lexeme: ${value.raw}`);
+        }
+        break;
+      case 'enumeration':
+        if (typeof value.value !== 'string' || !value.value || /[\s,\[\]()"]/.test(value.value)) {
+          throw new TypeError(`Invalid WKT enumeration: ${value.value}`);
+        }
+        break;
+      default:
+        throw new TypeError(`Invalid WKT value in ${node.keyword}`);
+    }
   }
 }
 
@@ -511,6 +611,153 @@ function resolveProfile(rootKeyword: string, profile: WKTCRSProfile | 'auto'): W
     return profile;
   }
   return WKT1_ROOT_KEYWORDS.has(rootKeyword.toUpperCase()) ? 'wkt1' : 'wkt2:2019';
+}
+
+function validateNodeValues(node: WKTCRSNode): string | null {
+  const keyword = node.keyword.toUpperCase();
+  const values = node.values;
+  const typeAt = (index: number, ...types: WKTCRSValue['type'][]) =>
+    Boolean(values[index] && types.includes(values[index].type));
+  const exact = (length: number, ...types: WKTCRSValue['type'][]) =>
+    values.length === length && types.every((type, index) => typeAt(index, type));
+
+  if (
+    [
+      'ANGLEUNIT',
+      'LENGTHUNIT',
+      'PARAMETRICUNIT',
+      'SCALEUNIT',
+      'TIMEUNIT',
+      'TEMPORALQUANTITY',
+      'UNIT'
+    ].includes(keyword) &&
+    !(values.length >= 2 && typeAt(0, 'string') && typeAt(1, 'number'))
+  ) {
+    return `${node.keyword} must start with a quoted name and numeric conversion factor`;
+  }
+  if (keyword === 'CS' && !exact(2, 'enumeration', 'number')) {
+    return `${node.keyword} must contain a coordinate-system type and dimension`;
+  }
+  if (keyword === 'BBOX' && !exact(4, 'number', 'number', 'number', 'number')) {
+    return `${node.keyword} must contain four numeric bounds`;
+  }
+  if (
+    [
+      'ENSEMBLEACCURACY',
+      'EPOCH',
+      'COORDEPOCH',
+      'FRAMEEPOCH',
+      'OPERATIONACCURACY',
+      'ORDER'
+    ].includes(keyword) &&
+    !exact(1, 'number')
+  ) {
+    return `${node.keyword} must contain one number`;
+  }
+  if (
+    ['ANCHOR', 'AREA', 'CALENDAR', 'CITATION', 'REMARK', 'SCOPE', 'URI', 'VERSION'].includes(
+      keyword
+    ) &&
+    !exact(1, 'string')
+  ) {
+    return `${node.keyword} must contain one quoted string`;
+  }
+  if (
+    ['ELLIPSOID', 'SPHEROID', 'TRIAXIAL'].includes(keyword) &&
+    !(values.length >= 3 && typeAt(0, 'string') && typeAt(1, 'number') && typeAt(2, 'number'))
+  ) {
+    return `${node.keyword} must start with a quoted name and numeric ellipsoid axes`;
+  }
+  if (
+    ['PARAMETER'].includes(keyword) &&
+    !(values.length >= 2 && typeAt(0, 'string') && typeAt(1, 'number'))
+  ) {
+    return `${node.keyword} must start with a quoted name and numeric value`;
+  }
+  if (keyword === 'PARAMETERFILE' && !exact(2, 'string', 'string')) {
+    return `${node.keyword} must contain a quoted name and file name`;
+  }
+  if (
+    ['AUTHORITY', 'ID'].includes(keyword) &&
+    !(values.length >= 2 && typeAt(0, 'string') && typeAt(1, 'string', 'number'))
+  ) {
+    return `${node.keyword} must start with a quoted authority and identifier`;
+  }
+  if (
+    ['AXIS'].includes(keyword) &&
+    !(values.length >= 2 && typeAt(0, 'string') && typeAt(1, 'enumeration'))
+  ) {
+    return `${node.keyword} must start with a quoted name and axis direction`;
+  }
+  if (['METHOD', 'PROJECTION'].includes(keyword) && !(values.length >= 1 && typeAt(0, 'string'))) {
+    return `${node.keyword} must start with a quoted name`;
+  }
+  if (keyword === 'TIMEEXTENT') {
+    const isTemporalValue = (index: number) => typeAt(index, 'enumeration', 'string');
+    if (values.length !== 2 || !isTemporalValue(0) || !isTemporalValue(1)) {
+      return `${node.keyword} must contain two date-time or quoted values`;
+    }
+  }
+  if (keyword === 'VERTICALEXTENT') {
+    if (
+      values.length < 2 ||
+      values.length > 3 ||
+      !typeAt(0, 'number') ||
+      !typeAt(1, 'number') ||
+      (values.length === 3 && !typeAt(2, 'node'))
+    ) {
+      return `${node.keyword} must contain two numeric bounds and an optional unit`;
+    }
+  }
+  if (keyword === 'COORDINATEMETADATA') {
+    if (
+      values.length < 1 ||
+      values.length > 2 ||
+      !typeAt(0, 'node') ||
+      (values.length === 2 &&
+        (!typeAt(1, 'node') ||
+          !['EPOCH', 'COORDEPOCH'].includes((values[1] as WKTCRSNode).keyword.toUpperCase())))
+    ) {
+      return `${node.keyword} must contain a CRS and an optional coordinate epoch`;
+    }
+  }
+  if (keyword === 'BOUNDCRS') {
+    const childKeywords = values
+      .slice(0, 3)
+      .map(value => (value.type === 'node' ? value.keyword.toUpperCase() : ''));
+    if (
+      childKeywords[0] !== 'SOURCECRS' ||
+      childKeywords[1] !== 'TARGETCRS' ||
+      childKeywords[2] !== 'ABRIDGEDTRANSFORMATION'
+    ) {
+      return `${node.keyword} must start with SOURCECRS, TARGETCRS, and ABRIDGEDTRANSFORMATION`;
+    }
+  }
+  if (
+    [
+      'COMPOUNDCRS',
+      'CONCATENATEDOPERATION',
+      'COORDINATEOPERATION',
+      'DERIVEDPROJCRS',
+      'ENGCRS',
+      'ENGINEERINGCRS',
+      'GEODCRS',
+      'GEODETICCRS',
+      'GEOGCRS',
+      'GEOGRAPHICCRS',
+      'PARAMETRICCRS',
+      'POINTMOTIONOPERATION',
+      'PROJCRS',
+      'PROJECTEDCRS',
+      'TIMECRS',
+      'VERTCRS',
+      'VERTICALCRS'
+    ].includes(keyword) &&
+    !typeAt(0, 'string')
+  ) {
+    return `${node.keyword} must start with a quoted name`;
+  }
+  return null;
 }
 
 function visitNode(

--- a/modules/crs/src/wkt-crs.ts
+++ b/modules/crs/src/wkt-crs.ts
@@ -72,7 +72,6 @@ export type ValidateWKTCRSOptions = {
 export type WKTCRSValidationIssueCode =
   | 'invalid-root'
   | 'unknown-keyword'
-  | 'mixed-delimiters'
   | 'empty-node'
   | 'invalid-value';
 
@@ -347,20 +346,12 @@ export function validateWKTCRS(
     });
   }
 
-  visitNode(ast.root, [], ast.root.delimiter, node => {
+  visitNode(ast.root, [], node => {
     const keyword = node.node.keyword.toUpperCase();
     if (!options?.allowExtensions && !knownKeywords.has(keyword)) {
       issues.push({
         code: 'unknown-keyword',
         message: `${node.node.keyword} is not defined by the ${profile} profile`,
-        path: node.path,
-        keyword: node.node.keyword
-      });
-    }
-    if (node.node.delimiter !== ast.root.delimiter) {
-      issues.push({
-        code: 'mixed-delimiters',
-        message: `${node.node.keyword} uses a different delimiter from the WKT root`,
         path: node.path,
         keyword: node.node.keyword
       });
@@ -763,14 +754,13 @@ function validateNodeValues(node: WKTCRSNode): string | null {
 function visitNode(
   node: WKTCRSNode,
   path: number[],
-  rootDelimiter: WKTCRSDelimiter,
-  visitor: (entry: {node: WKTCRSNode; path: number[]; rootDelimiter: WKTCRSDelimiter}) => void
+  visitor: (entry: {node: WKTCRSNode; path: number[]}) => void
 ): void {
-  visitor({node, path, rootDelimiter});
+  visitor({node, path});
   for (let index = 0; index < node.values.length; index++) {
     const value = node.values[index];
     if (value.type === 'node') {
-      visitNode(value, [...path, index], rootDelimiter, visitor);
+      visitNode(value, [...path, index], visitor);
     }
   }
 }

--- a/modules/crs/src/wkt-crs.ts
+++ b/modules/crs/src/wkt-crs.ts
@@ -48,7 +48,7 @@ export type WKTCRSAst = {
 export type ParseWKTCRSOptions = {
   /** Validation profile. `auto` distinguishes WKT1 from WKT2 by root keyword. */
   profile?: WKTCRSProfile | 'auto';
-  /** Validate known keywords and delimiter consistency after parsing. */
+  /** Validate known profile keywords and unambiguous value shapes after parsing. */
   strict?: boolean;
 };
 
@@ -148,6 +148,12 @@ const WKT1_KEYWORDS = new Set([
   'UNIT',
   'VERT_DATUM'
 ]);
+
+const GDAL_WKT1_ROOT_KEYWORDS = new Set(WKT1_ROOT_KEYWORDS);
+const GDAL_WKT1_KEYWORDS = new Set([...WKT1_KEYWORDS, 'EXTENSION']);
+
+const ESRI_WKT1_ROOT_KEYWORDS = new Set([...WKT1_ROOT_KEYWORDS, 'COMPDCS', 'LOCALCS', 'VERTCS']);
+const ESRI_WKT1_KEYWORDS = new Set([...WKT1_KEYWORDS, 'COMPDCS', 'LOCALCS', 'VDATUM', 'VERTCS']);
 
 const WKT2_2015_ROOT_KEYWORDS = new Set([
   'BOUNDCRS',
@@ -280,6 +286,22 @@ const WKT2_2015_KEYWORDS = new Set(
   [...WKT2_KEYWORDS].filter(keyword => !WKT2_2019_ADDITION_KEYWORDS.has(keyword))
 );
 
+const PROFILE_ROOT_KEYWORDS: Record<WKTCRSProfile, ReadonlySet<string>> = {
+  wkt1: WKT1_ROOT_KEYWORDS,
+  gdal: GDAL_WKT1_ROOT_KEYWORDS,
+  esri: ESRI_WKT1_ROOT_KEYWORDS,
+  'wkt2:2015': WKT2_2015_ROOT_KEYWORDS,
+  'wkt2:2019': WKT2_2019_ROOT_KEYWORDS
+};
+
+const PROFILE_KEYWORDS: Record<WKTCRSProfile, ReadonlySet<string>> = {
+  wkt1: WKT1_KEYWORDS,
+  gdal: GDAL_WKT1_KEYWORDS,
+  esri: ESRI_WKT1_KEYWORDS,
+  'wkt2:2015': WKT2_2015_KEYWORDS,
+  'wkt2:2019': WKT2_KEYWORDS
+};
+
 /** Parse WKT1, WKT2, or a compatible vendor WKT serialization. */
 export function parseWKTCRS(text: string, options?: ParseWKTCRSOptions): WKTCRSAst {
   const parser = new WKTParser(text);
@@ -312,7 +334,7 @@ export function encodeWKTCRS(ast: WKTCRSAst, options?: EncodeWKTCRSOptions): str
   return encodeNode(ast.root, format, indent, 0);
 }
 
-/** Validate root keywords, known profile keywords, and delimiter consistency. */
+/** Validate root keywords, known profile keywords, and unambiguous value shapes. */
 export function validateWKTCRS(
   ast: WKTCRSAst,
   options?: ValidateWKTCRSOptions
@@ -322,18 +344,8 @@ export function validateWKTCRS(
   }
 
   const profile = resolveProfile(ast.root.keyword, options?.profile || 'auto');
-  const rootKeywords =
-    profile === 'wkt1' || profile === 'gdal' || profile === 'esri'
-      ? WKT1_ROOT_KEYWORDS
-      : profile === 'wkt2:2015'
-        ? WKT2_2015_ROOT_KEYWORDS
-        : WKT2_2019_ROOT_KEYWORDS;
-  const knownKeywords =
-    profile === 'wkt1' || profile === 'gdal' || profile === 'esri'
-      ? WKT1_KEYWORDS
-      : profile === 'wkt2:2015'
-        ? WKT2_2015_KEYWORDS
-        : WKT2_KEYWORDS;
+  const rootKeywords = PROFILE_ROOT_KEYWORDS[profile];
+  const knownKeywords = PROFILE_KEYWORDS[profile];
   const issues: WKTCRSValidationIssue[] = [];
   const rootKeyword = ast.root.keyword.toUpperCase();
 
@@ -492,11 +504,6 @@ class WKTParser {
           continue;
         }
         return {type: 'string', value};
-      }
-      if (character === '\\' && this.source[this.offset] === '"') {
-        value += '"';
-        this.offset++;
-        continue;
       }
       value += character;
     }

--- a/modules/crs/src/wkt-crs.ts
+++ b/modules/crs/src/wkt-crs.ts
@@ -1,0 +1,543 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** WKT-CRS standards and common compatibility dialects understood by the validator. */
+export type WKTCRSProfile = 'wkt1' | 'wkt2:2015' | 'wkt2:2019' | 'gdal' | 'esri';
+
+/** Delimiter used by a WKT node. */
+export type WKTCRSDelimiter = 'bracket' | 'parenthesis';
+
+/** A quoted WKT string literal. */
+export type WKTCRSString = {
+  readonly type: 'string';
+  readonly value: string;
+};
+
+/** A WKT number with its source lexeme retained to preserve precision. */
+export type WKTCRSNumber = {
+  readonly type: 'number';
+  readonly value: number;
+  readonly raw: string;
+};
+
+/** An unquoted WKT enumeration or identifier. */
+export type WKTCRSEnumeration = {
+  readonly type: 'enumeration';
+  readonly value: string;
+};
+
+/** A keyword and its ordered WKT values. */
+export type WKTCRSNode = {
+  readonly type: 'node';
+  readonly keyword: string;
+  readonly delimiter: WKTCRSDelimiter;
+  readonly values: readonly WKTCRSValue[];
+};
+
+/** Values accepted inside a WKT node. */
+export type WKTCRSValue = WKTCRSNode | WKTCRSString | WKTCRSNumber | WKTCRSEnumeration;
+
+/** Syntax tree for one WKT coordinate reference system or coordinate operation. */
+export type WKTCRSAst = {
+  readonly type: 'wkt-crs';
+  readonly root: WKTCRSNode;
+};
+
+/** Options for parsing WKT coordinate reference systems. */
+export type ParseWKTCRSOptions = {
+  /** Validation profile. `auto` distinguishes WKT1 from WKT2 by root keyword. */
+  profile?: WKTCRSProfile | 'auto';
+  /** Validate known keywords and delimiter consistency after parsing. */
+  strict?: boolean;
+};
+
+/** Options for encoding a WKT syntax tree. */
+export type EncodeWKTCRSOptions = {
+  /** Compact output is the canonical serialization. */
+  format?: 'compact' | 'pretty';
+  /** Number of spaces used for each pretty-print indentation level. */
+  indent?: number;
+};
+
+/** Options for validating a WKT syntax tree. */
+export type ValidateWKTCRSOptions = {
+  /** Validation profile. `auto` distinguishes WKT1 from WKT2 by root keyword. */
+  profile?: WKTCRSProfile | 'auto';
+  /** Permit unrecognized extension keywords. Defaults to `false`. */
+  allowExtensions?: boolean;
+};
+
+/** Stable validation issue codes returned by {@link validateWKTCRS}. */
+export type WKTCRSValidationIssueCode =
+  | 'invalid-root'
+  | 'unknown-keyword'
+  | 'mixed-delimiters'
+  | 'empty-node';
+
+/** One profile validation issue in a WKT syntax tree. */
+export type WKTCRSValidationIssue = {
+  readonly code: WKTCRSValidationIssueCode;
+  readonly message: string;
+  /** Zero-based value indices from the root node to the offending node. */
+  readonly path: readonly number[];
+  readonly keyword: string;
+};
+
+/** Syntax error containing a source offset and one-based line and column. */
+export class WKTCRSSyntaxError extends SyntaxError {
+  readonly offset: number;
+  readonly line: number;
+  readonly column: number;
+
+  /** Create a WKT syntax error at a source location. */
+  constructor(message: string, source: string, offset: number) {
+    const location = getSourceLocation(source, offset);
+    super(`${message} at ${location.line}:${location.column}`);
+    this.name = 'WKTCRSSyntaxError';
+    this.offset = offset;
+    this.line = location.line;
+    this.column = location.column;
+  }
+}
+
+/** Error thrown when strict WKT profile validation fails. */
+export class WKTCRSValidationError extends Error {
+  readonly issues: readonly WKTCRSValidationIssue[];
+
+  /** Create an error from one or more validation issues. */
+  constructor(issues: readonly WKTCRSValidationIssue[]) {
+    super(issues[0]?.message || 'WKT validation failed');
+    this.name = 'WKTCRSValidationError';
+    this.issues = issues;
+  }
+}
+
+const NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[Ee][+-]?\d+)?/;
+const KEYWORD_PATTERN = /^[A-Za-z][A-Za-z0-9_]*/;
+
+const WKT1_ROOT_KEYWORDS = new Set([
+  'COMPD_CS',
+  'FITTED_CS',
+  'GEOCCS',
+  'GEOGCS',
+  'LOCAL_CS',
+  'PROJCS',
+  'VERT_CS'
+]);
+
+const WKT1_KEYWORDS = new Set([
+  ...WKT1_ROOT_KEYWORDS,
+  'AUTHORITY',
+  'AXIS',
+  'CONCAT_MT',
+  'DATUM',
+  'INVERSE_MT',
+  'LOCAL_DATUM',
+  'PARAMETER',
+  'PARAM_MT',
+  'PASSTHROUGH_MT',
+  'PRIMEM',
+  'PROJECTION',
+  'SPHEROID',
+  'TOWGS84',
+  'UNIT',
+  'VERT_DATUM'
+]);
+
+const WKT2_ROOT_KEYWORDS = new Set([
+  'BOUNDCRS',
+  'COMPOUNDCRS',
+  'CONCATENATEDOPERATION',
+  'COORDINATEMETADATA',
+  'COORDINATEOPERATION',
+  'DERIVEDPROJCRS',
+  'ENGCRS',
+  'ENGINEERINGCRS',
+  'GEODCRS',
+  'GEODETICCRS',
+  'GEOGCRS',
+  'GEOGRAPHICCRS',
+  'PARAMETRICCRS',
+  'POINTMOTIONOPERATION',
+  'PROJCRS',
+  'PROJECTEDCRS',
+  'TEMPORALCRS',
+  'TIMECRS',
+  'VERTCRS',
+  'VERTICALCRS'
+]);
+
+// WKT is intentionally represented as a generic syntax tree. This set supports strict profile
+// checking without restricting tolerant parsing of vendor extensions.
+const WKT2_KEYWORDS = new Set([
+  ...WKT2_ROOT_KEYWORDS,
+  'ABRIDGEDTRANSFORMATION',
+  'ANCHOR',
+  'ANGLEUNIT',
+  'AREA',
+  'AXIS',
+  'BASEENGCRS',
+  'BASEGEODCRS',
+  'BASEGEOGCRS',
+  'BASEPARAMCRS',
+  'BASEPROJCRS',
+  'BASETIMECRS',
+  'BASEVERTCRS',
+  'BBOX',
+  'BEARING',
+  'CALENDAR',
+  'CITATION',
+  'CONVERSION',
+  'COORDEPOCH',
+  'CS',
+  'DATUM',
+  'DERIVINGCONVERSION',
+  'DYNAMIC',
+  'EDATUM',
+  'ELLIPSOID',
+  'ENGINEERINGDATUM',
+  'ENSEMBLE',
+  'ENSEMBLEACCURACY',
+  'EPOCH',
+  'FRAMEEPOCH',
+  'GEODETICDATUM',
+  'GEOIDMODEL',
+  'ID',
+  'INTERPOLATIONCRS',
+  'LENGTHUNIT',
+  'MEMBER',
+  'MERIDIAN',
+  'METHOD',
+  'MODEL',
+  'OPERATIONACCURACY',
+  'ORDER',
+  'PARAMETER',
+  'PARAMETERFILE',
+  'PARAMETRICDATUM',
+  'PARAMETRICUNIT',
+  'PDATUM',
+  'PRIMEM',
+  'REMARK',
+  'SCALEUNIT',
+  'SCOPE',
+  'SOURCECRS',
+  'STEP',
+  'TARGETCRS',
+  'TCRS',
+  'TDATUM',
+  'TEMPORALDATUM',
+  'TIMEEXTENT',
+  'TIMEORIGIN',
+  'TIMEUNIT',
+  'TRF',
+  'URI',
+  'USAGE',
+  'VDATUM',
+  'VERSION',
+  'VERTICALDATUM',
+  'VRF'
+]);
+
+/** Parse WKT1, WKT2, or a compatible vendor WKT serialization. */
+export function parseWKTCRS(text: string, options?: ParseWKTCRSOptions): WKTCRSAst {
+  const parser = new WKTParser(text);
+  const ast: WKTCRSAst = {type: 'wkt-crs', root: parser.parse()};
+
+  if (options?.strict) {
+    const issues = validateWKTCRS(ast, {
+      profile: options.profile,
+      allowExtensions: false
+    });
+    if (issues.length > 0) {
+      throw new WKTCRSValidationError(issues);
+    }
+  }
+
+  return ast;
+}
+
+/** Encode a WKT syntax tree without changing value lexemes or keyword spelling. */
+export function encodeWKTCRS(ast: WKTCRSAst, options?: EncodeWKTCRSOptions): string {
+  if (!ast || ast.type !== 'wkt-crs' || ast.root?.type !== 'node') {
+    throw new TypeError('encodeWKTCRS expects a WKTCRSAst');
+  }
+  const format = options?.format || 'compact';
+  const indent = options?.indent ?? 2;
+  if (!Number.isInteger(indent) || indent < 0) {
+    throw new RangeError('WKT indentation must be a non-negative integer');
+  }
+  return encodeNode(ast.root, format, indent, 0);
+}
+
+/** Validate root keywords, known profile keywords, and delimiter consistency. */
+export function validateWKTCRS(
+  ast: WKTCRSAst,
+  options?: ValidateWKTCRSOptions
+): WKTCRSValidationIssue[] {
+  if (!ast || ast.type !== 'wkt-crs' || ast.root?.type !== 'node') {
+    throw new TypeError('validateWKTCRS expects a WKTCRSAst');
+  }
+
+  const profile = resolveProfile(ast.root.keyword, options?.profile || 'auto');
+  const rootKeywords =
+    profile === 'wkt1' || profile === 'gdal' || profile === 'esri'
+      ? WKT1_ROOT_KEYWORDS
+      : WKT2_ROOT_KEYWORDS;
+  const knownKeywords =
+    profile === 'wkt1' || profile === 'gdal' || profile === 'esri' ? WKT1_KEYWORDS : WKT2_KEYWORDS;
+  const issues: WKTCRSValidationIssue[] = [];
+  const rootKeyword = ast.root.keyword.toUpperCase();
+
+  if (!rootKeywords.has(rootKeyword)) {
+    issues.push({
+      code: 'invalid-root',
+      message: `${ast.root.keyword} is not a ${profile} root keyword`,
+      path: [],
+      keyword: ast.root.keyword
+    });
+  }
+
+  visitNode(ast.root, [], ast.root.delimiter, node => {
+    const keyword = node.node.keyword.toUpperCase();
+    if (!options?.allowExtensions && !knownKeywords.has(keyword)) {
+      issues.push({
+        code: 'unknown-keyword',
+        message: `${node.node.keyword} is not defined by the ${profile} profile`,
+        path: node.path,
+        keyword: node.node.keyword
+      });
+    }
+    if (node.node.delimiter !== ast.root.delimiter) {
+      issues.push({
+        code: 'mixed-delimiters',
+        message: `${node.node.keyword} uses a different delimiter from the WKT root`,
+        path: node.path,
+        keyword: node.node.keyword
+      });
+    }
+    if (node.node.values.length === 0) {
+      issues.push({
+        code: 'empty-node',
+        message: `${node.node.keyword} must contain at least one value`,
+        path: node.path,
+        keyword: node.node.keyword
+      });
+    }
+  });
+
+  return issues;
+}
+
+class WKTParser {
+  private readonly source: string;
+  private offset = 0;
+
+  constructor(source: string) {
+    this.source = source;
+  }
+
+  parse(): WKTCRSNode {
+    this.skipWhitespace();
+    const root = this.parseNode();
+    this.skipWhitespace();
+    if (this.offset !== this.source.length) {
+      this.fail('Unexpected content after WKT root');
+    }
+    return root;
+  }
+
+  private parseNode(): WKTCRSNode {
+    const keyword = this.parseKeyword();
+    return this.parseNodeAfterKeyword(keyword);
+  }
+
+  private parseNodeAfterKeyword(keyword: string): WKTCRSNode {
+    this.skipWhitespace();
+    const opening = this.source[this.offset];
+    if (opening !== '[' && opening !== '(') {
+      this.fail(`Expected '[' or '(' after ${keyword}`);
+    }
+    this.offset++;
+    const delimiter: WKTCRSDelimiter = opening === '[' ? 'bracket' : 'parenthesis';
+    const closing = opening === '[' ? ']' : ')';
+    const values: WKTCRSValue[] = [];
+    this.skipWhitespace();
+
+    if (this.source[this.offset] === closing) {
+      this.offset++;
+      return {type: 'node', keyword, delimiter, values};
+    }
+
+    while (this.offset < this.source.length) {
+      values.push(this.parseValue());
+      this.skipWhitespace();
+      const character = this.source[this.offset];
+      if (character === ',') {
+        this.offset++;
+        this.skipWhitespace();
+        if (this.source[this.offset] === closing) {
+          this.fail('Expected a WKT value after comma');
+        }
+        continue;
+      }
+      if (character === closing) {
+        this.offset++;
+        return {type: 'node', keyword, delimiter, values};
+      }
+      if (character === ']' || character === ')') {
+        this.fail(`Expected '${closing}' to close ${keyword}`);
+      }
+      this.fail(`Expected ',' or '${closing}' in ${keyword}`);
+    }
+
+    this.fail(`Unterminated ${keyword} node`);
+  }
+
+  private parseValue(): WKTCRSValue {
+    this.skipWhitespace();
+    const character = this.source[this.offset];
+    if (character === '"') {
+      return this.parseString();
+    }
+
+    const numberMatch = this.source.slice(this.offset).match(NUMBER_PATTERN);
+    if (numberMatch) {
+      const raw = numberMatch[0];
+      this.offset += raw.length;
+      return {type: 'number', value: Number(raw), raw};
+    }
+
+    const keywordMatch = this.source.slice(this.offset).match(KEYWORD_PATTERN);
+    if (!keywordMatch) {
+      this.fail('Expected a WKT value');
+    }
+    const value = keywordMatch[0];
+    this.offset += value.length;
+    this.skipWhitespace();
+    if (this.source[this.offset] === '[' || this.source[this.offset] === '(') {
+      return this.parseNodeAfterKeyword(value);
+    }
+    return {type: 'enumeration', value};
+  }
+
+  private parseKeyword(): string {
+    const match = this.source.slice(this.offset).match(KEYWORD_PATTERN);
+    if (!match) {
+      this.fail('Expected a WKT keyword');
+    }
+    this.offset += match[0].length;
+    return match[0];
+  }
+
+  private parseString(): WKTCRSString {
+    this.offset++;
+    let value = '';
+    while (this.offset < this.source.length) {
+      const character = this.source[this.offset++];
+      if (character === '"') {
+        if (this.source[this.offset] === '"') {
+          value += '"';
+          this.offset++;
+          continue;
+        }
+        return {type: 'string', value};
+      }
+      if (character === '\\' && this.source[this.offset] === '"') {
+        value += '"';
+        this.offset++;
+        continue;
+      }
+      value += character;
+    }
+    this.fail('Unterminated WKT string');
+  }
+
+  private skipWhitespace(): void {
+    while (this.offset < this.source.length && /\s/.test(this.source[this.offset])) {
+      this.offset++;
+    }
+  }
+
+  private fail(message: string): never {
+    throw new WKTCRSSyntaxError(message, this.source, this.offset);
+  }
+}
+
+function encodeNode(
+  node: WKTCRSNode,
+  format: 'compact' | 'pretty',
+  indent: number,
+  depth: number
+): string {
+  const opening = node.delimiter === 'bracket' ? '[' : '(';
+  const closing = node.delimiter === 'bracket' ? ']' : ')';
+  if (node.values.length === 0) {
+    return `${node.keyword}${opening}${closing}`;
+  }
+  if (format === 'compact') {
+    return `${node.keyword}${opening}${node.values
+      .map(value => encodeValue(value, format, indent, depth + 1))
+      .join(',')}${closing}`;
+  }
+  const indentation = ' '.repeat(indent * (depth + 1));
+  const closingIndentation = ' '.repeat(indent * depth);
+  const values = node.values
+    .map(value => `${indentation}${encodeValue(value, format, indent, depth + 1)}`)
+    .join(',\n');
+  return `${node.keyword}${opening}\n${values}\n${closingIndentation}${closing}`;
+}
+
+function encodeValue(
+  value: WKTCRSValue,
+  format: 'compact' | 'pretty',
+  indent: number,
+  depth: number
+): string {
+  switch (value.type) {
+    case 'node':
+      return encodeNode(value, format, indent, depth);
+    case 'string':
+      return `"${value.value.replace(/"/g, '""')}"`;
+    case 'number':
+      return value.raw;
+    case 'enumeration':
+      return value.value;
+  }
+}
+
+function resolveProfile(rootKeyword: string, profile: WKTCRSProfile | 'auto'): WKTCRSProfile {
+  if (profile !== 'auto') {
+    return profile;
+  }
+  return WKT1_ROOT_KEYWORDS.has(rootKeyword.toUpperCase()) ? 'wkt1' : 'wkt2:2019';
+}
+
+function visitNode(
+  node: WKTCRSNode,
+  path: number[],
+  rootDelimiter: WKTCRSDelimiter,
+  visitor: (entry: {node: WKTCRSNode; path: number[]; rootDelimiter: WKTCRSDelimiter}) => void
+): void {
+  visitor({node, path, rootDelimiter});
+  for (let index = 0; index < node.values.length; index++) {
+    const value = node.values[index];
+    if (value.type === 'node') {
+      visitNode(value, [...path, index], rootDelimiter, visitor);
+    }
+  }
+}
+
+function getSourceLocation(source: string, offset: number): {line: number; column: number} {
+  let line = 1;
+  let column = 1;
+  for (let index = 0; index < offset && index < source.length; index++) {
+    if (source[index] === '\n') {
+      line++;
+      column = 1;
+    } else {
+      column++;
+    }
+  }
+  return {line, column};
+}

--- a/modules/crs/test/crs-types.spec.ts
+++ b/modules/crs/test/crs-types.spec.ts
@@ -8,9 +8,11 @@ import {
   invalidCRSType,
   objectDefinitions,
   proj4Definitions,
+  projAst,
   serializedDefinitions,
   unsupportedCompoundCRS,
-  unsupportedVerticalCRS
+  unsupportedVerticalCRS,
+  wktAst
 } from './crs-types';
 
 test('CRS definitions expose the intended compile-time subsets', () => {
@@ -20,4 +22,6 @@ test('CRS definitions expose the intended compile-time subsets', () => {
   expect(invalidCRSType).toBeTruthy();
   expect(unsupportedCompoundCRS).toBeTruthy();
   expect(unsupportedVerticalCRS).toBeTruthy();
+  expect(wktAst.root.keyword).toBe('GEOGCRS');
+  expect(projAst.parameters[0].name).toBe('proj');
 });

--- a/modules/crs/test/crs-types.ts
+++ b/modules/crs/test/crs-types.ts
@@ -2,7 +2,14 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {CRSDefinition, PROJJSONCRS} from '@math.gl/crs';
+import type {
+  CRSDefinition,
+  PROJJSONCRS,
+  PROJParameter,
+  PROJStringAst,
+  WKTCRSAst,
+  WKTCRSNode
+} from '@math.gl/crs';
 import type {Proj4CRSDefinition} from '@math.gl/proj4';
 
 import {
@@ -43,3 +50,14 @@ export const proj4Definitions: Proj4CRSDefinition[] = [
 export const unsupportedCompoundCRS: Proj4CRSDefinition = wgs84Egm2008CompoundCRS;
 // @ts-expect-error proj4js does not transform VerticalCRS objects.
 export const unsupportedVerticalCRS: Proj4CRSDefinition = egm2008VerticalCRS;
+
+const wktRoot: WKTCRSNode = {
+  type: 'node',
+  keyword: 'GEOGCRS',
+  delimiter: 'bracket',
+  values: [{type: 'string', value: 'WGS 84'}]
+};
+export const wktAst: WKTCRSAst = {type: 'wkt-crs', root: wktRoot};
+
+const projParameter: PROJParameter = {type: 'parameter', name: 'proj', value: 'longlat'};
+export const projAst: PROJStringAst = {type: 'proj-string', parameters: [projParameter]};

--- a/modules/crs/test/proj-string.spec.ts
+++ b/modules/crs/test/proj-string.spec.ts
@@ -56,4 +56,13 @@ describe('PROJ string codec', () => {
     expect(error?.line).toBe(2);
     expect(error?.column).toBe(1);
   });
+
+  test('rejects unsafe caller-constructed raw values', () => {
+    expect(() =>
+      encodePROJString({
+        type: 'proj-string',
+        parameters: [{type: 'parameter', name: 'title', value: 'safe', rawValue: 'two tokens'}]
+      })
+    ).toThrow('Invalid PROJ raw parameter value');
+  });
 });

--- a/modules/crs/test/proj-string.spec.ts
+++ b/modules/crs/test/proj-string.spec.ts
@@ -1,0 +1,59 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+
+import {encodePROJString, parsePROJString, PROJStringSyntaxError} from '@math.gl/crs';
+
+describe('PROJ string codec', () => {
+  test('parses definitions, flags, duplicates, and optional plus signs', () => {
+    const ast = parsePROJString('proj=utm +zone=32 +ellps=GRS80 +zone=33 +no_defs');
+    expect(ast.parameters.map(parameter => parameter.name)).toEqual([
+      'proj',
+      'zone',
+      'ellps',
+      'zone',
+      'no_defs'
+    ]);
+    expect(ast.parameters[4].value).toBeUndefined();
+    expect(encodePROJString(ast)).toBe('+proj=utm +zone=32 +ellps=GRS80 +zone=33 +no_defs');
+  });
+
+  test('preserves pipelines and parameter order', () => {
+    const text =
+      '+proj=pipeline +ellps=GRS80 +step +proj=cart +step +inv +proj=helmert +x=10 +step +proj=cart';
+    const ast = parsePROJString(text);
+    expect(ast.parameters.filter(parameter => parameter.name === 'step')).toHaveLength(3);
+    expect(encodePROJString(ast)).toBe(text);
+  });
+
+  test('preserves quoted raw values while exposing decoded values', () => {
+    const text = '+proj=pipeline +title="A local pipeline" +empty="" +step +proj=noop';
+    const ast = parsePROJString(text);
+    expect(ast.parameters[1]).toMatchObject({
+      name: 'title',
+      value: 'A local pipeline',
+      rawValue: '"A local pipeline"'
+    });
+    expect(encodePROJString(ast)).toBe(text);
+  });
+
+  test('supports multiline canonical output', () => {
+    const ast = parsePROJString('+proj=merc +ellps=WGS84');
+    expect(encodePROJString(ast, {format: 'multiline'})).toBe('+proj=merc\n+ellps=WGS84');
+  });
+
+  test('rejects empty and unterminated input with locations', () => {
+    expect(() => parsePROJString('  ')).toThrow(PROJStringSyntaxError);
+    let error: PROJStringSyntaxError | undefined;
+    try {
+      parsePROJString('+proj=pipeline\n+title="unterminated');
+    } catch (caughtError) {
+      error = caughtError as PROJStringSyntaxError;
+    }
+    expect(error).toBeInstanceOf(PROJStringSyntaxError);
+    expect(error?.line).toBe(2);
+    expect(error?.column).toBe(1);
+  });
+});

--- a/modules/crs/test/wkt-crs.spec.ts
+++ b/modules/crs/test/wkt-crs.spec.ts
@@ -61,6 +61,13 @@ describe('WKT-CRS codec', () => {
     expect(validateWKTCRS(ast, {profile: 'gdal', allowExtensions: true})).toEqual([]);
   });
 
+  test('treats a backslash before a closing quote as literal', () => {
+    const text = 'GEOGCRS["C:\\"]';
+    const ast = parseWKTCRS(text);
+    expect(ast.root.values[0]).toEqual({type: 'string', value: 'C:\\'});
+    expect(encodeWKTCRS(ast)).toBe(text);
+  });
+
   test('accepts and preserves independently matched delimiters', () => {
     const text =
       'GEOGCS["WGS 84",DATUM("WGS_1984",SPHEROID("WGS 84",6378137,298.257223563)),PRIMEM("Greenwich",0),UNIT("degree",0.0174532925199433)]';
@@ -89,6 +96,21 @@ describe('WKT-CRS codec', () => {
       validateWKTCRS(parseWKTCRS(pointMotionOperation), {profile: 'wkt2:2015'})
     ).toContainEqual(
       expect.objectContaining({code: 'invalid-root', keyword: 'POINTMOTIONOPERATION'})
+    );
+  });
+
+  test('distinguishes GDAL and ESRI WKT1 extensions', () => {
+    const gdal = 'PROJCS["Web Mercator",EXTENSION["PROJ4","+proj=merc"]]';
+    expect(validateWKTCRS(parseWKTCRS(gdal), {profile: 'gdal'})).toEqual([]);
+    expect(validateWKTCRS(parseWKTCRS(gdal), {profile: 'wkt1'})).toContainEqual(
+      expect.objectContaining({code: 'unknown-keyword', keyword: 'EXTENSION'})
+    );
+
+    const esri =
+      'VERTCS["NAVD_1988",VDATUM["North_American_Vertical_Datum_1988"],PARAMETER["Vertical_Shift",0],UNIT["Meter",1]]';
+    expect(validateWKTCRS(parseWKTCRS(esri), {profile: 'esri'})).toEqual([]);
+    expect(validateWKTCRS(parseWKTCRS(esri), {profile: 'wkt1'})).toContainEqual(
+      expect.objectContaining({code: 'invalid-root', keyword: 'VERTCS'})
     );
   });
 

--- a/modules/crs/test/wkt-crs.spec.ts
+++ b/modules/crs/test/wkt-crs.spec.ts
@@ -61,11 +61,12 @@ describe('WKT-CRS codec', () => {
     expect(validateWKTCRS(ast, {profile: 'gdal', allowExtensions: true})).toEqual([]);
   });
 
-  test('reports mixed delimiters', () => {
-    const ast = parseWKTCRS('GEOGCS["WGS 84",DATUM("WGS_1984")]');
-    expect(validateWKTCRS(ast, {profile: 'wkt1'})).toContainEqual(
-      expect.objectContaining({code: 'mixed-delimiters', keyword: 'DATUM'})
-    );
+  test('accepts and preserves independently matched delimiters', () => {
+    const text =
+      'GEOGCS["WGS 84",DATUM("WGS_1984",SPHEROID("WGS 84",6378137,298.257223563)),PRIMEM("Greenwich",0),UNIT("degree",0.0174532925199433)]';
+    const ast = parseWKTCRS(text);
+    expect(validateWKTCRS(ast, {profile: 'wkt1'})).toEqual([]);
+    expect(encodeWKTCRS(ast)).toBe(text);
   });
 
   test('parses standard unquoted date-time values in temporal extents', () => {

--- a/modules/crs/test/wkt-crs.spec.ts
+++ b/modules/crs/test/wkt-crs.spec.ts
@@ -1,0 +1,105 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+
+import {
+  encodeWKTCRS,
+  parseWKTCRS,
+  validateWKTCRS,
+  WKTCRSSyntaxError,
+  WKTCRSValidationError
+} from '@math.gl/crs';
+
+const WKT1 =
+  'PROJCS["NAD83 / Massachusetts Mainland",GEOGCS["NAD83",DATUM["North_American_Datum_1983",SPHEROID["GRS 1980",6378137,298.257222101]],PRIMEM["Greenwich",0],UNIT["degree",0.01745329251994328]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",42.68333333333333],UNIT["metre",1]]';
+
+const WKT2 = `GEODCRS["WGS 84",
+  DATUM["World Geodetic System 1984",
+    ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],
+  CS[ellipsoidal,2],
+  AXIS["Latitude (lat)",north,ORDER[1]],
+  AXIS["Longitude (lon)",east,ORDER[2]],
+  ANGLEUNIT["degree",1.74532925199433E-2]]`;
+
+const WKT2_DOCUMENTS = [
+  'COORDINATEMETADATA[GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563]],CS[ellipsoidal,2],AXIS["latitude",north],AXIS["longitude",east],ANGLEUNIT["degree",0.0174532925199433]],EPOCH[2021.3]]',
+  'COORDINATEOPERATION["Longitude rotation",SOURCECRS[GEOGCRS["Source",DATUM["Datum",ELLIPSOID["Sphere",6371000,0]],CS[ellipsoidal,2],AXIS["latitude",north],AXIS["longitude",east],ANGLEUNIT["degree",0.0174532925199433]]],TARGETCRS[GEOGCRS["Target",DATUM["Datum",ELLIPSOID["Sphere",6371000,0]],CS[ellipsoidal,2],AXIS["latitude",north],AXIS["longitude",east],ANGLEUNIT["degree",0.0174532925199433]]],METHOD["Longitude rotation"],PARAMETER["Longitude offset",2,ANGLEUNIT["degree",0.0174532925199433]],OPERATIONACCURACY[0.1]]',
+  'CONCATENATEDOPERATION["Two steps",SOURCECRS[GEOGCRS["A",DATUM["A",ELLIPSOID["Sphere",6371000,0]],CS[ellipsoidal,2],AXIS["lat",north],AXIS["lon",east],ANGLEUNIT["degree",0.0174532925199433]]],TARGETCRS[GEOGCRS["B",DATUM["B",ELLIPSOID["Sphere",6371000,0]],CS[ellipsoidal,2],AXIS["lat",north],AXIS["lon",east],ANGLEUNIT["degree",0.0174532925199433]]],STEP[COORDINATEOPERATION["First",SOURCECRS[GEOGCRS["A"]],TARGETCRS[GEOGCRS["B"]],METHOD["noop"]]],STEP[COORDINATEOPERATION["Second",SOURCECRS[GEOGCRS["B"]],TARGETCRS[GEOGCRS["C"]],METHOD["noop"]]]]',
+  'BOUNDCRS[SOURCECRS[GEOGCRS["NAD83",DATUM["North American Datum 1983",ELLIPSOID["GRS 1980",6378137,298.257222101]],CS[ellipsoidal,2],AXIS["latitude",north],AXIS["longitude",east],ANGLEUNIT["degree",0.0174532925199433]]],TARGETCRS[GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563]],CS[ellipsoidal,2],AXIS["latitude",north],AXIS["longitude",east],ANGLEUNIT["degree",0.0174532925199433]]],ABRIDGEDTRANSFORMATION["NAD83 to WGS 84",METHOD["Geocentric translations"],PARAMETER["X-axis translation",0,LENGTHUNIT["metre",1]]]]'
+];
+
+describe('WKT-CRS codec', () => {
+  test('round trips WKT1 with exact number lexemes', () => {
+    const ast = parseWKTCRS(WKT1, {profile: 'wkt1', strict: true});
+    expect(ast.root.keyword).toBe('PROJCS');
+    expect(ast.root.values[1]).toMatchObject({type: 'node', keyword: 'GEOGCS'});
+    expect(encodeWKTCRS(ast)).toBe(WKT1);
+  });
+
+  test('round trips WKT2 with canonical whitespace and scientific notation', () => {
+    const ast = parseWKTCRS(WKT2, {profile: 'wkt2:2019', strict: true});
+    const encoded = encodeWKTCRS(ast);
+    expect(encoded).toContain('1.74532925199433E-2');
+    expect(encoded).not.toContain('\n');
+    expect(encodeWKTCRS(parseWKTCRS(encoded))).toBe(encoded);
+  });
+
+  test.each(WKT2_DOCUMENTS)('round trips WKT2 root forms', text => {
+    const ast = parseWKTCRS(text, {profile: 'wkt2:2019', strict: true});
+    expect(encodeWKTCRS(ast)).toBe(text);
+  });
+
+  test('preserves alternate delimiters, escaped strings, and vendor nodes', () => {
+    const text = 'GEOGCS("A ""quoted"" name",VENDOR_NODE("é",custom),UNIT("degree",1.0))';
+    const ast = parseWKTCRS(text);
+    expect(encodeWKTCRS(ast)).toBe(text);
+    expect(validateWKTCRS(ast, {profile: 'gdal'})).toContainEqual(
+      expect.objectContaining({code: 'unknown-keyword', keyword: 'VENDOR_NODE'})
+    );
+    expect(validateWKTCRS(ast, {profile: 'gdal', allowExtensions: true})).toEqual([]);
+  });
+
+  test('reports mixed delimiters', () => {
+    const ast = parseWKTCRS('GEOGCS["WGS 84",DATUM("WGS_1984")]');
+    expect(validateWKTCRS(ast, {profile: 'wkt1'})).toContainEqual(
+      expect.objectContaining({code: 'mixed-delimiters', keyword: 'DATUM'})
+    );
+  });
+
+  test('strict mode rejects profile violations', () => {
+    expect(() =>
+      parseWKTCRS('GEOGCS["WGS 84",VENDOR[1]]', {profile: 'wkt1', strict: true})
+    ).toThrow(WKTCRSValidationError);
+  });
+
+  test('reports precise syntax locations', () => {
+    let error: WKTCRSSyntaxError | undefined;
+    try {
+      parseWKTCRS('GEOGCRS["WGS 84",\n  DATUM["WGS 84"]');
+    } catch (caughtError) {
+      error = caughtError as WKTCRSSyntaxError;
+    }
+    expect(error).toBeInstanceOf(WKTCRSSyntaxError);
+    expect(error?.line).toBe(2);
+    expect(error?.column).toBeGreaterThan(1);
+  });
+
+  test('pretty prints a parseable document', () => {
+    const pretty = encodeWKTCRS(parseWKTCRS(WKT1), {format: 'pretty', indent: 2});
+    expect(pretty).toContain('\n');
+    expect(encodeWKTCRS(parseWKTCRS(pretty))).toBe(WKT1);
+  });
+
+  test.each([
+    '',
+    'GEOGCRS',
+    'GEOGCRS["WGS 84",]',
+    'GEOGCRS["unterminated]',
+    'GEOGCRS[DATUM["WGS 84"] extra]',
+    'GEOGCRS[DATUM["WGS 84"]])'
+  ])('rejects malformed input %#', text => {
+    expect(() => parseWKTCRS(text)).toThrow(WKTCRSSyntaxError);
+  });
+});

--- a/modules/crs/test/wkt-crs.spec.ts
+++ b/modules/crs/test/wkt-crs.spec.ts
@@ -68,6 +68,36 @@ describe('WKT-CRS codec', () => {
     );
   });
 
+  test('parses standard unquoted date-time values in temporal extents', () => {
+    const text =
+      'TIMECRS["Calendar time",TDATUM["Gregorian",TIMEORIGIN["0000-01-01"]],CS[temporalDateTime,1],AXIS["time (T)",future],TIMEUNIT["day",86400],USAGE[SCOPE["History"],TIMEEXTENT[2013-01-01,2014-07-12T17:00+01]]]';
+    const ast = parseWKTCRS(text, {profile: 'wkt2:2019', strict: true});
+    expect(encodeWKTCRS(ast)).toBe(text);
+  });
+
+  test('distinguishes WKT2:2015 from WKT2:2019 additions', () => {
+    const text = 'COORDINATEMETADATA[GEOGCRS["WGS 84"],EPOCH[2021.3]]';
+    expect(validateWKTCRS(parseWKTCRS(text), {profile: 'wkt2:2015'})).toContainEqual(
+      expect.objectContaining({code: 'invalid-root', keyword: 'COORDINATEMETADATA'})
+    );
+    expect(validateWKTCRS(parseWKTCRS(text), {profile: 'wkt2:2019'})).toEqual([]);
+
+    const pointMotionOperation =
+      'POINTMOTIONOPERATION["Velocity model",SOURCECRS[GEODCRS["Source"]],METHOD["Velocity grid"]]';
+    expect(
+      validateWKTCRS(parseWKTCRS(pointMotionOperation), {profile: 'wkt2:2015'})
+    ).toContainEqual(
+      expect.objectContaining({code: 'invalid-root', keyword: 'POINTMOTIONOPERATION'})
+    );
+  });
+
+  test('validates unambiguous standard value shapes', () => {
+    const ast = parseWKTCRS('GEOGCRS["WGS 84",CS[ellipsoidal,"two"]]');
+    expect(validateWKTCRS(ast, {profile: 'wkt2:2019'})).toContainEqual(
+      expect.objectContaining({code: 'invalid-value', keyword: 'CS'})
+    );
+  });
+
   test('strict mode rejects profile violations', () => {
     expect(() =>
       parseWKTCRS('GEOGCS["WGS 84",VENDOR[1]]', {profile: 'wkt1', strict: true})
@@ -90,6 +120,13 @@ describe('WKT-CRS codec', () => {
     const pretty = encodeWKTCRS(parseWKTCRS(WKT1), {format: 'pretty', indent: 2});
     expect(pretty).toContain('\n');
     expect(encodeWKTCRS(parseWKTCRS(pretty))).toBe(WKT1);
+  });
+
+  test('rejects unsafe caller-constructed AST lexemes', () => {
+    const ast = parseWKTCRS('GEOGCRS["WGS 84",ID["EPSG",4326]]');
+    const id = ast.root.values[1] as any;
+    id.values[1] = {type: 'number', value: 4326, raw: '4326]'};
+    expect(() => encodeWKTCRS(ast)).toThrow('Invalid WKT number lexeme');
   });
 
   test.each([


### PR DESCRIPTION
## Goals

- Complete the dependency-free `@math.gl/crs` serialization foundation.
- Preserve WKT and PROJ syntax without claiming semantic conversion to PROJJSON.
- Provide browser-safe shared codecs for loaders.gl, deck.gl, and other vis.gl projects.

## Changes

- Adds discriminated WKT AST types plus tolerant parsing, compact/pretty encoding, profile validation, and precise syntax errors.
- Covers WKT1, WKT2:2015/2019, coordinate metadata, operations, concatenated operations, bound CRS, common vendor extensions, alternate delimiters, escaped Unicode strings, and exact number lexemes.
- Adds ordered PROJ AST types plus parsing/encoding for definitions, flags, duplicate parameters, quoted values, and pipelines.
- Exports compile-time API examples and expands Node/browser round-trip and malformed-input tests.
- Documents the syntax-only boundary: no registry lookup, semantic equivalence, transformation execution, or general WKT/PROJ-to-PROJJSON conversion.

## Validation

- `yarn build`
- `yarn check:crs-types`
- `yarn check:projjson-types`
- `yarn test-node`
- `yarn test-headless`
- `yarn lint fix`
- `yarn build` in `website/`