### PR TITLE
Use lowercase string literals for public API constants

### DIFF
--- a/docs/modules/core/api-reference/euler.md
+++ b/docs/modules/core/api-reference/euler.md
@@ -14,16 +14,18 @@ import {Euler} from '@math.gl/core';
 
 ## Constants
 
-- `Euler.ZYX`
-- `Euler.YXZ`
-- `Euler.XZY`
-- `Euler.ZXY`
-- `Euler.YZX`
-- `Euler.XYZ`
-- `Euler.RollPitchYaw`
+- `Euler.ZYX` = `'zyx'`
+- `Euler.YXZ` = `'yxz'`
+- `Euler.XZY` = `'xzy'`
+- `Euler.ZXY` = `'zxy'`
+- `Euler.YZX` = `'yzx'`
+- `Euler.XYZ` = `'xyz'`
+- `Euler.RollPitchYaw` = `'zyx'`
 
 - `Euler.DefaultOrder` (= `Euler.ZYX`)
-- `Euler.RotationOrders` = `['ZYX', 'YXZ', 'XZY', 'ZXY', 'YZX', 'XYZ']`;
+- `Euler.RotationOrders` provides the same named string values.
+
+These compatibility constants are deprecated. New code should pass an `EulerRotationOrder` string such as `'zyx'` directly.
 
 ## Members
 
@@ -51,9 +53,9 @@ rotation order in all notations
 
 ### constructor
 
-(x = 0, y = 0, z = 0, order = Euler.DefaultOrder)
+(x = 0, y = 0, z = 0, order = 'zyx')
 
-- Number|Number[], Number, Number, Number
+- Number|Number[], Number, Number, EulerRotationOrder
 
 ### fromRollPitchYaw
 
@@ -63,7 +65,7 @@ Common ZYX rotation order
 
 ### fromRotationMatrix
 
-`euler.fromRotationMatrix(m, order = Euler.DefaultOrder)`
+`euler.fromRotationMatrix(m, order = 'zyx')`
 
 ### fromQuaternion
 

--- a/docs/modules/culling/api-reference/axis-aligned-bounding-box.md
+++ b/docs/modules/culling/api-reference/axis-aligned-bounding-box.md
@@ -89,9 +89,9 @@ Determines which side of a plane the axis-aligned bounding box is located.
 
 Returns
 
-- `INTERSECTION.INSIDE` if the entire box is on the side of the plane the normal is pointing
-- `INTERSECTION.OUTSIDE` if the entire box is on the opposite side, and
-- `INTERSECTION.INTERSECTING` if the box intersects the plane.
+- `'inside'` if the entire box is on the side of the plane the normal is pointing
+- `'outside'` if the entire box is on the opposite side, and
+- `'intersecting'` if the box intersects the plane.
 
 ### `distanceTo(point : Number[3]) : Number`
 

--- a/docs/modules/culling/api-reference/bounding-sphere.md
+++ b/docs/modules/culling/api-reference/bounding-sphere.md
@@ -123,9 +123,9 @@ Determines which side of a plane a sphere is located.
 
 - `plane` The plane to test against.
   Returns
-- `INTERSECTION.INSIDE` if the entire sphere is on the side of the plane the normal is pointing
-- `INTERSECTION.OUTSIDE` if the entire sphere is on the opposite side
-- `INTERSECTION.INTERSECTING` if the sphere intersects the plane.
+- `'inside'` if the entire sphere is on the side of the plane the normal is pointing
+- `'outside'` if the entire sphere is on the opposite side
+- `'intersecting'` if the sphere intersects the plane.
 
 ### `transform(transform : Number[16]) : BoundingSphere`
 

--- a/docs/modules/culling/api-reference/bounding-volume.md
+++ b/docs/modules/culling/api-reference/bounding-volume.md
@@ -12,9 +12,9 @@ Determines which side of a plane a sphere is located.
 
 - `plane` The plane to test against.
   Returns
-- `INTERSECTION.INSIDE` if the entire sphere is on the side of the plane the normal is pointing
-- `INTERSECTION.OUTSIDE` if the entire sphere is on the opposite side
-- `INTERSECTION.INTERSECTING` if the sphere intersects the plane.
+- `'inside'` if the entire sphere is on the side of the plane the normal is pointing
+- `'outside'` if the entire sphere is on the opposite side
+- `'intersecting'` if the sphere intersects the plane.
 
 ### transform(transform : Number[16]) : BoundingSphere
 

--- a/docs/modules/culling/api-reference/culling-volume.md
+++ b/docs/modules/culling/api-reference/culling-volume.md
@@ -30,7 +30,7 @@ Constructs a culling volume from a bounding sphere. Creates six planes that crea
 
 - `boundingSphere` The bounding sphere used to create the culling volume.
 
-### computeVisibility(boundingVolume : Object) : Interset
+### computeVisibility(boundingVolume : Object) : CullingResult
 
 Determines whether a bounding volume intersects the culling volume.
 
@@ -38,7 +38,9 @@ Determines whether a bounding volume intersects the culling volume.
 
 Returns
 
-- `INTERSECTION.OUTSIDE`, `INTERSECTION.INTERSECTING`, or `INTERSECTION.INSIDE`.
+- `'outside'`, `'intersecting'`, or `'inside'`.
+
+`INTERSECTION.OUTSIDE`, `INTERSECTION.INTERSECTING`, and `INTERSECTION.INSIDE` remain as deprecated string-valued compatibility constants.
 
 ### computeVisibilityWithPlaneMask(boundingVolume : Object, parentPlaneMask : Number) : Number
 

--- a/docs/modules/culling/api-reference/oriented-bounding-box.md
+++ b/docs/modules/culling/api-reference/oriented-bounding-box.md
@@ -111,9 +111,9 @@ Determines which side of a plane the oriented bounding box is located.
 
 Returns
 
-- `INTERSECTION.INSIDE` if the entire box is on the side of the plane the normal is pointing
-- `INTERSECTION.OUTSIDE` if the entire box is on the opposite side, and
-- `INTERSECTION.INTERSECTING` if the box intersects the plane.
+- `'inside'` if the entire box is on the side of the plane the normal is pointing
+- `'outside'` if the entire box is on the opposite side, and
+- `'intersecting'` if the box intersects the plane.
 
 ### `distanceTo(point : Number[3]) : Number`
 

--- a/docs/modules/polygon/api-reference/polygon-utils.md
+++ b/docs/modules/polygon/api-reference/polygon-utils.md
@@ -10,6 +10,12 @@ import {getPolygonWindingDirection} from '@math.gl/polygon';
 
 ## Types
 
+### WindingDirection
+
+`'clockwise' | 'counter-clockwise' | 'none'`
+
+`WINDING.CLOCKWISE`, `WINDING.COUNTER_CLOCKWISE`, and `WINDING.NONE` remain as deprecated string-valued compatibility constants.
+
 ### PolygonParams
 
 `PolygonParams`
@@ -33,7 +39,7 @@ Checks winding direction of the polygon and reverses the polygon in case if oppo
 Arguments:
 
 - `points` (Array|TypedArray) - a flat array of the points that define the polygon.
-- `direction` (Number) - Requested winding direction. A positive 1 for clockwise, -1 for counter clockwise.
+- `direction` (`'clockwise' | 'counter-clockwise'`) - Requested winding direction.
 - `options` (PolygonParams) - Polygon parameters.
 
 Returns:
@@ -68,8 +74,7 @@ Arguments:
 
 Returns:
 
-- A positive number is clockwise.
-- A negative number is counter clockwise.
+- `'clockwise'`, `'counter-clockwise'`, or `'none'` for a degenerate polygon.
 
 ### forEachSegmentInPolygon
 
@@ -92,7 +97,7 @@ Checks winding direction of the polygon and reverses the polygon in case if oppo
 Arguments:
 
 - `points` (Array[]|TypedArray[]) - an array of the points that define the polygon.
-- `direction` (Number) - Requested winding direction. A positive 1 for clockwise, -1 for counter clockwise.
+- `direction` (`'clockwise' | 'counter-clockwise'`) - Requested winding direction.
 - `options` (PolygonParams) - Polygon parameters.
 
 Returns:
@@ -127,8 +132,7 @@ Arguments:
 
 Returns:
 
-- A positive number is clockwise.
-- A negative number is counter clockwise.
+- `'clockwise'`, `'counter-clockwise'`, or `'none'` for a degenerate polygon.
 
 ### forEachSegmentInPolygonPoints
 

--- a/docs/modules/polygon/api-reference/polygon.md
+++ b/docs/modules/polygon/api-reference/polygon.md
@@ -38,12 +38,7 @@ Returns the direction of the polygon path.
 
 `polygon.getWindingDirection()`
 
-- A positive number is clockwise.
-- A negative number is counter clockwise.
-
-Note:
-
-- A convenience method that returns `Math.sign(polygon.getSignedArea())`
+- Returns `'clockwise'`, `'counter-clockwise'`, or `'none'` for a degenerate polygon.
 
 ### forEachSegment
 
@@ -55,8 +50,7 @@ Lets the application iterate over each segment.
 
 Checks winding direction of the polygon and reverses the polygon in case if opposite winding direction. Note: points of the polygon are modified in-place.
 
-- A positive number is clockwise.
-- A negative number is counter clockwise.
+- `direction` is `'clockwise'` or `'counter-clockwise'`.
 
 `polygon.modifyWindingDirection(direction);`
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -59,6 +59,7 @@ Highlights:
 - New typed-array geometry utilities module.
 - Functionality additions to improve 3D Tiles support in loaders.gl.
 - Stronger type guarantees for math classes via the new sized array types.
+- Culling results, polygon winding directions, and Euler rotation orders now use descriptive string literal types; legacy named constants remain as deprecated string-valued aliases.
 
 **`@math.gl/expressions`** (NEW EXPERIMENTAL MODULE)
 

--- a/modules/core/src/classes/euler.ts
+++ b/modules/core/src/classes/euler.ts
@@ -14,8 +14,10 @@ import {checkNumber} from '../lib/validators';
 const ERR_UNKNOWN_ORDER = 'Unknown Euler angle order';
 const ALMOST_ONE = 0.99999;
 
-// eslint-disable-next-line no-shadow
-enum RotationOrder {
+/** Order in which Euler rotations are applied. */
+export type EulerRotationOrder = 'zyx' | 'yxz' | 'xzy' | 'zxy' | 'yzx' | 'xyz';
+
+enum RotationOrderIndex {
   ZYX = 0,
   YXZ = 1,
   XZY = 2,
@@ -24,37 +26,65 @@ enum RotationOrder {
   XYZ = 5
 }
 
+const ROTATION_ORDER_INDICES: Record<EulerRotationOrder, RotationOrderIndex> = {
+  zyx: RotationOrderIndex.ZYX,
+  yxz: RotationOrderIndex.YXZ,
+  xzy: RotationOrderIndex.XZY,
+  zxy: RotationOrderIndex.ZXY,
+  yzx: RotationOrderIndex.YZX,
+  xyz: RotationOrderIndex.XYZ
+};
+
+const ROTATION_ORDERS = {
+  ZYX: 'zyx',
+  YXZ: 'yxz',
+  XZY: 'xzy',
+  ZXY: 'zxy',
+  YZX: 'yzx',
+  XYZ: 'xyz'
+} as const;
+
 export class Euler extends MathArray {
   // Constants
-  static get ZYX(): RotationOrder {
-    return RotationOrder.ZYX;
+  /** @deprecated Pass the string `'zyx'` directly. */
+  static get ZYX(): EulerRotationOrder {
+    return 'zyx';
   }
-  static get YXZ(): RotationOrder {
-    return RotationOrder.YXZ;
+  /** @deprecated Pass the string `'yxz'` directly. */
+  static get YXZ(): EulerRotationOrder {
+    return 'yxz';
   }
-  static get XZY(): RotationOrder {
-    return RotationOrder.XZY;
+  /** @deprecated Pass the string `'xzy'` directly. */
+  static get XZY(): EulerRotationOrder {
+    return 'xzy';
   }
-  static get ZXY(): RotationOrder {
-    return RotationOrder.ZXY;
+  /** @deprecated Pass the string `'zxy'` directly. */
+  static get ZXY(): EulerRotationOrder {
+    return 'zxy';
   }
-  static get YZX(): RotationOrder {
-    return RotationOrder.YZX;
+  /** @deprecated Pass the string `'yzx'` directly. */
+  static get YZX(): EulerRotationOrder {
+    return 'yzx';
   }
-  static get XYZ(): RotationOrder {
-    return RotationOrder.XYZ;
+  /** @deprecated Pass the string `'xyz'` directly. */
+  static get XYZ(): EulerRotationOrder {
+    return 'xyz';
   }
-  static get RollPitchYaw(): RotationOrder {
-    return RotationOrder.ZYX;
+  /** @deprecated Pass the string `'zyx'` directly. */
+  static get RollPitchYaw(): EulerRotationOrder {
+    return 'zyx';
   }
-  static get DefaultOrder(): RotationOrder {
-    return RotationOrder.ZYX;
+  /** @deprecated Pass the string `'zyx'` directly. */
+  static get DefaultOrder(): EulerRotationOrder {
+    return 'zyx';
   }
-  static get RotationOrders(): typeof RotationOrder {
-    return RotationOrder;
+  /** @deprecated Pass an {@link EulerRotationOrder} string directly. */
+  static get RotationOrders(): typeof ROTATION_ORDERS {
+    return ROTATION_ORDERS;
   }
-  static rotationOrder(order: RotationOrder): string {
-    return RotationOrder[order];
+  /** @deprecated Euler rotation orders are already represented as strings. */
+  static rotationOrder(order: EulerRotationOrder): EulerRotationOrder {
+    return order;
   }
   get ELEMENTS(): number {
     return 4;
@@ -67,7 +97,7 @@ export class Euler extends MathArray {
    * @param {Number=} [z]
    * @param {Number=} [order]
    */
-  constructor(x = 0, y = 0, z = 0, order = Euler.DefaultOrder) {
+  constructor(x = 0, y = 0, z = 0, order: EulerRotationOrder = 'zyx') {
     // PERF NOTE: initialize elements as double precision numbers
     super(-0, -0, -0, -0);
     // eslint-disable-next-line prefer-rest-params
@@ -93,7 +123,7 @@ export class Euler extends MathArray {
     const roll = Math.atan2(t3, t4);
     const pitch = Math.asin(t2);
     const yaw = Math.atan2(t1, t0);
-    return this.set(roll, pitch, yaw, Euler.RollPitchYaw);
+    return this.set(roll, pitch, yaw, 'zyx');
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -111,18 +141,19 @@ export class Euler extends MathArray {
     this[0] = array[0];
     this[1] = array[1];
     this[2] = array[2];
-    // @ts-expect-error
-    this[3] = Number.isFinite(array[3]) || this.order;
+    if (Number.isFinite(array[3]) && validateOrder(array[3])) {
+      this[3] = array[3];
+    }
     return this.check();
   }
 
   // Sets the three angles, and optionally sets the rotation order
   // If order is not specified, preserves currently set order
-  set(x = 0, y = 0, z = 0, order: RotationOrder): this {
+  set(x = 0, y = 0, z = 0, order: EulerRotationOrder): this {
     this[0] = x;
     this[1] = y;
     this[2] = z;
-    this[3] = Number.isFinite(order) ? order : this[3];
+    this[3] = order ? checkOrder(order) : this[3];
     return this.check();
   }
 
@@ -248,16 +279,16 @@ export class Euler extends MathArray {
   }
 
   // rotation order, in all three angle notations
-  get order(): RotationOrder {
-    return this[3];
+  get order(): EulerRotationOrder {
+    return getOrder(this[3]);
   }
-  set order(value: RotationOrder) {
+  set order(value: EulerRotationOrder) {
     this[3] = checkOrder(value);
   }
 
   // Constructors
-  fromVector3(v: Readonly<NumericArray>, order: RotationOrder): this {
-    return this.set(v[0], v[1], v[2], Number.isFinite(order) ? order : this[3]);
+  fromVector3(v: Readonly<NumericArray>, order: EulerRotationOrder = this.order): this {
+    return this.set(v[0], v[1], v[2], order);
   }
 
   // TODO - with and without 4th element
@@ -273,10 +304,10 @@ export class Euler extends MathArray {
 
   // Common ZYX rotation order
   fromRollPitchYaw(roll: number, pitch: number, yaw: number): this {
-    return this.set(roll, pitch, yaw, RotationOrder.ZYX);
+    return this.set(roll, pitch, yaw, 'zyx');
   }
 
-  fromRotationMatrix(m: Readonly<NumericArray>, order: RotationOrder = Euler.DefaultOrder): this {
+  fromRotationMatrix(m: Readonly<NumericArray>, order: EulerRotationOrder = 'zyx'): this {
     this._fromRotationMatrix(m, order);
     return this.check();
   }
@@ -291,17 +322,17 @@ export class Euler extends MathArray {
   getQuaternion(): Quaternion {
     const q = new Quaternion();
     switch (this[3]) {
-      case RotationOrder.XYZ:
+      case RotationOrderIndex.XYZ:
         return q.rotateX(this[0]).rotateY(this[1]).rotateZ(this[2]);
-      case RotationOrder.YXZ:
+      case RotationOrderIndex.YXZ:
         return q.rotateY(this[1]).rotateX(this[0]).rotateZ(this[2]);
-      case RotationOrder.ZXY:
+      case RotationOrderIndex.ZXY:
         return q.rotateZ(this[2]).rotateX(this[0]).rotateY(this[1]);
-      case RotationOrder.ZYX:
+      case RotationOrderIndex.ZYX:
         return q.rotateZ(this[2]).rotateY(this[1]).rotateX(this[0]);
-      case RotationOrder.YZX:
+      case RotationOrderIndex.YZX:
         return q.rotateY(this[1]).rotateZ(this[2]).rotateX(this[0]);
-      case RotationOrder.XZY:
+      case RotationOrderIndex.XZY:
         return q.rotateX(this[0]).rotateZ(this[2]).rotateY(this[1]);
       default:
         throw new Error(ERR_UNKNOWN_ORDER);
@@ -316,7 +347,7 @@ export class Euler extends MathArray {
   //   const q = new Quaternion().setFromEuler(this);
   //   return this.setFromQuaternion(q, newOrder);
   /* eslint-disable complexity, max-statements, one-var */
-  _fromRotationMatrix(m: Readonly<NumericArray>, order = Euler.DefaultOrder): this {
+  _fromRotationMatrix(m: Readonly<NumericArray>, order: EulerRotationOrder = 'zyx'): this {
     // assumes the upper 3x3 of m is a pure rotation matrix (i.e, unscaled)
     const m11 = m[0],
       m12 = m[4],
@@ -327,9 +358,9 @@ export class Euler extends MathArray {
     const m31 = m[2],
       m32 = m[6],
       m33 = m[10];
-    order = order || this[3];
-    switch (order) {
-      case Euler.XYZ:
+    const orderIndex = order ? checkOrder(order) : this[3];
+    switch (orderIndex) {
+      case RotationOrderIndex.XYZ:
         this[1] = Math.asin(clamp(m13, -1, 1));
         if (Math.abs(m13) < ALMOST_ONE) {
           this[0] = Math.atan2(-m23, m33);
@@ -339,7 +370,7 @@ export class Euler extends MathArray {
           this[2] = 0;
         }
         break;
-      case Euler.YXZ:
+      case RotationOrderIndex.YXZ:
         this[0] = Math.asin(-clamp(m23, -1, 1));
         if (Math.abs(m23) < ALMOST_ONE) {
           this[1] = Math.atan2(m13, m33);
@@ -349,7 +380,7 @@ export class Euler extends MathArray {
           this[2] = 0;
         }
         break;
-      case Euler.ZXY:
+      case RotationOrderIndex.ZXY:
         this[0] = Math.asin(clamp(m32, -1, 1));
         if (Math.abs(m32) < ALMOST_ONE) {
           this[1] = Math.atan2(-m31, m33);
@@ -359,7 +390,7 @@ export class Euler extends MathArray {
           this[2] = Math.atan2(m21, m11);
         }
         break;
-      case Euler.ZYX:
+      case RotationOrderIndex.ZYX:
         this[1] = Math.asin(-clamp(m31, -1, 1));
         if (Math.abs(m31) < ALMOST_ONE) {
           this[0] = Math.atan2(m32, m33);
@@ -369,7 +400,7 @@ export class Euler extends MathArray {
           this[2] = Math.atan2(-m12, m22);
         }
         break;
-      case Euler.YZX:
+      case RotationOrderIndex.YZX:
         this[2] = Math.asin(clamp(m21, -1, 1));
         if (Math.abs(m21) < ALMOST_ONE) {
           this[0] = Math.atan2(-m23, m22);
@@ -379,7 +410,7 @@ export class Euler extends MathArray {
           this[1] = Math.atan2(m13, m33);
         }
         break;
-      case Euler.XZY:
+      case RotationOrderIndex.XZY:
         this[2] = Math.asin(-clamp(m12, -1, 1));
         if (Math.abs(m12) < ALMOST_ONE) {
           this[0] = Math.atan2(m32, m22);
@@ -392,7 +423,7 @@ export class Euler extends MathArray {
       default:
         throw new Error(ERR_UNKNOWN_ORDER);
     }
-    this[3] = order;
+    this[3] = orderIndex;
     return this;
   }
 
@@ -408,7 +439,7 @@ export class Euler extends MathArray {
     const d = Math.sin(y);
     const f = Math.sin(z);
     switch (this[3]) {
-      case Euler.XYZ: {
+      case RotationOrderIndex.XYZ: {
         const ae = a * e,
           af = a * f,
           be = b * e,
@@ -424,7 +455,7 @@ export class Euler extends MathArray {
         te[10] = a * c;
         break;
       }
-      case Euler.YXZ: {
+      case RotationOrderIndex.YXZ: {
         const ce = c * e,
           cf = c * f,
           de = d * e,
@@ -440,7 +471,7 @@ export class Euler extends MathArray {
         te[10] = a * c;
         break;
       }
-      case Euler.ZXY: {
+      case RotationOrderIndex.ZXY: {
         const ce = c * e,
           cf = c * f,
           de = d * e,
@@ -456,7 +487,7 @@ export class Euler extends MathArray {
         te[10] = a * c;
         break;
       }
-      case Euler.ZYX: {
+      case RotationOrderIndex.ZYX: {
         const ae = a * e,
           af = a * f,
           be = b * e,
@@ -472,7 +503,7 @@ export class Euler extends MathArray {
         te[10] = a * c;
         break;
       }
-      case Euler.YZX: {
+      case RotationOrderIndex.YZX: {
         const ac = a * c,
           ad = a * d,
           bc = b * c,
@@ -488,7 +519,7 @@ export class Euler extends MathArray {
         te[10] = ac - bd * f;
         break;
       }
-      case Euler.XZY: {
+      case RotationOrderIndex.XZY: {
         const ac = a * c,
           ad = a * d,
           bc = b * c,
@@ -541,9 +572,29 @@ function validateOrder(value: number): boolean {
   return value >= 0 && value < 6;
 }
 
-function checkOrder(value: number) {
-  if (value < 0 && value >= 6) {
+function checkOrder(value: EulerRotationOrder): RotationOrderIndex {
+  const order = ROTATION_ORDER_INDICES[value];
+  if (order === undefined) {
     throw new Error(ERR_UNKNOWN_ORDER);
   }
-  return value;
+  return order;
+}
+
+function getOrder(value: number): EulerRotationOrder {
+  switch (value) {
+    case RotationOrderIndex.ZYX:
+      return 'zyx';
+    case RotationOrderIndex.YXZ:
+      return 'yxz';
+    case RotationOrderIndex.XZY:
+      return 'xzy';
+    case RotationOrderIndex.ZXY:
+      return 'zxy';
+    case RotationOrderIndex.YZX:
+      return 'yzx';
+    case RotationOrderIndex.XYZ:
+      return 'xyz';
+    default:
+      throw new Error(ERR_UNKNOWN_ORDER);
+  }
 }

--- a/modules/core/src/classes/pose.ts
+++ b/modules/core/src/classes/pose.ts
@@ -39,8 +39,7 @@ export class Pose {
       this.position = new Vector3(x, y, z);
     }
     if (Array.isArray(orientation) && orientation.length === 4) {
-      // @ts-expect-error
-      this.orientation = new Euler(orientation, orientation[3]);
+      this.orientation = new Euler().fromArray(orientation);
     } else {
       this.orientation = new Euler(roll, pitch, yaw, 'zyx');
     }

--- a/modules/core/src/classes/pose.ts
+++ b/modules/core/src/classes/pose.ts
@@ -42,7 +42,7 @@ export class Pose {
       // @ts-expect-error
       this.orientation = new Euler(orientation, orientation[3]);
     } else {
-      this.orientation = new Euler(roll, pitch, yaw, Euler.RollPitchYaw);
+      this.orientation = new Euler(roll, pitch, yaw, 'zyx');
     }
   }
 

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -41,6 +41,7 @@ export type {Matrix4Like} from './classes/matrix4';
 export {SphericalCoordinates} from './classes/spherical-coordinates';
 export {Pose} from './classes/pose';
 export {Euler} from './classes/euler';
+export type {EulerRotationOrder} from './classes/euler';
 
 export * as _MathUtils from './lib/math-utils';
 

--- a/modules/core/test/classes/euler.spec.ts
+++ b/modules/core/test/classes/euler.spec.ts
@@ -33,18 +33,18 @@ function extendToMatrix4(arr) {
 
 test('Euler#import', () => {
   expect(typeof Euler).toBe('function');
-  expect(Euler.ZYX >= 0).toBeTruthy();
-  expect(Euler.YXZ > 0).toBeTruthy();
-  expect(Euler.XZY > 0).toBeTruthy();
-  expect(Euler.ZXY > 0).toBeTruthy();
-  expect(Euler.YZX > 0).toBeTruthy();
-  expect(Euler.XYZ > 0).toBeTruthy();
+  expect(Euler.ZYX).toBe('zyx');
+  expect(Euler.YXZ).toBe('yxz');
+  expect(Euler.XZY).toBe('xzy');
+  expect(Euler.ZXY).toBe('zxy');
+  expect(Euler.YZX).toBe('yzx');
+  expect(Euler.XYZ).toBe('xyz');
 
-  expect(Euler.RollPitchYaw >= 0).toBeTruthy();
-  expect(Euler.DefaultOrder >= 0).toBeTruthy();
-  expect(Euler.RotationOrders).toBeTruthy();
+  expect(Euler.RollPitchYaw).toBe('zyx');
+  expect(Euler.DefaultOrder).toBe('zyx');
+  expect(Euler.RotationOrders.XYZ).toBe('xyz');
 
-  expect(Euler.rotationOrder(Euler.ZYX)).toBe('ZYX');
+  expect(Euler.rotationOrder(Euler.ZYX)).toBe('zyx');
 });
 
 test('Euler#construct and Array.isArray check', () => {
@@ -77,6 +77,7 @@ test('Euler#coverage', () => {
 
   euler.order = Euler.XYZ;
   euler.order = euler.order;
+  expect(euler.order).toBe('xyz');
 
   euler.copy([0, 0, 0, 1]);
 

--- a/modules/core/test/classes/pose.spec.ts
+++ b/modules/core/test/classes/pose.spec.ts
@@ -84,6 +84,15 @@ test('Pose#constructor', () => {
   pose2 = new Pose(flattenProps);
 
   expect(pose1.equals(pose2), 'reconstructed from flatten props').toBeTruthy();
+
+  pose1 = new Pose({orientation: new Euler(1, 2, 3, 'xyz')});
+  pose2 = new Pose(pose1);
+  expect(pose1.equals(pose2), 'preserves packed order when reconstructed from a pose').toBeTruthy();
+  expect(pose2.orientation.order).toBe('xyz');
+
+  pose2 = new Pose(JSON.parse(JSON.stringify(pose1)));
+  expect(pose1.equals(pose2), 'preserves packed order when reconstructed from JSON').toBeTruthy();
+  expect(pose2.orientation.order).toBe('xyz');
 });
 
 test('Pose#equals', () => {

--- a/modules/core/test/threejs-tests/matrix4-three.spec.ts
+++ b/modules/core/test/threejs-tests/matrix4-three.spec.ts
@@ -198,11 +198,11 @@ test.skip('three.js#Matrix4#extractRotation', () => {
 
 test.skip('three.js#Matrix4#makeRotationFromEuler/extractRotation', () => {
   const testValues = [
-    new Euler(0, 0, 0, 'XYZ'),
-    new Euler(1, 0, 0, 'XYZ'),
-    new Euler(0, 1, 0, 'ZYX'),
-    new Euler(0, 0, 0.5, 'YZX'),
-    new Euler(0, 0, -0.5, 'YZX')
+    new Euler(0, 0, 0, 'xyz'),
+    new Euler(1, 0, 0, 'xyz'),
+    new Euler(0, 1, 0, 'zyx'),
+    new Euler(0, 0, 0.5, 'yzx'),
+    new Euler(0, 0, -0.5, 'yzx')
   ];
 
   for (let i = 0; i < testValues.length; i++) {

--- a/modules/core/test/threejs-tests/quaternion-three.spec.ts
+++ b/modules/core/test/threejs-tests/quaternion-three.spec.ts
@@ -14,7 +14,7 @@ import {test, expect} from 'vitest';
 import {Quaternion, Vector3, Vector4, Matrix4, Euler} from '@math.gl/core';
 import {x, y, z, w, eps} from './constants';
 
-const orders = ['XYZ', 'YXZ', 'ZXY', 'ZYX', 'YZX', 'XZY'];
+const orders = ['xyz', 'yxz', 'zxy', 'zyx', 'yzx', 'xzy'];
 // const eulerAngles = new Euler(0.1, -0.3, 0.25);
 
 function qSub(a, b) {

--- a/modules/culling/src/constants.ts
+++ b/modules/culling/src/constants.ts
@@ -2,8 +2,14 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-export const INTERSECTION = {
-  OUTSIDE: -1, // Represents that an object is not contained within the frustum.
-  INTERSECTING: 0, // Represents that an object intersects one of the frustum's planes.
-  INSIDE: 1 // Represents that an object is fully within the frustum.
-} as const;
+/** Classification returned by culling intersection tests. */
+export type CullingResult = 'outside' | 'intersecting' | 'inside';
+
+/**
+ * @deprecated Use the string values of {@link CullingResult} directly.
+ */
+export enum INTERSECTION {
+  OUTSIDE = 'outside', // The object is not contained within the frustum.
+  INTERSECTING = 'intersecting', // The object intersects one or more frustum planes.
+  INSIDE = 'inside' // The object is fully within the frustum.
+}

--- a/modules/culling/src/index.ts
+++ b/modules/culling/src/index.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 export {INTERSECTION} from './constants';
+export type {CullingResult} from './constants';
 
 export {AxisAlignedBoundingBox} from './lib/bounding-volumes/axis-aligned-bounding-box';
 export {BoundingSphere} from './lib/bounding-volumes/bounding-sphere';

--- a/modules/culling/src/lib/bounding-volumes/axis-aligned-bounding-box.ts
+++ b/modules/culling/src/lib/bounding-volumes/axis-aligned-bounding-box.ts
@@ -5,7 +5,7 @@
 import {BoundingVolume} from './bounding-volume';
 import {Vector3} from '@math.gl/core';
 import {Plane} from '../plane';
-import {INTERSECTION} from '../../constants';
+import type {CullingResult} from '../../constants';
 
 const scratchVector = new Vector3();
 const scratchNormal = new Vector3();
@@ -97,7 +97,7 @@ export class AxisAlignedBoundingBox implements BoundingVolume {
   /**
    * Determines which side of a plane a box is located.
    */
-  intersectPlane(plane: Plane): number {
+  intersectPlane(plane: Plane): CullingResult {
     const {halfDiagonal} = this;
     const normal = scratchNormal.from(plane.normal);
     const e =
@@ -107,15 +107,15 @@ export class AxisAlignedBoundingBox implements BoundingVolume {
     const s = this.center.dot(normal) + plane.distance; // signed distance from center
 
     if (s - e > 0) {
-      return INTERSECTION.INSIDE;
+      return 'inside';
     }
 
     if (s + e < 0) {
       // Not in front because normals point inward
-      return INTERSECTION.OUTSIDE;
+      return 'outside';
     }
 
-    return INTERSECTION.INTERSECTING;
+    return 'intersecting';
   }
 
   /** Computes the estimated distance from the closest point on a bounding box to a point. */

--- a/modules/culling/src/lib/bounding-volumes/bounding-sphere.ts
+++ b/modules/culling/src/lib/bounding-volumes/bounding-sphere.ts
@@ -7,7 +7,7 @@
 
 import {NumericArray, Vector3, mat4} from '@math.gl/core';
 
-import {INTERSECTION} from '../../constants';
+import type {CullingResult} from '../../constants';
 import {BoundingVolume} from './bounding-volume';
 import {Plane} from '../plane';
 
@@ -131,7 +131,7 @@ export class BoundingSphere implements BoundingVolume {
   }
 
   /** Determines which side of a plane a sphere is located. */
-  intersectPlane(plane: Plane): number {
+  intersectPlane(plane: Plane): CullingResult {
     const center = this.center;
     const radius = this.radius;
     const normal = plane.normal;
@@ -139,13 +139,13 @@ export class BoundingSphere implements BoundingVolume {
 
     // The center point is negative side of the plane normal
     if (distanceToPlane < -radius) {
-      return INTERSECTION.OUTSIDE;
+      return 'outside';
     }
     // The center point is positive side of the plane, but radius extends beyond it; partial overlap
     if (distanceToPlane < radius) {
-      return INTERSECTION.INTERSECTING;
+      return 'intersecting';
     }
     // The center point and radius is positive side of the plane
-    return INTERSECTION.INSIDE;
+    return 'inside';
   }
 }

--- a/modules/culling/src/lib/bounding-volumes/bounding-volume.ts
+++ b/modules/culling/src/lib/bounding-volumes/bounding-volume.ts
@@ -4,6 +4,7 @@
 
 // import {INTERSECTION} from '../../constants';
 import {Plane} from '../plane';
+import type {CullingResult} from '../../constants';
 
 /**
  * Common interface for BoundingVolumes
@@ -28,9 +29,9 @@ export interface BoundingVolume {
    *
    * @param plane The plane to test against.
    * @returns
-   *  - `INTERSECTION.INSIDE` if the entire box is on the side of the plane the normal is pointing.
-   *  - `INTERSECTION.OUTSIDE` if the entire box is on the opposite side.
-   *  - `INTERSECTION.INTERSECTING` if the box intersects the plane.
+   *  - `'inside'` if the entire box is on the side of the plane the normal is pointing.
+   *  - `'outside'` if the entire box is on the opposite side.
+   *  - `'intersecting'` if the box intersects the plane.
    */
-  intersectPlane(plane: Plane): number;
+  intersectPlane(plane: Plane): CullingResult;
 }

--- a/modules/culling/src/lib/bounding-volumes/oriented-bounding-box.ts
+++ b/modules/culling/src/lib/bounding-volumes/oriented-bounding-box.ts
@@ -11,7 +11,7 @@ import {Vector3, Matrix3, Matrix4, Quaternion} from '@math.gl/core';
 import type {BoundingVolume} from './bounding-volume';
 import {BoundingSphere} from './bounding-sphere';
 import {Plane} from '../plane';
-import {INTERSECTION} from '../../constants';
+import type {CullingResult} from '../../constants';
 
 const scratchVector3 = new Vector3();
 const scratchOffset = new Vector3();
@@ -129,7 +129,7 @@ export class OrientedBoundingBox implements BoundingVolume {
   }
 
   /** Determines which side of a plane the oriented bounding box is located. */
-  intersectPlane(plane: Plane): number {
+  intersectPlane(plane: Plane): CullingResult {
     const center = this.center;
     const normal = plane.normal;
     const halfAxes = this.halfAxes;
@@ -159,12 +159,12 @@ export class OrientedBoundingBox implements BoundingVolume {
 
     if (distanceToPlane <= -radEffective) {
       // The entire box is on the negative side of the plane normal
-      return INTERSECTION.OUTSIDE;
+      return 'outside';
     } else if (distanceToPlane >= radEffective) {
       // The entire box is on the positive side of the plane normal
-      return INTERSECTION.INSIDE;
+      return 'inside';
     }
-    return INTERSECTION.INTERSECTING;
+    return 'intersecting';
   }
 
   /** Computes the estimated distance from the closest point on a bounding box to a point. */

--- a/modules/culling/src/lib/culling-volume.ts
+++ b/modules/culling/src/lib/culling-volume.ts
@@ -7,7 +7,7 @@
 
 /* eslint-disable */
 import {Vector3, assert} from '@math.gl/core';
-import {INTERSECTION} from '../constants';
+import type {CullingResult} from '../constants';
 import {Plane} from './plane';
 import type {BoundingVolume} from './bounding-volumes/bounding-volume';
 import type {BoundingSphere} from './bounding-volumes/bounding-sphere';
@@ -93,19 +93,19 @@ export class CullingVolume {
   }
 
   /** Determines whether a bounding volume intersects the culling volume. */
-  computeVisibility(boundingVolume: BoundingVolume): number {
+  computeVisibility(boundingVolume: BoundingVolume): CullingResult {
     // const planes = this.planes;
-    let intersect: number = INTERSECTION.INSIDE;
+    let intersect: CullingResult = 'inside';
     for (const plane of this.planes) {
       const result = boundingVolume.intersectPlane(plane);
       switch (result) {
-        case INTERSECTION.OUTSIDE:
+        case 'outside':
           // We are done
-          return INTERSECTION.OUTSIDE;
+          return 'outside';
 
-        case INTERSECTION.INTERSECTING:
+        case 'intersecting':
           // If no other intersection is outside, return INTERSECTING
-          intersect = INTERSECTION.INTERSECTING;
+          intersect = 'intersecting';
           break;
 
         default:
@@ -149,9 +149,9 @@ export class CullingVolume {
 
       const plane = planes[k];
       const result = boundingVolume.intersectPlane(plane);
-      if (result === INTERSECTION.OUTSIDE) {
+      if (result === 'outside') {
         return CullingVolume.MASK_OUTSIDE;
-      } else if (result === INTERSECTION.INTERSECTING) {
+      } else if (result === 'intersecting') {
         mask |= flag;
       }
     }

--- a/modules/culling/src/lib/shapes/implicit-shape.ts
+++ b/modules/culling/src/lib/shapes/implicit-shape.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {Matrix4, Vector3} from '@math.gl/core';
-import {INTERSECTION} from '../../constants';
+import type {CullingResult} from '../../constants';
 import {AxisAlignedBoundingBox} from '../bounding-volumes/axis-aligned-bounding-box';
 import {BoundingSphere} from '../bounding-volumes/bounding-sphere';
 import type {BoundingVolume} from '../bounding-volumes/bounding-volume';
@@ -84,14 +84,14 @@ export abstract class ImplicitShapeBase implements ImplicitShape {
     return localDistance * Math.min(scales[0], scales[1], scales[2]);
   }
 
-  intersectPlane(plane: Plane): number {
+  intersectPlane(plane: Plane): CullingResult {
     const maximum = this.getSupportPoint(plane.normal);
     const minimum = this.getSupportPoint([-plane.normal[0], -plane.normal[1], -plane.normal[2]]);
     const maxDistance = plane.getPointDistance(maximum);
     const minDistance = plane.getPointDistance(minimum);
-    if (minDistance > 0) return INTERSECTION.INSIDE;
-    if (maxDistance < 0) return INTERSECTION.OUTSIDE;
-    return INTERSECTION.INTERSECTING;
+    if (minDistance > 0) return 'inside';
+    if (maxDistance < 0) return 'outside';
+    return 'intersecting';
   }
 
   intersectRay(ray: Ray): RayIntersection | undefined {

--- a/modules/culling/src/lib/shapes/plane-shape.ts
+++ b/modules/culling/src/lib/shapes/plane-shape.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {Vector3} from '@math.gl/core';
-import {INTERSECTION} from '../../constants';
+import type {CullingResult} from '../../constants';
 import {ImplicitShapeBase, type ImplicitShape, type LocalRayIntersection} from './implicit-shape';
 import type {AxisAlignedBoundingBox} from '../bounding-volumes/axis-aligned-bounding-box';
 import type {BoundingSphere} from '../bounding-volumes/bounding-sphere';
@@ -58,16 +58,16 @@ export class PlaneShape extends ImplicitShapeBase {
     if (this.sizeZ !== undefined && Math.abs(z) > this.sizeZ / 2 + 1e-12) return undefined;
     return {distance, normal: [0, 1, 0]};
   }
-  override intersectPlane(plane: Plane): number {
+  override intersectPlane(plane: Plane): CullingResult {
     const boundaryPoint = new Vector3(0, 0, 0).transform(this.matrix);
     const inverse = this.inverseMatrix;
     const boundaryNormal = new Vector3(inverse[1], inverse[5], inverse[9]).normalize();
     const alignment = boundaryNormal.dot(plane.normal);
-    if (Math.abs(Math.abs(alignment) - 1) > 1e-10) return INTERSECTION.INTERSECTING;
+    if (Math.abs(Math.abs(alignment) - 1) > 1e-10) return 'intersecting';
     const boundaryDistance = plane.getPointDistance(boundaryPoint);
-    if (alignment < 0 && boundaryDistance > 0) return INTERSECTION.INSIDE;
-    if (alignment > 0 && boundaryDistance < 0) return INTERSECTION.OUTSIDE;
-    return INTERSECTION.INTERSECTING;
+    if (alignment < 0 && boundaryDistance > 0) return 'inside';
+    if (alignment > 0 && boundaryDistance < 0) return 'outside';
+    return 'intersecting';
   }
   override getAxisAlignedBoundingBox(): AxisAlignedBoundingBox | undefined {
     return undefined;

--- a/modules/culling/test/lib/culling-volume.spec.ts
+++ b/modules/culling/test/lib/culling-volume.spec.ts
@@ -13,6 +13,7 @@ import {
   _PerspectiveFrustum as PerspectiveFrustum,
   INTERSECTION
 } from '@math.gl/culling';
+import type {CullingResult} from '@math.gl/culling';
 import {BoundingVolume} from '../../dist/lib/bounding-volumes/bounding-volume';
 
 const VECTOR3_UNIT_Z = Object.freeze(new Vector3(0, 0, 1));
@@ -28,6 +29,12 @@ const cullingVolume = frustum.computeCullingVolume(
   new Vector3().copy(VECTOR3_UNIT_Z).negate(),
   new Vector3(0, 1, 0)
 );
+
+test('INTERSECTION compatibility constants are string-valued', () => {
+  expect(INTERSECTION.OUTSIDE).toBe('outside');
+  expect(INTERSECTION.INTERSECTING).toBe('intersecting');
+  expect(INTERSECTION.INSIDE).toBe('inside');
+});
 
 test('CullingVolume#constructor', () => {
   expect(() => new CullingVolume()).not.toThrow();
@@ -64,7 +71,7 @@ test('CullingVolume#computeVisibilityWithPlaneMask throws without a parent plane
 function testWithAndWithoutPlaneMask(
   culling: CullingVolume,
   bound: BoundingVolume,
-  intersect: number
+  intersect: CullingResult
 ) {
   const actualIntersect = culling.computeVisibility(bound);
   expect(actualIntersect).toBe(intersect);

--- a/modules/polygon/src/index.ts
+++ b/modules/polygon/src/index.ts
@@ -11,6 +11,7 @@ export {
   modifyPolygonWindingDirection,
   WINDING
 } from './polygon-utils';
+export type {PolygonWinding, WindingDirection} from './polygon-utils';
 
 export {earcut} from './earcut';
 

--- a/modules/polygon/src/polygon-utils.ts
+++ b/modules/polygon/src/polygon-utils.ts
@@ -7,10 +7,20 @@
 import {equals} from '@math.gl/core';
 import type {NumericArray} from '@math.gl/core';
 
-export const WINDING = {
-  CLOCKWISE: 1,
-  COUNTER_CLOCKWISE: -1
-} as const;
+/** Direction in which a polygon's vertices are ordered. */
+export type WindingDirection = 'clockwise' | 'counter-clockwise' | 'none';
+
+/** A non-degenerate polygon winding direction. */
+export type PolygonWinding = Exclude<WindingDirection, 'none'>;
+
+/**
+ * @deprecated Use the string values of {@link WindingDirection} directly.
+ */
+export enum WINDING {
+  CLOCKWISE = 'clockwise',
+  COUNTER_CLOCKWISE = 'counter-clockwise',
+  NONE = 'none'
+}
 
 /** Polygon representation where each point is represented as a separate array of positions. */
 type PointsArray = NumericArray[];
@@ -67,13 +77,13 @@ type PolygonParams = {
  * Checks winding direction of the polygon and reverses the polygon in case of opposite winding direction.
  * Note: points are modified in-place.
  * @param points An array that represents points of the polygon.
- * @param direction Requested winding direction. 1 is for clockwise, -1 for counterclockwise winding direction.
+ * @param direction Requested winding direction.
  * @param options Parameters of the polygon.
  * @return Returns true if the winding direction was changed.
  */
 export function modifyPolygonWindingDirection(
   points: NumericArray,
-  direction: number,
+  direction: PolygonWinding,
   options: PolygonParams = {}
 ): boolean {
   const windingDirection = getPolygonWindingDirection(points, options);
@@ -93,8 +103,8 @@ export function modifyPolygonWindingDirection(
 export function getPolygonWindingDirection(
   points: NumericArray,
   options: PolygonParams = {}
-): number {
-  return Math.sign(getPolygonSignedArea(points, options));
+): WindingDirection {
+  return getWindingDirection(getPolygonSignedArea(points, options));
 }
 
 export const DimIndex: Record<string, number> = {
@@ -190,13 +200,13 @@ function reversePolygon(
  * Checks winding direction of the polygon and reverses the polygon in case of opposite winding direction.
  * Note: points are modified in-place.
  * @param points Array of points that represent the polygon.
- * @param direction Requested winding direction. 1 is for clockwise, -1 for counterclockwise winding direction.
+ * @param direction Requested winding direction.
  * @param options Parameters of the polygon.
  * @return Returns true if the winding direction was changed.
  */
 export function modifyPolygonWindingDirectionPoints(
   points: PointsArray,
-  direction: number,
+  direction: PolygonWinding,
   options: PolygonParams = {}
 ): boolean {
   const currentDirection = getPolygonWindingDirectionPoints(points, options);
@@ -216,8 +226,14 @@ export function modifyPolygonWindingDirectionPoints(
 export function getPolygonWindingDirectionPoints(
   points: PointsArray,
   options: PolygonParams = {}
-): number {
-  return Math.sign(getPolygonSignedAreaPoints(points, options));
+): WindingDirection {
+  return getWindingDirection(getPolygonSignedAreaPoints(points, options));
+}
+
+function getWindingDirection(signedArea: number): WindingDirection {
+  if (signedArea > 0) return 'clockwise';
+  if (signedArea < 0) return 'counter-clockwise';
+  return 'none';
 }
 
 /**

--- a/modules/polygon/src/polygon.ts
+++ b/modules/polygon/src/polygon.ts
@@ -4,7 +4,7 @@
 
 /* eslint-disable no-undef, no-console */
 import {isArray} from '@math.gl/core';
-import type {SegmentVisitorPoints} from './polygon-utils';
+import type {PolygonWinding, SegmentVisitorPoints, WindingDirection} from './polygon-utils';
 import type {NumericArray} from '@math.gl/core';
 
 import {
@@ -62,10 +62,13 @@ export class Polygon {
 
   /**
    * Returns winding direction of the polygon.
-   * @returns Winding direction of the polygon. 1 is for clockwise, -1 for counterclockwise winding direction.
+   * @returns `'clockwise'`, `'counter-clockwise'`, or `'none'` for a degenerate polygon.
    */
-  getWindingDirection(): number {
-    return Math.sign(this.getSignedArea());
+  getWindingDirection(): WindingDirection {
+    const signedArea = this.getSignedArea();
+    if (signedArea > 0) return 'clockwise';
+    if (signedArea < 0) return 'counter-clockwise';
+    return 'none';
   }
 
   /**
@@ -90,10 +93,10 @@ export class Polygon {
 
   /**
    * Checks winding direction of the polygon and reverses the polygon in case of opposite winding direction.
-   * @param direction Requested winding direction. 1 is for clockwise, -1 for counterclockwise winding direction.
+   * @param direction Requested winding direction.
    * @return Returns true if the winding direction was changed.
    */
-  modifyWindingDirection(direction: number): boolean {
+  modifyWindingDirection(direction: PolygonWinding): boolean {
     if (this.isFlatArray) {
       return modifyPolygonWindingDirection(this.points as NumericArray, direction, this.options);
     }

--- a/modules/polygon/test/polygon.spec.ts
+++ b/modules/polygon/test/polygon.spec.ts
@@ -140,22 +140,26 @@ test('Polygon#methods', () => {
 
   for (const tc of TEST_CASES) {
     const polygon = new Polygon(tc.polygon, tc.options);
+    const windingSign = tc.sign === WINDING.CLOCKWISE ? 1 : -1;
     expect(polygon, `${tc.title}: Created polygon`).toBeTruthy();
     expect(
-      equals(polygon.getSignedArea(), tc.area * tc.sign),
+      equals(polygon.getSignedArea(), tc.area * windingSign),
       `${tc.title}: getSignedArea() returned expected result`
     ).toBe(true);
     expect(
       equals(polygon.getArea(), tc.area),
       `${tc.title}: getArea() returned expected result`
     ).toBe(true);
-    expect(
-      equals(polygon.getWindingDirection(), tc.sign),
-      `${tc.title}: getWindingDirection() returned expected result`
-    ).toBe(true);
+    expect(polygon.getWindingDirection(), `${tc.title}: winding direction`).toBe(tc.sign);
   }
 
   configure({EPSILON: 1e-12});
+});
+
+test('WINDING compatibility constants are string-valued', () => {
+  expect(WINDING.CLOCKWISE).toBe('clockwise');
+  expect(WINDING.COUNTER_CLOCKWISE).toBe('counter-clockwise');
+  expect(WINDING.NONE).toBe('none');
 });
 
 test('Polygon#forEachSegment', () => {


### PR DESCRIPTION
## Summary

- replace numeric culling classifications and polygon winding directions with lowercase string literal APIs
- expose lowercase Euler rotation-order strings while retaining its numeric packed representation internally
- retain INTERSECTION, WINDING, and Euler named constants as deprecated string-valued compatibility aliases
- update public types, documentation, and tests

## Validation

- yarn lint
- yarn build
- yarn test-node (791 passed, 129 skipped)