### PR TITLE
chore: improve coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
         run: yarn test-node
 
       - name: Run headless tests with coverage
-        run: yarn cover
+        run: yarn test-coverage
 
       - name: Run lint
         run: yarn lint
@@ -73,3 +73,6 @@ jobs:
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage/lcov.info
+          format: lcov
+          fail-on-error: false

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "check:crs-types": "npx tsc --project test/types/crs/tsconfig.json",
     "check:projjson-types": "node scripts/generate-projjson-types.mjs --check",
     "generate:projjson-types": "node scripts/generate-projjson-types.mjs",
-    "cover": "ocular-test headless --coverage",
+    "cover": "yarn test-coverage",
     "lint": "ocular-lint",
     "metrics": "ocular-metrics",
     "playwright:install": "playwright install chromium",
@@ -30,6 +30,7 @@
     "test-browser": "ocular-test browser",
     "test-headless": "ocular-test headless",
     "test-node": "ocular-test node",
+    "test-coverage": "ocular-test headless --coverage",
     "test-pre-commit": "yarn lint && ocular-test node"
   },
   "devDependencies": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,8 +40,14 @@ export default getVitestConfig({
     }
   },
   coverage: {
-    include: ['modules/**/src/**/*.{js,ts}'],
+    provider: 'v8',
+    reporter: ['text', 'lcov'],
+    include: ['modules/**/src/**/*.{js,jsx,cjs,mjs,ts,tsx}'],
     exclude: [
+      '**/*disabled',
+      '**/deprecated',
+      '**/libs/**',
+      '**/wip/**',
       '**/*.d.ts',
       '**/*.map',
       '**/*.{bundle,min}.{js,ts}',
@@ -50,6 +56,7 @@ export default getVitestConfig({
       'test/**',
       'modules/**/test/**',
       'modules/**/wip/**'
-    ]
+    ],
+    excludeAfterRemap: true
   }
 });


### PR DESCRIPTION
## Summary
- make Vitest V8/LCOV coverage configuration explicit
- add a `test-coverage` script while preserving `cover`
- configure CI to upload `coverage/lcov.info` to Coveralls

## Verification
- `yarn lint`
- full headless coverage suite: 66 files passed, 792 tests passed, 70.1% statements