### PR TITLE
fix(crs): reject malformed quoted values

### DIFF
--- a/modules/crs/src/proj-string.ts
+++ b/modules/crs/src/proj-string.ts
@@ -92,7 +92,11 @@ function validateRawParameterValue(rawValue: string): void {
     }
     return;
   }
+  if (rawValue.length < 2) {
+    throw new TypeError(`Invalid PROJ raw parameter value: ${rawValue}`);
+  }
   let escaped = false;
+  let closingQuoteFound = false;
   for (let index = 1; index < rawValue.length; index++) {
     const character = rawValue[index];
     if (escaped) {
@@ -106,8 +110,11 @@ function validateRawParameterValue(rawValue: string): void {
     if (character === first && index !== rawValue.length - 1) {
       throw new TypeError(`Invalid PROJ raw parameter value: ${rawValue}`);
     }
+    if (character === first) {
+      closingQuoteFound = true;
+    }
   }
-  if (escaped || rawValue[rawValue.length - 1] !== first) {
+  if (escaped || !closingQuoteFound || rawValue[rawValue.length - 1] !== first) {
     throw new TypeError(`Invalid PROJ raw parameter value: ${rawValue}`);
   }
 }

--- a/modules/crs/src/wkt-crs.ts
+++ b/modules/crs/src/wkt-crs.ts
@@ -463,13 +463,16 @@ class WKTParser {
     }
 
     const start = this.offset;
-    while (this.offset < this.source.length && !/[\s,\[\]()]/.test(this.source[this.offset])) {
+    while (this.offset < this.source.length && !/[\s,\[\]()"]/.test(this.source[this.offset])) {
       this.offset++;
     }
     if (start === this.offset) {
       this.fail('Expected a WKT value');
     }
     const value = this.source.slice(start, this.offset);
+    if (this.source[this.offset] === '"') {
+      this.fail('Unexpected quote in unquoted WKT value');
+    }
     this.skipWhitespace();
     if (this.source[this.offset] === '[' || this.source[this.offset] === '(') {
       if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(value)) {

--- a/modules/crs/test/proj-string.spec.ts
+++ b/modules/crs/test/proj-string.spec.ts
@@ -64,5 +64,17 @@ describe('PROJ string codec', () => {
         parameters: [{type: 'parameter', name: 'title', value: 'safe', rawValue: 'two tokens'}]
       })
     ).toThrow('Invalid PROJ raw parameter value');
+    expect(() =>
+      encodePROJString({
+        type: 'proj-string',
+        parameters: [{type: 'parameter', name: 'title', rawValue: '"'}]
+      })
+    ).toThrow('Invalid PROJ raw parameter value');
+    expect(() =>
+      encodePROJString({
+        type: 'proj-string',
+        parameters: [{type: 'parameter', name: 'title', rawValue: '"' + '\\' + '"'}]
+      })
+    ).toThrow('Invalid PROJ raw parameter value');
   });
 });

--- a/modules/crs/test/wkt-crs.spec.ts
+++ b/modules/crs/test/wkt-crs.spec.ts
@@ -68,6 +68,10 @@ describe('WKT-CRS codec', () => {
     expect(encodeWKTCRS(ast)).toBe(text);
   });
 
+  test('rejects quotes embedded in unquoted values', () => {
+    expect(() => parseWKTCRS('GEOGCRS["x",VENDOR[north"bad]]')).toThrow(WKTCRSSyntaxError);
+  });
+
   test('accepts and preserves independently matched delimiters', () => {
     const text =
       'GEOGCS["WGS 84",DATUM("WGS_1984",SPHEROID("WGS 84",6378137,298.257223563)),PRIMEM("Greenwich",0),UNIT("degree",0.0174532925199433)]';


### PR DESCRIPTION
## Summary

Follow-up fixes for CRS codec review feedback posted after #112 merged.

- Reject quotes embedded in unquoted WKT values so malformed input cannot produce an unencodable AST.
- Reject empty or backslash-escaped closing delimiters in caller-constructed raw PROJ values.
- Add regression coverage for both cases.

Focused CRS codec tests pass: 65 passed, 2 skipped.
