### PR TITLE
feat(proj4): add CRS compatibility utilities

### DIFF
--- a/docs/modules/proj4/README.md
+++ b/docs/modules/proj4/README.md
@@ -38,6 +38,38 @@ PROJJSON is an OSGeo/PROJ specification designed as a lossless JSON encoding of 
 
 Within WKT there exists both OGC WKT and ESRI WKT syntax; both are generally supported though some more-obscure projection keywords may not be used. WKT definitions remain strings at this API boundary. Note that PROJ strings [can be slightly more accurate](https://github.com/proj4js/proj4js/issues/222) in some circumstances than WKT strings.
 
+### Checking CRS compatibility
+
+Use `checkProj4CRSCompatibility` when CRS metadata may be broader than proj4js's executable CRS
+model. The result distinguishes a definition that proj4js constructed successfully from one that is
+unsupported or has not been checked. Metadata resolution or preservation does not imply that
+coordinates have been transformed.
+
+```js
+import {checkProj4CRSCompatibility, toProj4CRSDefinition} from '@math.gl/proj4';
+
+const compatibility = checkProj4CRSCompatibility(crs);
+if (compatibility.status === 'supported') {
+  const proj4CRS = toProj4CRSDefinition(crs);
+  // Constructing a Proj4Projection and calling project/unproject are separate steps.
+}
+```
+
+Serialized WKT and PROJ strings are probed by default without transforming coordinates. Applications
+can use `{serialized: 'unknown'}` when they do not want to probe, or `{serialized: 'accept'}` when
+they intentionally defer validation to `Proj4Projection` construction. Unsupported PROJJSON object
+types are reported with a reason such as `unsupported-crs-type`.
+
+`toProj4CRSDefinition` is strict by default and never drops CRS components. An application that
+intentionally needs only the horizontal part of a `CompoundCRS` can opt into the lossy behavior:
+
+```js
+const horizontalCRS = toProj4CRSDefinition(compoundCRS, {mode: 'horizontal'});
+```
+
+Horizontal extraction rejects compounds with no horizontal CRS or more than one eligible horizontal
+CRS. It does not transform, convert, or preserve the discarded vertical or temporal coordinates.
+
 There are thousands of named "EPSG" projections. This module only includes aliases for those in the section below by default. To use a different EPSG projection, you can use https://epsg.io. For example, https://epsg.io/4326 defines standard longitude-latitude coordinates and lists multiple projection definitions. Choose an `OGC WKT`, `ESRI WKT`, `PROJ.4`, or `PROJJSON` definition.
 
 The epsg.io website also has a public API, e.g., for WGS 84: `https://epsg.io/?q=4326&format=json`

--- a/docs/modules/proj4/api-reference/proj4-projection.md
+++ b/docs/modules/proj4/api-reference/proj4-projection.md
@@ -66,6 +66,27 @@ Defines projection aliases from authority codes, PROJ strings, WKT strings, or P
 
 Registers an NTv2 datum grid that projection definitions can reference with `+nadgrids=<name>`. Set `options.includeErrorFields` to `false` when the grid does not contain latitude and longitude error columns.
 
+## CRS compatibility utilities
+
+### `checkProj4CRSCompatibility(definition, options?)`
+
+Checks whether a broad `CRSDefinition` can be constructed by proj4js. It returns a structured result
+with `status` set to `supported`, `unsupported`, or `unknown`, along with `checked`, `lossy`, an
+optional CRS `type`, and a stable `reason` code.
+
+For serialized WKT and PROJ strings, `options.serialized` can be `probe` (the default), `unknown`,
+or `accept`. Probing constructs a proj4js converter but does not transform any coordinates.
+
+### `toProj4CRSDefinition(definition, options?)`
+
+Narrows a broad CRS definition to `Proj4CRSDefinition`. Supported object definitions are returned
+unchanged, and serialized definitions are passed through unchanged. Unsupported object types throw
+`Proj4CRSCompatibilityError` in the default `strict` mode.
+
+Set `options.mode` to `horizontal` to explicitly extract the single Proj4-compatible horizontal
+component from a `CompoundCRS`. This is lossy and rejects compounds with no or multiple eligible
+horizontal components.
+
 ## Methods
 
 ### `constructor(options: Proj4ProjectionOptions)`

--- a/modules/proj4/src/index.ts
+++ b/modules/proj4/src/index.ts
@@ -4,8 +4,22 @@
 
 export {Proj4Projection} from './lib/proj4-projection';
 export type {
-  Proj4CRSDefinition,
   Proj4DatumGridOptions,
-  Proj4PROJJSONCRS,
   Proj4ProjectionOptions
 } from './lib/proj4-projection';
+export {
+  checkProj4CRSCompatibility,
+  Proj4CRSCompatibilityError,
+  toProj4CRSDefinition
+} from './lib/proj4-crs';
+export type {
+  CheckProj4CRSCompatibilityOptions,
+  Proj4CRSCompatibilityReason,
+  Proj4CRSCompatibilityResult,
+  Proj4CRSCompatibilityStatus,
+  Proj4CRSDefinition,
+  Proj4CRSConversionMode,
+  Proj4PROJJSONCRS,
+  Proj4SerializedCRSCheckMode,
+  ToProj4CRSDefinitionOptions
+} from './lib/proj4-crs';

--- a/modules/proj4/src/lib/proj4-crs.ts
+++ b/modules/proj4/src/lib/proj4-crs.ts
@@ -84,6 +84,13 @@ function isProj4CRSObject(definition: PROJJSONCRS): definition is Proj4PROJJSONC
   return PROJ4_CRS_TYPES.has(definition.type as Proj4PROJJSONCRS['type']);
 }
 
+function isHorizontalProj4CRSObject(definition: PROJJSONCRS): definition is Proj4PROJJSONCRS {
+  if (!isProj4CRSObject(definition)) {
+    return false;
+  }
+  return definition.type !== 'BoundCRS' || isHorizontalProj4CRSObject(definition.source_crs);
+}
+
 function unsupportedResult(
   type: string | undefined,
   reason: Proj4CRSCompatibilityReason,
@@ -104,7 +111,7 @@ function findHorizontalComponent(
   }
 
   const horizontalComponents = definition.components.filter(
-    (component): component is Proj4PROJJSONCRS => isProj4CRSObject(component)
+    (component): component is Proj4PROJJSONCRS => isHorizontalProj4CRSObject(component)
   );
 
   if (horizontalComponents.length === 0) {

--- a/modules/proj4/src/lib/proj4-crs.ts
+++ b/modules/proj4/src/lib/proj4-crs.ts
@@ -1,0 +1,219 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import proj4 from 'proj4';
+import type {CRSDefinition, PROJJSONCRS, PROJJSONCRSByType} from '@math.gl/crs';
+
+/** PROJJSON object variants currently parsed by proj4js 2.20.9. */
+export type Proj4PROJJSONCRS = PROJJSONCRSByType<
+  'GeographicCRS' | 'GeodeticCRS' | 'ProjectedCRS' | 'BoundCRS'
+>;
+
+/** A CRS definition currently accepted by proj4js 2.20.9. */
+export type Proj4CRSDefinition = CRSDefinition<Proj4PROJJSONCRS>;
+
+export type Proj4CRSConversionMode = 'strict' | 'horizontal';
+
+export type Proj4SerializedCRSCheckMode = 'probe' | 'unknown' | 'accept';
+
+export type ToProj4CRSDefinitionOptions = {
+  /** Allow an explicit, lossy extraction of the horizontal component of a CompoundCRS. */
+  mode?: Proj4CRSConversionMode;
+};
+
+export type CheckProj4CRSCompatibilityOptions = {
+  /** Select strict conversion or explicit horizontal extraction for CompoundCRS objects. */
+  mode?: Proj4CRSConversionMode;
+  /** Select how serialized CRS strings are treated. Defaults to a proj4js construction probe. */
+  serialized?: Proj4SerializedCRSCheckMode;
+};
+
+export type Proj4CRSCompatibilityStatus = 'supported' | 'unsupported' | 'unknown';
+
+export type Proj4CRSCompatibilityReason =
+  | 'unsupported-crs-type'
+  | 'missing-horizontal-crs'
+  | 'ambiguous-horizontal-crs'
+  | 'proj4js-parse-error'
+  | 'serialized-definition-not-checked';
+
+export type Proj4CRSCompatibilityResult = {
+  status: Proj4CRSCompatibilityStatus;
+  /** Whether proj4js construction was actually attempted. */
+  checked: boolean;
+  /** True when the selected definition represents only part of the input CRS. */
+  lossy: boolean;
+  /** The top-level PROJJSON type, when the input is an object. */
+  type?: string;
+  reason?: Proj4CRSCompatibilityReason;
+  message?: string;
+};
+
+/** Thrown when a CRS cannot be converted to the requested Proj4 definition mode. */
+export class Proj4CRSCompatibilityError extends Error {
+  readonly compatibility: Proj4CRSCompatibilityResult;
+
+  constructor(compatibility: Proj4CRSCompatibilityResult) {
+    super(compatibility.message || 'CRS is not compatible with proj4js');
+    this.name = 'Proj4CRSCompatibilityError';
+    this.compatibility = compatibility;
+  }
+}
+
+type Proj4Runtime = (from: Proj4CRSDefinition, to: Proj4CRSDefinition) => unknown;
+
+const proj4Runtime = proj4 as unknown as Proj4Runtime;
+
+const PROJ4_CRS_TYPES = new Set<Proj4PROJJSONCRS['type']>([
+  'GeographicCRS',
+  'GeodeticCRS',
+  'ProjectedCRS',
+  'BoundCRS'
+]);
+
+function isCRSObject(definition: CRSDefinition): definition is PROJJSONCRS {
+  return typeof definition === 'object' && definition !== null;
+}
+
+function getCRSType(definition: PROJJSONCRS): string | undefined {
+  return typeof definition.type === 'string' ? definition.type : undefined;
+}
+
+function isProj4CRSObject(definition: PROJJSONCRS): definition is Proj4PROJJSONCRS {
+  return PROJ4_CRS_TYPES.has(definition.type as Proj4PROJJSONCRS['type']);
+}
+
+function unsupportedResult(
+  type: string | undefined,
+  reason: Proj4CRSCompatibilityReason,
+  message: string,
+  lossy = false
+): Proj4CRSCompatibilityResult {
+  return {status: 'unsupported', checked: false, lossy, type, reason, message};
+}
+
+function findHorizontalComponent(
+  definition: PROJJSONCRS
+): {definition: Proj4PROJJSONCRS} | {reason: Proj4CRSCompatibilityReason; message: string} {
+  if (definition.type !== 'CompoundCRS' || !Array.isArray(definition.components)) {
+    return {
+      reason: 'missing-horizontal-crs',
+      message: 'CompoundCRS does not contain a components array'
+    };
+  }
+
+  const horizontalComponents = definition.components.filter(
+    (component): component is Proj4PROJJSONCRS => isProj4CRSObject(component)
+  );
+
+  if (horizontalComponents.length === 0) {
+    return {
+      reason: 'missing-horizontal-crs',
+      message: 'CompoundCRS does not contain a Proj4-compatible horizontal CRS'
+    };
+  }
+  if (horizontalComponents.length > 1) {
+    return {
+      reason: 'ambiguous-horizontal-crs',
+      message: 'CompoundCRS contains more than one Proj4-compatible horizontal CRS'
+    };
+  }
+  return {definition: horizontalComponents[0]};
+}
+
+function getProj4Definition(
+  definition: CRSDefinition,
+  mode: Proj4CRSConversionMode
+): {definition: Proj4CRSDefinition; lossy: boolean; type?: string} {
+  if (!isCRSObject(definition)) {
+    return {definition: definition as Proj4CRSDefinition, lossy: false};
+  }
+
+  if (isProj4CRSObject(definition)) {
+    return {definition, lossy: false, type: getCRSType(definition)};
+  }
+
+  if (mode === 'horizontal' && definition.type === 'CompoundCRS') {
+    const horizontal = findHorizontalComponent(definition);
+    if ('reason' in horizontal) {
+      throw new Proj4CRSCompatibilityError(
+        unsupportedResult(getCRSType(definition), horizontal.reason, horizontal.message, true)
+      );
+    }
+    return {definition: horizontal.definition, lossy: true, type: getCRSType(definition)};
+  }
+
+  const type = getCRSType(definition);
+  throw new Proj4CRSCompatibilityError(
+    unsupportedResult(
+      type,
+      'unsupported-crs-type',
+      type ? `${type} is not supported by proj4js` : 'CRS object has no supported type'
+    )
+  );
+}
+
+function probeProj4Definition(
+  definition: Proj4CRSDefinition,
+  type: string | undefined,
+  lossy: boolean
+): Proj4CRSCompatibilityResult {
+  try {
+    // Constructing the converter parses and initializes the definitions; no coordinates are used.
+    proj4Runtime(definition, 'WGS84');
+    return {status: 'supported', checked: true, lossy, type};
+  } catch (error) {
+    return {
+      status: 'unsupported',
+      checked: true,
+      lossy,
+      type,
+      reason: 'proj4js-parse-error',
+      message: error instanceof Error ? error.message : String(error)
+    };
+  }
+}
+
+/** Convert a broad CRS definition to the Proj4-executable CRS definition type. */
+export function toProj4CRSDefinition(
+  definition: CRSDefinition,
+  options?: ToProj4CRSDefinitionOptions
+): Proj4CRSDefinition {
+  return getProj4Definition(definition, options?.mode || 'strict').definition;
+}
+
+/** Check whether a CRS definition can be constructed and used by proj4js. */
+export function checkProj4CRSCompatibility(
+  definition: CRSDefinition,
+  options?: CheckProj4CRSCompatibilityOptions
+): Proj4CRSCompatibilityResult {
+  const mode = options?.mode || 'strict';
+
+  if (!isCRSObject(definition)) {
+    const serialized = options?.serialized || 'probe';
+    if (serialized === 'unknown') {
+      return {
+        status: 'unknown',
+        checked: false,
+        lossy: false,
+        reason: 'serialized-definition-not-checked',
+        message: 'Serialized CRS definition was not checked with proj4js'
+      };
+    }
+    if (serialized === 'accept') {
+      return {status: 'supported', checked: false, lossy: false};
+    }
+    return probeProj4Definition(definition as Proj4CRSDefinition, undefined, false);
+  }
+
+  try {
+    const converted = getProj4Definition(definition, mode);
+    return probeProj4Definition(converted.definition, converted.type, converted.lossy);
+  } catch (error) {
+    if (error instanceof Proj4CRSCompatibilityError) {
+      return error.compatibility;
+    }
+    throw error;
+  }
+}

--- a/modules/proj4/src/lib/proj4-projection.ts
+++ b/modules/proj4/src/lib/proj4-projection.ts
@@ -3,15 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 import proj4 from 'proj4';
-import type {CRSDefinition, PROJJSONCRSByType} from '@math.gl/crs';
-
-/** PROJJSON object variants currently parsed by proj4js 2.20.9. */
-export type Proj4PROJJSONCRS = PROJJSONCRSByType<
-  'GeographicCRS' | 'GeodeticCRS' | 'ProjectedCRS' | 'BoundCRS'
->;
-
-/** A CRS definition currently accepted by proj4js 2.20.9. */
-export type Proj4CRSDefinition = CRSDefinition<Proj4PROJJSONCRS>;
+import type {Proj4CRSDefinition} from './proj4-crs';
+export type {Proj4CRSDefinition, Proj4PROJJSONCRS} from './proj4-crs';
 
 export type Proj4ProjectionOptions = {
   from?: Proj4CRSDefinition;

--- a/modules/proj4/test/lib/proj4-crs.spec.ts
+++ b/modules/proj4/test/lib/proj4-crs.spec.ts
@@ -60,12 +60,27 @@ test('horizontal extraction rejects missing or ambiguous components', () => {
     type: 'CompoundCRS' as const,
     components: [egm2008VerticalCRS]
   };
+  const verticalBoundCRS = {
+    ...etrs89BoundCRS,
+    source_crs: egm2008VerticalCRS
+  };
+  const verticalBoundCompound = {
+    type: 'CompoundCRS' as const,
+    components: [verticalBoundCRS]
+  };
+  const horizontalAndVerticalBoundCompound = {
+    type: 'CompoundCRS' as const,
+    components: [wgs84GeographicCRS, verticalBoundCRS]
+  };
   const ambiguousCompound = {
     type: 'CompoundCRS' as const,
     components: [wgs84GeographicCRS, utm31NProjectedCRS]
   };
 
   expect(() => toProj4CRSDefinition(verticalOnlyCompound, {mode: 'horizontal'})).toThrow(
+    'does not contain a Proj4-compatible horizontal CRS'
+  );
+  expect(() => toProj4CRSDefinition(verticalBoundCompound, {mode: 'horizontal'})).toThrow(
     'does not contain a Proj4-compatible horizontal CRS'
   );
   expect(() => toProj4CRSDefinition(ambiguousCompound, {mode: 'horizontal'})).toThrow(
@@ -75,6 +90,18 @@ test('horizontal extraction rejects missing or ambiguous components', () => {
   expect(checkProj4CRSCompatibility(verticalOnlyCompound, {mode: 'horizontal'})).toMatchObject({
     status: 'unsupported',
     reason: 'missing-horizontal-crs',
+    lossy: true
+  });
+  expect(checkProj4CRSCompatibility(verticalBoundCompound, {mode: 'horizontal'})).toMatchObject({
+    status: 'unsupported',
+    reason: 'missing-horizontal-crs',
+    lossy: true
+  });
+  expect(
+    checkProj4CRSCompatibility(horizontalAndVerticalBoundCompound, {mode: 'horizontal'})
+  ).toMatchObject({
+    status: 'supported',
+    checked: true,
     lossy: true
   });
   expect(checkProj4CRSCompatibility(ambiguousCompound, {mode: 'horizontal'})).toMatchObject({

--- a/modules/proj4/test/lib/proj4-crs.spec.ts
+++ b/modules/proj4/test/lib/proj4-crs.spec.ts
@@ -1,0 +1,123 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {
+  checkProj4CRSCompatibility,
+  Proj4CRSCompatibilityError,
+  toProj4CRSDefinition
+} from '@math.gl/proj4';
+import {
+  egm2008VerticalCRS,
+  etrs89BoundCRS,
+  utm31NProjectedCRS,
+  wgs84Egm2008CompoundCRS,
+  wgs84GeographicCRS
+} from '@math.gl/crs/test/projjson-fixtures';
+
+const WGS84_WKT2 =
+  'GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563]],PRIMEM["Greenwich",0],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1]],AXIS["geodetic longitude (Lon)",east,ORDER[2]],ANGLEUNIT["degree",0.0174532925199433]]';
+
+test('toProj4CRSDefinition preserves supported definitions', () => {
+  expect(toProj4CRSDefinition(wgs84GeographicCRS)).toBe(wgs84GeographicCRS);
+  expect(toProj4CRSDefinition('EPSG:4326')).toBe('EPSG:4326');
+});
+
+test('toProj4CRSDefinition rejects unsupported CRS objects in strict mode', () => {
+  expect(() => toProj4CRSDefinition(wgs84Egm2008CompoundCRS)).toThrow(Proj4CRSCompatibilityError);
+
+  try {
+    toProj4CRSDefinition(egm2008VerticalCRS);
+  } catch (error) {
+    expect(error).toBeInstanceOf(Proj4CRSCompatibilityError);
+    expect((error as Proj4CRSCompatibilityError).compatibility).toMatchObject({
+      status: 'unsupported',
+      reason: 'unsupported-crs-type',
+      type: 'VerticalCRS',
+      lossy: false
+    });
+  }
+});
+
+test('toProj4CRSDefinition explicitly extracts a compound horizontal CRS', () => {
+  const horizontal = toProj4CRSDefinition(wgs84Egm2008CompoundCRS, {mode: 'horizontal'});
+  expect(horizontal).toBe(wgs84Egm2008CompoundCRS.components[0]);
+
+  const compatibility = checkProj4CRSCompatibility(wgs84Egm2008CompoundCRS, {
+    mode: 'horizontal'
+  });
+  expect(compatibility).toMatchObject({
+    status: 'supported',
+    checked: true,
+    lossy: true,
+    type: 'CompoundCRS'
+  });
+});
+
+test('horizontal extraction rejects missing or ambiguous components', () => {
+  const verticalOnlyCompound = {
+    type: 'CompoundCRS' as const,
+    components: [egm2008VerticalCRS]
+  };
+  const ambiguousCompound = {
+    type: 'CompoundCRS' as const,
+    components: [wgs84GeographicCRS, utm31NProjectedCRS]
+  };
+
+  expect(() => toProj4CRSDefinition(verticalOnlyCompound, {mode: 'horizontal'})).toThrow(
+    'does not contain a Proj4-compatible horizontal CRS'
+  );
+  expect(() => toProj4CRSDefinition(ambiguousCompound, {mode: 'horizontal'})).toThrow(
+    'more than one Proj4-compatible horizontal CRS'
+  );
+
+  expect(checkProj4CRSCompatibility(verticalOnlyCompound, {mode: 'horizontal'})).toMatchObject({
+    status: 'unsupported',
+    reason: 'missing-horizontal-crs',
+    lossy: true
+  });
+  expect(checkProj4CRSCompatibility(ambiguousCompound, {mode: 'horizontal'})).toMatchObject({
+    status: 'unsupported',
+    reason: 'ambiguous-horizontal-crs',
+    lossy: true
+  });
+});
+
+test('checkProj4CRSCompatibility probes supported CRS objects without transforming coordinates', () => {
+  for (const definition of [wgs84GeographicCRS, utm31NProjectedCRS, etrs89BoundCRS]) {
+    expect(checkProj4CRSCompatibility(definition)).toMatchObject({
+      status: 'supported',
+      checked: true,
+      lossy: false
+    });
+  }
+});
+
+test('checkProj4CRSCompatibility supports serialized definition policies', () => {
+  expect(checkProj4CRSCompatibility(WGS84_WKT2)).toMatchObject({
+    status: 'supported',
+    checked: true,
+    lossy: false
+  });
+  expect(checkProj4CRSCompatibility('+proj=longlat +datum=WGS84 +no_defs')).toMatchObject({
+    status: 'supported',
+    checked: true,
+    lossy: false
+  });
+  expect(
+    checkProj4CRSCompatibility('+proj=longlat +datum=WGS84 +no_defs', {serialized: 'unknown'})
+  ).toMatchObject({
+    status: 'unknown',
+    checked: false,
+    reason: 'serialized-definition-not-checked'
+  });
+  expect(
+    checkProj4CRSCompatibility('+proj=longlat +datum=WGS84 +no_defs', {serialized: 'accept'})
+  ).toMatchObject({status: 'supported', checked: false});
+  expect(checkProj4CRSCompatibility('+proj=not-a-projection')).toMatchObject({
+    status: 'unsupported',
+    checked: true,
+    reason: 'proj4js-parse-error'
+  });
+});

--- a/test/types/crs/index.ts
+++ b/test/types/crs/index.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Proj4Projection, type Proj4CRSDefinition} from '@math.gl/proj4';
+import {
+  checkProj4CRSCompatibility,
+  Proj4Projection,
+  toProj4CRSDefinition,
+  type Proj4CRSCompatibilityResult,
+  type Proj4CRSDefinition
+} from '@math.gl/proj4';
 import type {CRSDefinition, PROJJSONCRSByType} from '@math.gl/crs';
 
 const serialized: CRSDefinition = 'EPSG:4326';
@@ -19,5 +25,9 @@ const geographic: PROJJSONCRSByType<'GeographicCRS'> = {
   }
 };
 const definition: Proj4CRSDefinition = geographic;
+const convertedDefinition: Proj4CRSDefinition = toProj4CRSDefinition(geographic);
+const compatibility: Proj4CRSCompatibilityResult = checkProj4CRSCompatibility(geographic);
 
 new Proj4Projection({from: definition, to: serialized});
+void convertedDefinition;
+void compatibility;


### PR DESCRIPTION
## Summary

- Add toProj4CRSDefinition and checkProj4CRSCompatibility.
- Preserve the broad @math.gl/crs model while exposing Proj4's executable boundary.
- Support strict conversion and explicit horizontal extraction for compound CRS.
- Add structured compatibility diagnostics and serialized-definition probing.
- Document that metadata resolution does not imply coordinate transformation.

## Validation

- yarn lint
- yarn build
- yarn check:crs-types
- yarn test-node modules/proj4/test/lib/proj4-crs.spec.ts
