### PR TITLE
feat(proj): add lightweight EPSG:3857 utilities

### DIFF
--- a/modules/proj/README.md
+++ b/modules/proj/README.md
@@ -1,0 +1,5 @@
+# @math.gl/proj
+
+[math.gl](https://math.gl) utilities for lightweight coordinate reference system conversions.
+
+The initial implementation supports WGS84/EPSG:4326 and EPSG:3857 Web Mercator meter coordinates. General CRS transformations remain available through `@math.gl/proj4`.

--- a/modules/proj/package.json
+++ b/modules/proj/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@math.gl/proj",
+  "description": "Lightweight coordinate reference system projection utilities",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "version": "4.2.0-alpha.5",
+  "keywords": [
+    "math",
+    "geospatial",
+    "projection",
+    "coordinate reference system",
+    "web mercator",
+    "EPSG:3857",
+    "EPSG:4326"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/math.gl.git"
+  },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "dependencies": {
+    "@math.gl/web-mercator": "4.2.0-alpha.5"
+  }
+}

--- a/modules/proj/src/index.ts
+++ b/modules/proj/src/index.ts
@@ -1,0 +1,16 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export {
+  EPSG3857_EARTH_RADIUS,
+  EPSG3857_HALF_CIRCUMFERENCE,
+  EPSG3857_MAX_LATITUDE,
+  EPSG3857_UNITS_PER_METER,
+  lngLatToEPSG3857,
+  EPSG3857ToLngLat,
+  EPSG4326ToEPSG3857,
+  EPSG3857ToEPSG4326
+} from '@math.gl/web-mercator';
+
+export type {EPSG3857Options} from '@math.gl/web-mercator';

--- a/modules/proj/test/proj.spec.ts
+++ b/modules/proj/test/proj.spec.ts
@@ -1,0 +1,19 @@
+import {test, expect} from 'vitest';
+import {
+  EPSG4326ToEPSG3857,
+  EPSG3857ToEPSG4326,
+  lngLatToEPSG3857,
+  EPSG3857ToLngLat
+} from '@math.gl/proj';
+
+test('@math.gl/proj re-exports the EPSG converters', () => {
+  const coordinate = [-122.4, 37.8, 100];
+  const projected = EPSG4326ToEPSG3857(coordinate);
+  const unprojected = EPSG3857ToEPSG4326(projected);
+
+  expect(projected).toEqual(lngLatToEPSG3857(coordinate));
+  expect(unprojected).toEqual(EPSG3857ToLngLat(projected));
+  expect(unprojected[0]).toBeCloseTo(coordinate[0], 10);
+  expect(unprojected[1]).toBeCloseTo(coordinate[1], 10);
+  expect(unprojected[2]).toBe(coordinate[2]);
+});

--- a/modules/proj/tsconfig.json
+++ b/modules/proj/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    {"path": "../web-mercator"}
+  ]
+}

--- a/modules/web-mercator/src/index.ts
+++ b/modules/web-mercator/src/index.ts
@@ -25,6 +25,19 @@ export {
   getProjectionParameters
 } from './web-mercator-utils';
 
+export {
+  EPSG3857_EARTH_RADIUS,
+  EPSG3857_HALF_CIRCUMFERENCE,
+  EPSG3857_MAX_LATITUDE,
+  EPSG3857_UNITS_PER_METER,
+  lngLatToEPSG3857,
+  EPSG3857ToLngLat,
+  EPSG4326ToEPSG3857,
+  EPSG3857ToEPSG4326
+} from './mercator-meters';
+
+export type {EPSG3857Options} from './mercator-meters';
+
 /** Types */
 export type {FitBoundsOptions} from './fit-bounds';
 export type {DistanceScales} from './web-mercator-utils';

--- a/modules/web-mercator/src/mercator-meters.ts
+++ b/modules/web-mercator/src/mercator-meters.ts
@@ -1,0 +1,83 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+const PI = Math.PI;
+const DEGREES_TO_RADIANS = PI / 180;
+const RADIANS_TO_DEGREES = 180 / PI;
+
+/** Radius of the sphere used by EPSG:3857, in meters. */
+export const EPSG3857_EARTH_RADIUS = 6378137;
+
+/** Half the circumference of the EPSG:3857 sphere, in meters. */
+export const EPSG3857_HALF_CIRCUMFERENCE = PI * EPSG3857_EARTH_RADIUS;
+
+/** Maximum latitude with a finite value in the spherical Mercator projection. */
+export const EPSG3857_MAX_LATITUDE = Math.atan(Math.sinh(PI)) * RADIANS_TO_DEGREES;
+
+/** EPSG:3857 meters per 512-unit world coordinate at the equator. */
+export const EPSG3857_UNITS_PER_METER = 512 / (2 * EPSG3857_HALF_CIRCUMFERENCE);
+
+export type EPSG3857Options = {
+  /** Clamp latitude to the finite Web Mercator range. Defaults to true. */
+  clampLatitude?: boolean;
+};
+
+/**
+ * Convert WGS84 longitude/latitude coordinates to EPSG:3857 meters.
+ *
+ * The optional third coordinate is preserved as an elevation in meters.
+ */
+export function lngLatToEPSG3857(lngLatZ: number[], options: EPSG3857Options = {}): number[] {
+  const [longitude, latitude, z] = lngLatZ;
+  const {clampLatitude = true} = options;
+
+  if (!Number.isFinite(longitude) || !Number.isFinite(latitude)) {
+    throw new Error('Invalid longitude or latitude');
+  }
+  if (lngLatZ.length >= 3 && !Number.isFinite(z)) {
+    throw new Error('Invalid elevation');
+  }
+
+  const projectedLatitude = clampLatitude
+    ? Math.max(-EPSG3857_MAX_LATITUDE, Math.min(EPSG3857_MAX_LATITUDE, latitude))
+    : latitude;
+
+  if (projectedLatitude < -EPSG3857_MAX_LATITUDE || projectedLatitude > EPSG3857_MAX_LATITUDE) {
+    throw new Error('Latitude is outside the finite EPSG:3857 range');
+  }
+
+  const x = EPSG3857_EARTH_RADIUS * longitude * DEGREES_TO_RADIANS;
+  const y =
+    EPSG3857_EARTH_RADIUS *
+    Math.log(Math.tan(PI / 4 + (projectedLatitude * DEGREES_TO_RADIANS) / 2));
+
+  return lngLatZ.length >= 3 ? [x, y, z] : [x, y];
+}
+
+/**
+ * Convert EPSG:3857 meters to WGS84 longitude/latitude coordinates.
+ *
+ * The optional third coordinate is preserved as an elevation in meters.
+ */
+export function EPSG3857ToLngLat(xyz: number[]): number[] {
+  const [x, y, z] = xyz;
+
+  if (!Number.isFinite(x) || !Number.isFinite(y)) {
+    throw new Error('Invalid EPSG:3857 coordinate');
+  }
+  if (xyz.length >= 3 && !Number.isFinite(z)) {
+    throw new Error('Invalid elevation');
+  }
+
+  const longitude = (x / EPSG3857_EARTH_RADIUS) * RADIANS_TO_DEGREES;
+  const latitude = Math.atan(Math.sinh(y / EPSG3857_EARTH_RADIUS)) * RADIANS_TO_DEGREES;
+
+  return xyz.length >= 3 ? [longitude, latitude, z] : [longitude, latitude];
+}
+
+/** Explicit EPSG:4326 to EPSG:3857 alias. */
+export const EPSG4326ToEPSG3857 = lngLatToEPSG3857;
+
+/** Explicit EPSG:3857 to EPSG:4326 alias. */
+export const EPSG3857ToEPSG4326 = EPSG3857ToLngLat;

--- a/modules/web-mercator/test/spec/mercator-meters.spec.ts
+++ b/modules/web-mercator/test/spec/mercator-meters.spec.ts
@@ -1,0 +1,47 @@
+import {test, expect} from 'vitest';
+import {
+  EPSG3857_EARTH_RADIUS,
+  EPSG3857_HALF_CIRCUMFERENCE,
+  EPSG3857_MAX_LATITUDE,
+  lngLatToEPSG3857,
+  EPSG3857ToLngLat
+} from '@math.gl/web-mercator';
+
+test('lngLatToEPSG3857', () => {
+  const result = lngLatToEPSG3857([-122.4, 37.8, 100]);
+
+  expect(result[0]).toBeCloseTo(-13625505.673096687, 6);
+  expect(result[1]).toBeCloseTo(4551210.919691888, 6);
+  expect(result[2]).toBe(100);
+});
+
+test('EPSG3857ToLngLat', () => {
+  const result = EPSG3857ToLngLat([-13625505.673096687, 4551210.919691888, 100]);
+
+  expect(result[0]).toBeCloseTo(-122.4, 10);
+  expect(result[1]).toBeCloseTo(37.8, 10);
+  expect(result[2]).toBe(100);
+});
+
+test('EPSG3857 constants', () => {
+  expect(EPSG3857_HALF_CIRCUMFERENCE).toBeCloseTo(Math.PI * EPSG3857_EARTH_RADIUS, 12);
+  expect(EPSG3857_MAX_LATITUDE).toBeCloseTo(85.0511287798066, 12);
+});
+
+test('lngLatToEPSG3857 clamps latitude by default', () => {
+  const result = lngLatToEPSG3857([0, 90]);
+  const unprojected = EPSG3857ToLngLat(result);
+
+  expect(unprojected[1]).toBeCloseTo(EPSG3857_MAX_LATITUDE, 12);
+});
+
+test('lngLatToEPSG3857 can reject out-of-range latitude', () => {
+  expect(() => lngLatToEPSG3857([0, 90], {clampLatitude: false})).toThrow(/finite EPSG:3857 range/);
+});
+
+test('EPSG3857 converters preserve dimensionality', () => {
+  expect(lngLatToEPSG3857([0, 0])).toHaveLength(2);
+  expect(EPSG3857ToLngLat([0, 0])).toHaveLength(2);
+  expect(lngLatToEPSG3857([0, 0, 0])).toHaveLength(3);
+  expect(EPSG3857ToLngLat([0, 0, 0])).toHaveLength(3);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -69,6 +69,8 @@
       "@math.gl/geometry-utils/test/*": ["./modules/geometry-utils/test/*"],
       "@math.gl/polygon/*": ["./modules/polygon/src/*"],
       "@math.gl/polygon/test/*": ["./modules/polygon/test/*"],
+      "@math.gl/proj/*": ["./modules/proj/src/*"],
+      "@math.gl/proj/test/*": ["./modules/proj/test/*"],
       "@math.gl/proj4/*": ["./modules/proj4/src/*"],
       "@math.gl/proj4/test/*": ["./modules/proj4/test/*"],
       "@math.gl/sun/*": ["./modules/sun/src/*"],

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -14,6 +14,7 @@
       "@math.gl/geoid": ["./modules/geoid/src/index.ts"],
       "@math.gl/geospatial": ["./modules/geospatial/src/index.ts"],
       "@math.gl/polygon": ["./modules/polygon/src/index.ts"],
+      "@math.gl/proj": ["./modules/proj/src/index.ts"],
       "@math.gl/proj4": ["./modules/proj4/src/index.ts"],
       "@math.gl/sun": ["./modules/sun/src/index.ts"],
       "@math.gl/types": ["./modules/types/src/index.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4274,6 +4274,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@math.gl/proj@workspace:modules/proj":
+  version: 0.0.0-use.local
+  resolution: "@math.gl/proj@workspace:modules/proj"
+  dependencies:
+    "@math.gl/web-mercator": "npm:4.2.0-alpha.5"
+  languageName: unknown
+  linkType: soft
+
 "@math.gl/sun@workspace:modules/sun":
   version: 0.0.0-use.local
   resolution: "@math.gl/sun@workspace:modules/sun"
@@ -4293,7 +4301,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@math.gl/web-mercator@workspace:modules/web-mercator":
+"@math.gl/web-mercator@npm:4.2.0-alpha.5, @math.gl/web-mercator@workspace:modules/web-mercator":
   version: 0.0.0-use.local
   resolution: "@math.gl/web-mercator@workspace:modules/web-mercator"
   dependencies:


### PR DESCRIPTION
## Summary

- add exact WGS84/EPSG:3857 meter conversion utilities to `@math.gl/web-mercator`
- add a lightweight `@math.gl/proj` facade without a proj4 runtime dependency
- preserve optional elevation values and support configurable latitude clamping
- add package metadata, workspace mappings, documentation, and tests

## Verification

- `yarn build`
- `yarn lint`
- `yarn vitest run --project=node modules/web-mercator/test/spec modules/proj/test`
- full commit hook: 796 passed, 129 skipped
