### PR TITLE
feat(geoarrow): add Arrow-independent columnar geometry kernels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Build code
         run: yarn build
 
+      - name: Check GeoArrow package boundary
+        run: yarn check:geoarrow-boundary
+
       - name: Check CRS type boundaries
         run: yarn check:crs-types
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v5.0.0-alpha.1
 
+- feat(geoarrow): Add runtime-independent physical descriptors, columnar kernels, codecs, builder,
+  polygon tessellation, and worker-transfer support
 - chore: Improve coverage reporting (#118)
 - feat: Use lowercase string literals for public API constants (#116)
 - feat(proj): Add lightweight EPSG3857 utilities (#117)

--- a/docs/modules/geoarrow/README.md
+++ b/docs/modules/geoarrow/README.md
@@ -1,0 +1,56 @@
+# @math.gl/geoarrow
+
+`@math.gl/geoarrow` is the Arrow-runtime-independent home for columnar geospatial math in math.gl.
+It defines a small immutable descriptor ABI over borrowed typed arrays and implements synchronous
+geometry kernels directly over that ABI.
+
+## Design goals
+
+- **Columnar first:** inspection, counting, and bounds do not create per-row geometry objects.
+- **Runtime neutral:** loaders and dataframe libraries adapt buffers at the package boundary.
+- **Zero-copy when possible:** slices and identity conversions retain descriptor and buffer identity.
+- **Complete geometry semantics:** XY, XYZ, XYM, and XYZM remain distinct; native, mixed, serialized,
+  null, empty, sliced, and chunked columns share one contract.
+- **Renderer ready:** polygon tessellation returns flat positions, row attribution, and indices
+  without importing a graphics runtime.
+- **Safe by default:** stable validation diagnostics and opt-in work/output limits guard untrusted
+  inputs.
+
+## Installation
+
+```bash
+npm install @math.gl/geoarrow
+```
+
+## First column
+
+```typescript
+import {GeoArrowBuilder, inspectGeoArrowColumn, getGeoArrowBounds} from '@math.gl/geoarrow';
+
+const points = GeoArrowBuilder.build(
+  [
+    {type: 'Point', coordinates: [-122.4, 37.8]},
+    null,
+    {type: 'Point', coordinates: [-73.9, 40.7]}
+  ],
+  {encoding: 'geoarrow.point', dimension: 'xy'}
+);
+
+inspectGeoArrowColumn(points);
+// {rowCount: 3, nullCount: 1, coordinateCount: 2, valid: true, ...}
+
+getGeoArrowBounds(points);
+// [-122.4, 37.8, -73.9, 40.7]
+```
+
+## Where to go next
+
+- [Physical layouts](./physical-layouts.md) explains every descriptor, nesting, offset, slice,
+  validity, union, and ownership rule.
+- [API reference](./api-reference/geoarrow.md) groups the public functions by task and documents
+  allocation and identity behavior.
+- [Migration guide](./migration-guide.md) maps the loaders.gl and luma.gl prototypes onto the
+  runtime-neutral API.
+
+The package README also contains complete examples for two-pass building, codecs, tessellation,
+resource limits, worker transfers, and runtime adapters.

--- a/docs/modules/geoarrow/api-reference/geoarrow.md
+++ b/docs/modules/geoarrow/api-reference/geoarrow.md
@@ -1,0 +1,170 @@
+# GeoArrow API reference
+
+All root functions are synchronous. Unless a function explicitly returns a new column or fills a
+caller-provided target, it treats descriptors and buffers as read-only.
+
+## Descriptors
+
+`GeoArrowColumn` is the semantic column envelope. `GeoArrowArray` is the union of the physical
+descriptor types:
+
+- `GeoArrowPrimitive`
+- `GeoArrowFixedSizeList`
+- `GeoArrowList`
+- `GeoArrowStruct`
+- `GeoArrowDenseUnion` and `GeoArrowDenseUnionChild`
+- `GeoArrowSerialized`
+- `GeoArrowValidity`
+
+Related semantic types include `GeoArrowEncoding`, `GeoArrowDimension`,
+`GeoArrowCoordinateLayout`, `GeoArrowGeometryValue`, and `GeoArrowBounds`.
+
+## Inspection, validation, traversal, and slicing
+
+### `inspectGeoArrowColumn(column)`
+
+Returns encoding, row/chunk/null/coordinate counts, storage kinds, and validation diagnostics. It
+does not decode WKB/WKT or construct per-row geometry objects.
+
+### `validateGeoArrowColumn(column)`
+
+Returns `{valid, issues}`. Each issue has a stable `code`, physical `path`, and human-readable
+`message`.
+
+### `visitGeoArrowCoordinates(column, visitor)`
+
+Visits native coordinate tuples in logical row order. The callback receives `(coordinate,
+rowIndex)`. The returned callback value is ignored; use `mapGeoArrowCoordinates` to allocate mapped
+output.
+
+### `sliceGeoArrowColumn(column, begin?, end?)`
+
+Returns a zero-copy logical slice while preserving chunk boundaries. A full slice returns `column`.
+
+### `sliceGeoArrowArray(array, begin, end)`
+
+Creates a zero-copy physical view by advancing logical offsets and bitmap bit offsets.
+
+### `getGeoArrowRowCount(column)` / `getGeoArrowVertexCount(column)`
+
+Count logical rows or native coordinate tuples directly over descriptors. Serialized columns must
+be decoded before vertex counting and therefore report zero.
+
+## Bounds and coordinate transforms
+
+### `getGeoArrowBounds(column)`
+
+Returns `[minX, minY, maxX, maxY]`, or `null` when no finite native coordinate exists.
+
+### `mapGeoArrowCoordinates(column, mapper, options?)`
+
+Allocates a new native column and applies `mapper(coordinate, rowIndex)` to each coordinate. Options
+select output dimension/layout and resource limits.
+
+### `mapGeoArrowCoordinatesInto(target, source, mapper, options?)`
+
+Maps into caller-owned coordinate buffers. Source and target must have compatible physical
+topology. The function returns `target` and never replaces its descriptors.
+
+## Physical conversion
+
+### `interleaveGeoArrowCoordinates(column)`
+
+Converts separated coordinates to fixed-size interleaved tuples. Already interleaved and
+non-coordinate columns are returned unchanged.
+
+### `convertGeoArrowColumn(column, options?)`
+
+Converts native geometry family, semantic dimension, or coordinate layout. Use the codec functions
+for serialized targets. Semantic ordinates map by name, so M is not reinterpreted as Z.
+
+### `normalizeGeoArrowUnion(column)`
+
+Sorts dense-union child descriptors by type ID. Dispatch and child buffers are retained. Non-union
+columns and already normalized unions are identity operations.
+
+### `rewindGeoArrow(column, options?)`
+
+Normalizes Polygon and MultiPolygon winding. `outer` is `counter-clockwise` by default; holes use
+the opposite orientation. If no ring changes, the original column is returned.
+
+## Builder
+
+### `new GeoArrowBuilder(options)`
+
+Creates a homogeneous native builder in `measure` or `write` mode. Append the same rows to both
+passes. Measure mode exposes exact `GeoArrowBuilderMeasurement` counts and can allocate a matching
+`GeoArrowBuilderTarget`. Write mode fills its target and `finish()` returns a borrowed column.
+
+### `GeoArrowBuilder.build(rows, options)`
+
+Convenience two-pass build with internal allocation.
+
+### `allocateGeoArrowBuilderTarget(measurement, options)`
+
+Allocates exact validity, coordinate, and offset buffers independently of a builder instance.
+
+### `makeGeoArrowColumnFromGeometryRows(rows, options?)`
+
+Builds homogeneous, geometry-collection, or mixed dense-union storage from materialized geometry
+values. Set `encoding: 'geoarrow.geometry'` to force a dense union for homogeneous values.
+
+## WKB and WKT
+
+### `decodeGeoArrowWKB(column)` / `decodeGeoArrowWKT(column)`
+
+Decode serialized chunks into native descriptors. Nulls, metadata, CRS, and edge semantics are
+preserved. Mixed-size serialized coordinates are normalized to the declared column dimension; the
+result may coalesce source chunks.
+
+### `encodeGeoArrowWKB(column)` / `encodeGeoArrowWKT(column)`
+
+Encode native rows into variable-width serialized descriptors. A column already in the requested
+encoding is returned unchanged.
+
+### `parseWKB(bytes)` / `writeWKB(geometry, dimension?)`
+
+Low-level single-geometry binary helpers. `parseWKB` also reports consumed byte length and rejects
+trailing bytes.
+
+### `parseWKT(text)` / `formatWKT(geometry, dimension?)`
+
+Low-level single-geometry text helpers, including dimension tokens, collections, MultiPoint syntax,
+and empty geometry.
+
+## Polygon tessellation
+
+### `tessellateGeoArrowPolygons(column, options?)`
+
+Returns `GeoArrowTessellation`:
+
+| Field | Meaning |
+| --- | --- |
+| `positions` | flat Float32 positions |
+| `sourceRowIndices` | top-level source row for each output vertex |
+| `indices` | Uint16 or Uint32 triangle indices |
+| `sourceDimension` | input tuple size |
+| `positionSize` | output tuple size |
+| `rowCount` | input logical rows |
+| `polygonCount` | primitive polygons tessellated |
+| `vertexCount` | output vertices |
+| `triangleCount` | output triangles |
+
+Options set `positionSize`, global `sourceRowOffset`, and resource limits. Polygon holes and
+MultiPolygon row attribution are preserved.
+
+## Limits and transfer
+
+### `assertGeoArrowResourceLimits(column, options?)`
+
+Checks optional maximum rows, coordinates, chunks, nesting depth, and estimated output bytes.
+
+### `getGeoArrowTransferList(column)`
+
+Returns unique `ArrayBuffer` instances reachable from the descriptor tree. Shared buffers are
+omitted and no buffer is detached.
+
+### `prepareGeoArrowTransfer(column)`
+
+Available from `@math.gl/geoarrow/worker`. Returns `{column, transferList}` for explicit use with
+`postMessage` or another structured-clone transport.

--- a/docs/modules/geoarrow/migration-guide.md
+++ b/docs/modules/geoarrow/migration-guide.md
@@ -1,0 +1,113 @@
+# Migrating GeoArrow work into math.gl
+
+`@math.gl/geoarrow` consolidates the reusable math from the loaders.gl GeoArrow tentpole work and
+luma.gl's private polygon/interleaving prototype. The key architectural change is that math.gl owns
+the runtime-neutral descriptor ABI and pure kernels; adapters remain with the runtime that owns the
+table objects.
+
+## Responsibility split
+
+| Concern | New owner |
+| --- | --- |
+| File/network loading, schemas, GeoParquet metadata | loaders.gl |
+| Adapting table/vector buffers to descriptors | loaders.gl or the table runtime integration |
+| Physical validation, traversal, bounds, mapping, winding | `@math.gl/geoarrow` |
+| WKB/WKT native codecs | `@math.gl/geoarrow` |
+| Polygon/MultiPolygon tessellation | `@math.gl/geoarrow` |
+| GPU buffer creation and rendering | luma.gl/deck.gl |
+| Worker scheduling and ownership policy | the application or loader |
+
+This boundary prevents a graphics package from owning general-purpose geospatial math and prevents
+math.gl from acquiring a table-runtime dependency.
+
+## From loaders.gl
+
+The tentpole implementation established the important conformance matrix: all geometry families,
+XY/XYZ/XYM/XYZM, separated/interleaved coordinates, regular/large offsets, null/empty/chunked rows,
+dense unions, geometry collections, WKB/WKT, bounds, mapping, winding, resource budgets, and
+transfer-list deduplication. Those semantics are represented directly in `GeoArrowColumn`.
+
+| Loader-facing concept | Runtime-neutral equivalent |
+| --- | --- |
+| Arrow `Vector` or `Data` | `GeoArrowColumn` / `GeoArrowArray` descriptor tree |
+| Arrow field layout oracle | adapter validation plus `validateGeoArrowColumn` |
+| `inspectGeoArrowVector` | `inspectGeoArrowColumn` |
+| `getGeoarrowVertexCount` | `getGeoArrowVertexCount` |
+| Arrow bounds kernel | `getGeoArrowBounds` |
+| Arrow coordinate mapper | `mapGeoArrowCoordinates` or `mapGeoArrowCoordinatesInto` |
+| Arrow builder output | `GeoArrowBuilderTarget` and borrowed descriptors |
+| Arrow WKB/WKT construction | plain serialized/native descriptors |
+| Arrow transfer traversal | descriptor `getGeoArrowTransferList` |
+
+The loaders adapter should inspect Arrow schema/type metadata, then expose the physical buffers. It
+should preserve chunking, view offsets, validity bit offsets, list offset width, union type IDs and
+child names, semantic dimension, coordinate layout, CRS, and edge metadata. It should not iterate
+rows through scalar accessors.
+
+## From luma.gl
+
+The private prototype coupled tessellation and interleaving to Arrow vectors, worker lifecycle, and
+renderer-oriented options. The math.gl API separates these layers:
+
+| luma prototype | New API |
+| --- | --- |
+| Arrow-specific interleaving | `interleaveGeoArrowCoordinates` |
+| Arrow dense-union normalization | `normalizeGeoArrowUnion` |
+| `tessellateArrowPolygons` | `tessellateGeoArrowPolygons` |
+| implicit worker fallback | explicit `@math.gl/geoarrow/worker` transfer payload |
+| renderer-owned result assumptions | positions, row indices, indices, dimensions, and counts |
+
+The tessellation kernel retains the prototype's important behavior: Polygon/MultiPolygon and dense
+union support, holes, source-row identity across multipolygon primitives, Float64-to-Float32 output,
+separated/interleaved equivalence, ZM preservation, large polygons, and Uint16/Uint32 index choice.
+Color expansion and GPU resource creation stay in the renderer because they are not geometry math.
+
+## Adapter pattern
+
+An integration should have one narrow conversion function:
+
+```typescript
+function adaptGeometryColumn(runtimeColumn: RuntimeColumn): GeoArrowColumn {
+  return {
+    encoding: readExtensionEncoding(runtimeColumn),
+    dimension: readSemanticDimension(runtimeColumn),
+    coordinateLayout: readCoordinateLayout(runtimeColumn),
+    chunks: runtimeColumn.chunks.map(adaptPhysicalArray),
+    spatialReference: readSpatialReference(runtimeColumn),
+    edges: readEdgeSemantics(runtimeColumn)
+  };
+}
+```
+
+`adaptPhysicalArray` should return borrowed views. Validate once:
+
+```typescript
+const column = adaptGeometryColumn(runtimeColumn);
+const validation = validateGeoArrowColumn(column);
+if (!validation.valid) throw new Error(validation.issues[0].message);
+```
+
+All downstream consumers can then share math.gl kernels without importing the runtime adapter.
+
+## Behavioral differences to account for
+
+- Root math.gl APIs are synchronous. Schedule them in a worker when necessary rather than making
+  the math API itself conditionally asynchronous.
+- Transfer-list creation does not transfer ownership. Only the caller's transport operation may
+  detach buffers.
+- `dimension` is semantic. XYM and XYZ are not interchangeable despite both having three values.
+- Serialized columns are decoded explicitly before native coordinate traversal.
+- Identity operations return the original descriptor. Preserve this when wrapping the API.
+- Tessellation omits duplicate closing coordinates and attributes every output vertex to the
+  top-level source row.
+- Runtime-specific field negotiation and metadata merge policy remain outside math.gl.
+
+## Suggested integration sequence
+
+1. Add a zero-copy adapter and fixture tests in loaders.gl.
+2. Compare descriptor inspection, count, bounds, conversion, WKB/WKT, and tessellation against the
+   existing Arrow-backed fixtures.
+3. Replace luma's private interleaving and tessellation imports with `@math.gl/geoarrow`.
+4. Keep worker orchestration in luma/loaders and use `prepareGeoArrowTransfer` for payloads.
+5. Delete the duplicated kernels only after exact output fixtures and buffer-identity assertions
+   pass in the consumer repositories.

--- a/docs/modules/geoarrow/physical-layouts.md
+++ b/docs/modules/geoarrow/physical-layouts.md
@@ -1,0 +1,157 @@
+# GeoArrow physical layouts
+
+The descriptor model separates physical storage from the library that owns it. Descriptors are
+plain, immutable TypeScript objects; typed arrays are borrowed views into caller-owned memory.
+
+## Column envelope
+
+```typescript
+type GeoArrowColumn = Readonly<{
+  encoding: GeoArrowEncoding;
+  dimension: 'xy' | 'xyz' | 'xym' | 'xyzm';
+  coordinateLayout: 'interleaved' | 'separated' | null;
+  chunks: readonly GeoArrowArray[];
+  spatialReference?: SpatialReference | null;
+  edges?: 'planar' | 'spherical';
+  metadata?: Readonly<Record<string, unknown>>;
+}>;
+```
+
+The envelope contains semantic facts that cannot be recovered reliably from raw buffers. Each
+chunk has the same encoding, dimension, and coordinate layout but owns its logical `length`,
+validity, and physical views.
+
+## Geometry nesting
+
+Let `C` mean one coordinate tuple and `L<T>` mean a variable-size list.
+
+| Encoding | Descriptor shape | Row meaning |
+| --- | --- | --- |
+| `geoarrow.point` | `C` | one coordinate |
+| `geoarrow.linestring` | `L<C>` | coordinates in one line |
+| `geoarrow.multipoint` | `L<C>` | points in one multi-point |
+| `geoarrow.polygon` | `L<L<C>>` | rings in one polygon |
+| `geoarrow.multilinestring` | `L<L<C>>` | lines in one multi-line |
+| `geoarrow.multipolygon` | `L<L<L<C>>>` | polygons, rings, coordinates |
+| `geoarrow.geometry` | dense union | one selected child geometry |
+| `geoarrow.geometrycollection` | `L<dense union>` | zero or more child geometries |
+
+LineString and MultiPoint deliberately share a physical shape; their extension encoding supplies
+the semantic difference. The same is true for Polygon and MultiLineString.
+
+## Coordinate layouts
+
+Interleaved coordinates are a `GeoArrowFixedSizeList` whose child is a numeric primitive. Its
+`size` must match the semantic dimension.
+
+```text
+XY   [x0, y0, x1, y1, ...]
+XYZ  [x0, y0, z0, x1, y1, z1, ...]
+XYM  [x0, y0, m0, x1, y1, m1, ...]
+XYZM [x0, y0, z0, m0, x1, y1, z1, m1, ...]
+```
+
+Separated coordinates are a `GeoArrowStruct` with primitive children named `x`, `y`, and the
+dimension-appropriate `z` and/or `m`. The semantic names matter: a three-component tuple is not
+enough to decide whether the third component is Z or M.
+
+## Primitive views
+
+`GeoArrowPrimitive` supports logical views without creating typed-array slices:
+
+```typescript
+{
+  kind: 'primitive',
+  length: 100,
+  values: sourceValues,
+  offset: 2,
+  stride: 4
+}
+```
+
+Logical value `i` is read at `values[offset + i * stride]`. This can expose one component of an
+application-owned interleaved buffer without copying it.
+
+## Variable lists and Int64 offsets
+
+A `GeoArrowList` borrows `Int32Array` or `BigInt64Array` offsets. `offset` selects the first logical
+row in the offsets view. `offsetBase` maps absolute producer offsets back into the supplied child
+view:
+
+```text
+first = offsets[offset + row]     - offsetBase
+last  = offsets[offset + row + 1] - offsetBase
+```
+
+Offsets must be monotonic and within child storage. Int64 values must also be representable as safe
+JavaScript integers before a child view can be indexed.
+
+## Validity and slices
+
+Every nesting level may carry a `GeoArrowValidity`:
+
+```typescript
+{values: nullBitmap, bitOffset: 5}
+```
+
+Bit `bitOffset + i` corresponds to logical value `i`; one means valid. `sliceGeoArrowArray` advances
+the logical offset and bitmap bit offset while retaining the same backing buffers. A full slice is
+an identity operation.
+
+Null and empty are distinct:
+
+- a null row has a cleared top-level validity bit;
+- an empty variable geometry is valid and has equal adjacent list offsets;
+- an empty point is conventionally represented by non-finite coordinate ordinates.
+
+## Dense unions
+
+`GeoArrowDenseUnion` contains:
+
+- one `typeIds` entry per logical row;
+- one `valueOffsets` entry per logical row;
+- named children with stable integer type IDs;
+- an optional root validity bitmap.
+
+For row `i`, `typeIds[offset + i]` selects a child and `valueOffsets[offset + i]` selects the value
+inside that child. Child arrays remain compact; union rows do not require placeholder values.
+
+`normalizeGeoArrowUnion` sorts child descriptors by type ID without changing dispatch buffers or
+child buffer identity. Geometry collections use a variable list whose child is the same dense-union
+shape, so nested members share the union traversal machinery.
+
+## Serialized values
+
+`GeoArrowSerialized` stores WKB as `binary` and WKT as `utf8`. It borrows a byte buffer plus Int32 or
+Int64 offsets and supports the same `offset`, `offsetBase`, validity, slicing, and chunk rules as
+native geometry.
+
+Inspection does not decode serialized payloads. Decode explicitly with `decodeGeoArrowWKB` or
+`decodeGeoArrowWKT` before coordinate kernels.
+
+## Boxes
+
+`geoarrow.box` uses struct storage with canonical minimum ordinates followed by maximum ordinates:
+`xmin`, `ymin`, optional `zmin`/`mmin`, `xmax`, `ymax`, and optional `zmax`/`mmax`.
+
+## Borrowing and ownership
+
+Descriptors never claim ownership of buffers. The package follows these rules:
+
+1. read-only kernels do not write or detach;
+2. zero-copy slices retain backing buffer identity;
+3. identity conversions return the original descriptor;
+4. allocating kernels return new descriptors and buffers;
+5. builder write mode borrows caller-provided targets;
+6. `getGeoArrowTransferList` only reports transferable buffers—the caller decides whether to
+   transfer and detach them.
+
+Do not mutate borrowed input while a kernel is running. If concurrent writers are required, use
+application-level synchronization or immutable snapshots.
+
+## Validation boundary
+
+Call `validateGeoArrowColumn` after adapting data from an external runtime. Diagnostics have stable
+codes and physical paths. Validation checks logical lengths, bitmap coverage, primitive views,
+fixed-list sizes, list bounds, coordinate field names, list nesting, serialized storage kind, and
+dense-union dispatch.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -121,6 +121,16 @@
       },
       {
         "type": "category",
+        "label": "@math.gl/geoarrow",
+        "items": [
+          "modules/geoarrow/README",
+          "modules/geoarrow/physical-layouts",
+          "modules/geoarrow/api-reference/geoarrow",
+          "modules/geoarrow/migration-guide"
+        ]
+      },
+      {
+        "type": "category",
         "label": "@math.gl/geoid",
         "items": [
           "modules/geoid/README",

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -56,6 +56,7 @@ Highlights:
 - glTF 2.1 box, capsule, cylinder, plane and sphere analytic shapes in `@math.gl/culling`.
 - New expression evaluator module
 - New standards-based CRS definitions module and modernized proj4 support.
+- New runtime-independent GeoArrow descriptor and columnar geometry module.
 - New typed-array geometry utilities module.
 - Functionality additions to improve 3D Tiles support in loaders.gl.
 - Stronger type guarantees for math classes via the new sized array types.
@@ -83,6 +84,19 @@ Highlights:
   default/unknown/absent state.
 - Adds a comprehensive CRS developer guide covering standards, serialization versus semantics,
   axis order, dynamic and vertical CRS, transformation boundaries, and integration guidance.
+
+**`@math.gl/geoarrow`** (NEW MODULE)
+
+- Defines borrowed physical descriptors for native, mixed, box, WKB, and WKT geometry columns
+  without requiring an Arrow runtime.
+- Traverses and validates interleaved or separated XY/XYZ/XYM/XYZM coordinates, Int32/Int64 list
+  offsets, sliced validity bitmaps, chunks, dense unions, and geometry collections.
+- Adds synchronous bounds, vertex-count, coordinate-map, layout-conversion, winding, and resource
+  limit kernels.
+- Adds a two-pass builder, WKB/WKT codecs, Polygon/MultiPolygon tessellation, and an optional worker
+  transfer subpath.
+- Moves reusable GeoArrow math out of loaders.gl and luma.gl prototypes while leaving runtime
+  adapters, worker scheduling, and GPU resources with their owning libraries.
 
 **`@math.gl/proj4`**
 

--- a/modules/geoarrow/README.md
+++ b/modules/geoarrow/README.md
@@ -1,0 +1,299 @@
+# @math.gl/geoarrow
+
+Columnar geometry descriptors and synchronous CPU kernels for GeoArrow-compatible memory layouts.
+
+`@math.gl/geoarrow` works directly over borrowed typed arrays. It deliberately does not require an
+Arrow runtime: a loader, dataframe, database client, or application can adapt its buffers to the
+small descriptor ABI and use the same validation, conversion, codec, and tessellation kernels.
+
+## Install
+
+```bash
+npm install @math.gl/geoarrow
+```
+
+## Why descriptors?
+
+Columnar geometry should not need to become GeoJSON objects before useful work can begin. A
+`GeoArrowColumn` describes the physical buffers that already exist:
+
+- primitive numeric buffers;
+- interleaved fixed-size coordinate tuples or separated coordinate structs;
+- Int32 or Int64 variable-list offsets;
+- validity bitmaps with non-byte-aligned slice offsets;
+- dense unions for mixed geometry and list-of-union geometry collections;
+- binary WKB and UTF-8 WKT buffers;
+- one or more chunks.
+
+Descriptors borrow their buffers. Read-only kernels never mutate or detach them. Identity
+conversions return the original column object, so callers can use descriptor and `ArrayBuffer`
+identity as a reliable zero-copy signal.
+
+## Quick start
+
+```typescript
+import {
+  GeoArrowBuilder,
+  getGeoArrowBounds,
+  getGeoArrowVertexCount,
+  mapGeoArrowCoordinates
+} from '@math.gl/geoarrow';
+
+const column = GeoArrowBuilder.build(
+  [
+    {type: 'LineString', coordinates: [[-122.4, 37.8], [-73.9, 40.7]]},
+    null
+  ],
+  {
+    encoding: 'geoarrow.linestring',
+    dimension: 'xy',
+    coordinateLayout: 'interleaved',
+    offsetType: 'int32'
+  }
+);
+
+getGeoArrowVertexCount(column); // 2
+getGeoArrowBounds(column); // [-122.4, 37.8, -73.9, 40.7]
+
+const shifted = mapGeoArrowCoordinates(column, ([x, y]) => [x + 360, y]);
+```
+
+## Physical nesting
+
+`coord` below is either an interleaved `fixed-size-list` or a separated `struct`.
+
+| Encoding | Physical descriptor tree |
+| --- | --- |
+| Point | `coord` |
+| LineString | `list<coord>` |
+| MultiPoint | `list<coord>` |
+| Polygon | `list<list<coord>>` |
+| MultiLineString | `list<list<coord>>` |
+| MultiPolygon | `list<list<list<coord>>>` |
+| Geometry | `dense-union<geometry children>` |
+| GeometryCollection | `list<dense-union<geometry children>>` |
+| Box | `struct<minimum and maximum ordinates>` |
+| WKB | `serialized<binary>` |
+| WKT | `serialized<utf8>` |
+
+This example describes two XY points without copying the source coordinates:
+
+```typescript
+import type {GeoArrowColumn} from '@math.gl/geoarrow';
+
+const values = new Float64Array([10, 20, 30, 40]);
+const points: GeoArrowColumn = {
+  encoding: 'geoarrow.point',
+  dimension: 'xy',
+  coordinateLayout: 'interleaved',
+  chunks: [{
+    kind: 'fixed-size-list',
+    length: 2,
+    size: 2,
+    child: {kind: 'primitive', length: 4, values}
+  }]
+};
+```
+
+For separated coordinates, use canonical ordinate names. `x` and `y` are always present; `z` and
+`m` follow the semantic dimension and are never treated as interchangeable.
+
+```typescript
+const separatedPoints: GeoArrowColumn = {
+  encoding: 'geoarrow.point',
+  dimension: 'xym',
+  coordinateLayout: 'separated',
+  chunks: [{
+    kind: 'struct',
+    length: 2,
+    children: {
+      x: {kind: 'primitive', length: 2, values: new Float64Array([10, 30])},
+      y: {kind: 'primitive', length: 2, values: new Float64Array([20, 40])},
+      m: {kind: 'primitive', length: 2, values: new Float64Array([100, 200])}
+    }
+  }]
+};
+```
+
+## Slices, validity, and chunks
+
+Every physical descriptor has a logical `length` and may have a validity bitmap. A set bit means
+valid. `bitOffset` makes sliced null bitmaps explicit, including slices that do not begin at a byte
+boundary.
+
+Variable-width descriptors have an `offset` into their offsets buffer and an optional `offsetBase`.
+The child range for row `i` is:
+
+```text
+[offsets[offset + i] - offsetBase, offsets[offset + i + 1] - offsetBase)
+```
+
+Both `Int32Array` and `BigInt64Array` offsets are supported. Int64 values are checked before
+conversion to JavaScript numbers; values outside the safe integer range are rejected.
+
+`sliceGeoArrowColumn` creates zero-copy descriptor views and preserves chunk boundaries.
+`validateGeoArrowColumn` checks physical bounds, validity coverage, monotonic offsets, coordinate
+layout, list depth, and dense-union dispatch before an expensive operation is attempted.
+
+## Two-pass building
+
+`GeoArrowBuilder` has a measure pass and a write pass. This avoids growing arrays and lets an owner
+allocate buffers in a pool, shared arena, or renderer-specific allocator.
+
+```typescript
+const rows = [
+  {type: 'Polygon' as const, coordinates: [[[0, 0], [4, 0], [0, 4], [0, 0]]]},
+  null
+];
+const options = {
+  encoding: 'geoarrow.polygon' as const,
+  dimension: 'xy' as const,
+  coordinateLayout: 'separated' as const,
+  offsetType: 'int64' as const
+};
+
+const measure = new GeoArrowBuilder({...options, mode: 'measure'});
+rows.forEach(row => measure.append(row));
+
+const target = measure.allocateTarget();
+const write = new GeoArrowBuilder({...options, mode: 'write', target});
+rows.forEach(row => write.append(row));
+
+const polygons = write.finish(); // borrows target; no Arrow objects are constructed
+```
+
+`GeoArrowBuilder.build(rows, options)` is the convenient form when custom allocation is not needed.
+
+## Inspection and read-only kernels
+
+The following operations traverse descriptors directly and do not create per-row geometry objects:
+
+- `inspectGeoArrowColumn`
+- `validateGeoArrowColumn`
+- `getGeoArrowVertexCount`
+- `getGeoArrowBounds`
+- `visitGeoArrowCoordinates`
+- `getGeoArrowTransferList`
+
+Allocating transforms such as coordinate mapping, physical conversion, winding normalization, and
+codec decoding return new descriptors. Their inputs remain unchanged.
+
+## Conversion and winding
+
+```typescript
+import {
+  convertGeoArrowColumn,
+  interleaveGeoArrowCoordinates,
+  rewindGeoArrow
+} from '@math.gl/geoarrow';
+
+const interleaved = interleaveGeoArrowCoordinates(separatedPoints);
+const xyz = convertGeoArrowColumn(interleaved, {dimension: 'xyz'});
+const normalized = rewindGeoArrow(polygons, {outer: 'counter-clockwise'});
+```
+
+Semantic dimensions are mapped by ordinate name. Converting XYM to XYZ produces a zero Z; it does
+not reinterpret M as elevation. Requesting `geoarrow.geometry` always produces a dense union, even
+when every current row has the same geometry family.
+
+## WKB and WKT
+
+The codecs consume and produce the same plain descriptors:
+
+```typescript
+import {
+  decodeGeoArrowWKB,
+  encodeGeoArrowWKB,
+  decodeGeoArrowWKT,
+  encodeGeoArrowWKT
+} from '@math.gl/geoarrow';
+
+const wkb = encodeGeoArrowWKB(polygons);
+const decoded = decodeGeoArrowWKB(wkb);
+const wkt = encodeGeoArrowWKT(decoded);
+const nativeAgain = decodeGeoArrowWKT(wkt);
+```
+
+WKB decoding accepts little- or big-endian geometry, ISO Z/M/ZM type offsets, EWKB Z/M/SRID flags,
+multi-geometries, and nested geometry collections. WKT supports all corresponding geometry
+families, dimension tokens, both MultiPoint spellings, and empties. Decoding normalizes mixed-size
+serialized coordinates to the column's declared semantic dimension.
+
+## Polygon tessellation
+
+```typescript
+import {tessellateGeoArrowPolygons} from '@math.gl/geoarrow';
+
+const mesh = tessellateGeoArrowPolygons(polygons, {
+  positionSize: 3,
+  sourceRowOffset: 1000
+});
+
+// mesh.positions        Float32Array
+// mesh.sourceRowIndices Uint32Array
+// mesh.indices          Uint16Array or Uint32Array
+```
+
+Polygon, MultiPolygon, and polygon members of dense unions or geometry collections are supported.
+Holes are retained, duplicate closing coordinates are omitted from mesh vertices, and every output
+vertex retains its top-level source row. Tessellation uses `@math.gl/polygon` and is synchronous.
+
+## Resource limits
+
+Potentially allocating operations accept limits, and limits can also be checked directly:
+
+```typescript
+import {assertGeoArrowResourceLimits} from '@math.gl/geoarrow';
+
+assertGeoArrowResourceLimits(column, {
+  maximumRows: 1_000_000,
+  maximumCoordinates: 50_000_000,
+  maximumChunks: 10_000,
+  maximumNestingDepth: 8,
+  maximumOutputBytes: 1_000_000_000
+});
+```
+
+## Workers and transfer ownership
+
+Root APIs are synchronous. Worker-specific payload preparation is isolated in the optional subpath:
+
+```typescript
+import {prepareGeoArrowTransfer} from '@math.gl/geoarrow/worker';
+
+const payload = prepareGeoArrowTransfer(column);
+worker.postMessage(payload.column, {transfer: payload.transferList});
+```
+
+`prepareGeoArrowTransfer` only lists unique transferable buffers; it does not detach them. The
+explicit `postMessage` call transfers ownership. Shared buffers are omitted because they are not
+transferable.
+
+## Adapting another columnar runtime
+
+Keep runtime-specific objects at the boundary. Read their physical buffers and construct a
+`GeoArrowColumn`; do not call scalar `get(row)` methods. The adapter should preserve:
+
+1. chunk boundaries and logical lengths;
+2. typed-array byte offsets and strides;
+3. list offsets, including 64-bit offsets;
+4. validity bitmap plus bit offset;
+5. dense-union type IDs, value offsets, and child names;
+6. extension encoding, semantic dimension, coordinate layout, CRS, and edge metadata.
+
+Run `validateGeoArrowColumn` once at the trust boundary. Downstream math then remains independent of
+the producer runtime.
+
+## API groups
+
+- Descriptors: `GeoArrowColumn`, `GeoArrowArray`, all physical array descriptor types
+- Layout: `inspectGeoArrowColumn`, `validateGeoArrowColumn`, slicing and traversal
+- Kernels: count, bounds, map, interleave, convert, rewind, union normalization, resource limits
+- Construction: `GeoArrowBuilder`, `makeGeoArrowColumnFromGeometryRows`
+- Codecs: WKB/WKT encode, decode, parse, and format
+- Meshes: `tessellateGeoArrowPolygons`
+- Transfer: `getGeoArrowTransferList`, plus `@math.gl/geoarrow/worker`
+
+See the math.gl documentation for the full [physical-layout guide](../../docs/modules/geoarrow/physical-layouts.md),
+[API reference](../../docs/modules/geoarrow/api-reference/geoarrow.md), and
+[migration guide](../../docs/modules/geoarrow/migration-guide.md).

--- a/modules/geoarrow/package.json
+++ b/modules/geoarrow/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@math.gl/geoarrow",
+  "description": "Arrow-independent GeoArrow physical layouts and geometry kernels",
+  "license": "MIT",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "version": "5.0.0-alpha.1",
+  "keywords": [
+    "geoarrow",
+    "geospatial",
+    "columnar",
+    "typed-array",
+    "math"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/math.gl.git"
+  },
+  "types": "dist/index.d.ts",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./worker": {
+      "types": "./dist/worker.d.ts",
+      "import": "./dist/worker.js",
+      "require": "./dist/worker.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "sideEffects": false,
+  "dependencies": {
+    "@math.gl/crs": "5.0.0-alpha.1",
+    "@math.gl/polygon": "5.0.0-alpha.1",
+    "@math.gl/types": "5.0.0-alpha.1"
+  }
+}

--- a/modules/geoarrow/scripts/check-package-boundary.mjs
+++ b/modules/geoarrow/scripts/check-package-boundary.mjs
@@ -1,0 +1,46 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {readdir, readFile} from 'node:fs/promises';
+import {join} from 'node:path';
+
+const packageRoot = new URL('..', import.meta.url);
+const forbiddenPackage = ['apache', 'arrow'].join('-');
+const manifest = JSON.parse(await readFile(new URL('package.json', packageRoot), 'utf8'));
+const dependencySections = ['dependencies', 'peerDependencies', 'optionalDependencies'];
+
+for (const section of dependencySections) {
+  if (manifest[section]?.[forbiddenPackage]) {
+    throw new Error(`${section} must not reference ${forbiddenPackage}`);
+  }
+}
+
+for (const directory of ['src', 'dist']) {
+  const root = new URL(`${directory}/`, packageRoot);
+  let files = [];
+  try {
+    files = await collectFiles(root.pathname);
+  } catch (error) {
+    if (error?.code === 'ENOENT' && directory === 'dist') continue;
+    throw error;
+  }
+  for (const file of files) {
+    if (!/\.(?:[cm]?js|ts)$/.test(file)) continue;
+    const source = await readFile(file, 'utf8');
+    if (source.toLowerCase().includes(forbiddenPackage)) {
+      throw new Error(`${file} references forbidden package ${forbiddenPackage}`);
+    }
+  }
+}
+
+async function collectFiles(directory) {
+  const entries = await readdir(directory, {withFileTypes: true});
+  const files = [];
+  for (const entry of entries) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...(await collectFiles(path)));
+    else files.push(path);
+  }
+  return files;
+}

--- a/modules/geoarrow/src/builder.ts
+++ b/modules/geoarrow/src/builder.ts
@@ -1,0 +1,567 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {
+  GeoArrowArray,
+  GeoArrowColumn,
+  GeoArrowCoordinateLayout,
+  GeoArrowDenseUnion,
+  GeoArrowDimension,
+  GeoArrowEncoding,
+  GeoArrowGeometryValue,
+  GeoArrowOffsets,
+  GeoArrowStruct
+} from './types';
+import {
+  getGeoArrowDimensionSize,
+  getGeoArrowEncodingForGeometry,
+  getGeoArrowGeometryType
+} from './types';
+
+/** Concrete native encodings accepted by {@link GeoArrowBuilder}. */
+export type GeoArrowBuilderEncoding = Exclude<
+  GeoArrowEncoding,
+  | 'geoarrow.geometry'
+  | 'geoarrow.geometrycollection'
+  | 'geoarrow.box'
+  | 'geoarrow.wkb'
+  | 'geoarrow.wkt'
+>;
+
+/** Buffer counts produced by a measure pass. */
+export type GeoArrowBuilderMeasurement = Readonly<{
+  length: number;
+  nullCount: number;
+  coordinateCount: number;
+  geometryOffsetCount: number;
+  partOffsetCount: number;
+  ringOffsetCount: number;
+}>;
+
+/** Caller-owned buffers filled by a builder write pass. */
+export type GeoArrowBuilderTarget = {
+  validity: Uint8Array;
+  coordinates:
+    | Float32Array
+    | Float64Array
+    | {
+        x: Float32Array | Float64Array;
+        y: Float32Array | Float64Array;
+        z?: Float32Array | Float64Array;
+        m?: Float32Array | Float64Array;
+      };
+  geometryOffsets?: GeoArrowOffsets;
+  partOffsets?: GeoArrowOffsets;
+  ringOffsets?: GeoArrowOffsets;
+};
+
+/** Common builder options. */
+export type GeoArrowBuilderOptions = Readonly<{
+  encoding: GeoArrowBuilderEncoding;
+  dimension?: GeoArrowDimension;
+  coordinateLayout?: GeoArrowCoordinateLayout;
+  offsetType?: 'int32' | 'int64';
+  coordinateType?: 'float32' | 'float64';
+}>;
+
+/** Options for materializing a column from geometry values. */
+export type GeoArrowColumnFromRowsOptions = Omit<GeoArrowBuilderOptions, 'encoding'> &
+  Readonly<{
+    /** Forces homogeneous values into a dense-union column. */
+    encoding?: 'geoarrow.geometry';
+  }>;
+
+/** Measure-pass options. */
+export type GeoArrowBuilderMeasureOptions = GeoArrowBuilderOptions & Readonly<{mode: 'measure'}>;
+
+/** Write-pass options. */
+export type GeoArrowBuilderWriteOptions = GeoArrowBuilderOptions &
+  Readonly<{mode: 'write'; target: GeoArrowBuilderTarget}>;
+
+/** Options accepted by the incremental builder. */
+export type GeoArrowBuilderModeOptions =
+  | GeoArrowBuilderMeasureOptions
+  | GeoArrowBuilderWriteOptions;
+
+/**
+ * Two-pass writer for homogeneous native GeoArrow geometry columns.
+ *
+ * Feed the same rows to a measure builder, allocate its target, and then feed them to a write
+ * builder. The write result borrows the supplied target buffers.
+ */
+export class GeoArrowBuilder {
+  readonly encoding: GeoArrowBuilderEncoding;
+  readonly dimension: GeoArrowDimension;
+  readonly coordinateLayout: GeoArrowCoordinateLayout;
+  readonly offsetType: 'int32' | 'int64';
+  readonly coordinateType: 'float32' | 'float64';
+  private readonly mode: 'measure' | 'write';
+  private readonly target?: GeoArrowBuilderTarget;
+  private length = 0;
+  private nullCount = 0;
+  private coordinateCount = 0;
+  private partCount = 0;
+  private ringCount = 0;
+
+  constructor(options: GeoArrowBuilderModeOptions) {
+    this.mode = options.mode;
+    this.encoding = options.encoding;
+    this.dimension = options.dimension || 'xy';
+    this.coordinateLayout = options.coordinateLayout || 'interleaved';
+    this.offsetType = options.offsetType || 'int32';
+    this.coordinateType = options.coordinateType || 'float64';
+    this.target = options.mode === 'write' ? options.target : undefined;
+    if (this.target) this.initializeTargetOffsets(this.target);
+  }
+
+  /** Appends one geometry row or null. */
+  append(geometry: GeoArrowGeometryValue | null | undefined): this {
+    const rowIndex = this.length++;
+    if (!geometry) {
+      this.nullCount++;
+      this.appendNull(rowIndex);
+      return this;
+    }
+    const expectedType = getGeoArrowGeometryType(this.encoding);
+    if (geometry.type !== expectedType) {
+      throw new Error(`GeoArrowBuilder for ${this.encoding} cannot append ${geometry.type}`);
+    }
+    if (geometry.type === 'GeometryCollection') {
+      throw new Error('GeoArrowBuilder only accepts concrete geometry families');
+    }
+    if (this.target) setValidityBit(this.target.validity, rowIndex);
+
+    const depth = getBuilderDepth(this.encoding);
+    const coordinates = geometry.coordinates as readonly unknown[];
+    if (depth === 0) {
+      this.writeCoordinate(coordinates as readonly number[]);
+    } else if (depth === 1) {
+      this.writeCoordinateList(coordinates as readonly (readonly number[])[]);
+      this.writeOffset(this.target?.geometryOffsets, rowIndex + 1, this.coordinateCount);
+    } else if (depth === 2) {
+      for (const part of coordinates as readonly (readonly (readonly number[])[])[]) {
+        this.writeCoordinateList(part);
+        this.partCount++;
+        this.writeOffset(this.target?.partOffsets, this.partCount, this.coordinateCount);
+      }
+      this.writeOffset(this.target?.geometryOffsets, rowIndex + 1, this.partCount);
+    } else {
+      for (const polygon of coordinates as readonly (readonly (readonly (readonly number[])[])[])[]) {
+        for (const ring of polygon) {
+          this.writeCoordinateList(ring);
+          this.ringCount++;
+          this.writeOffset(this.target?.ringOffsets, this.ringCount, this.coordinateCount);
+        }
+        this.partCount++;
+        this.writeOffset(this.target?.partOffsets, this.partCount, this.ringCount);
+      }
+      this.writeOffset(this.target?.geometryOffsets, rowIndex + 1, this.partCount);
+    }
+    return this;
+  }
+
+  /** Returns current exact allocation counts. */
+  getMeasurement(): GeoArrowBuilderMeasurement {
+    const depth = getBuilderDepth(this.encoding);
+    return {
+      length: this.length,
+      nullCount: this.nullCount,
+      coordinateCount: this.coordinateCount,
+      geometryOffsetCount: depth >= 1 ? this.length + 1 : 0,
+      partOffsetCount: depth >= 2 ? this.partCount + 1 : 0,
+      ringOffsetCount: depth >= 3 ? this.ringCount + 1 : 0
+    };
+  }
+
+  /** Allocates a write target from the current measure pass. */
+  allocateTarget(): GeoArrowBuilderTarget {
+    if (this.mode !== 'measure') throw new Error('Only a measure builder can allocate a target');
+    return allocateGeoArrowBuilderTarget(this.getMeasurement(), {
+      encoding: this.encoding,
+      dimension: this.dimension,
+      coordinateLayout: this.coordinateLayout,
+      offsetType: this.offsetType,
+      coordinateType: this.coordinateType
+    });
+  }
+
+  /** Finishes a write pass and returns a one-chunk borrowed column. */
+  finish(): GeoArrowColumn {
+    if (!this.target) throw new Error('A measure builder has no finished column');
+    const measurement = this.getMeasurement();
+    assertTargetCapacity(this.target, measurement, getGeoArrowDimensionSize(this.dimension));
+    const coordinates = makeCoordinateArray(
+      this.target.coordinates,
+      measurement.coordinateCount,
+      this.dimension,
+      this.coordinateLayout
+    );
+    const depth = getBuilderDepth(this.encoding);
+    let chunk: GeoArrowArray = coordinates;
+    if (depth >= 3) {
+      chunk = {
+        kind: 'list',
+        length: this.ringCount,
+        offsets: this.target.ringOffsets!,
+        child: chunk
+      };
+    }
+    if (depth >= 2) {
+      chunk = {
+        kind: 'list',
+        length: this.partCount,
+        offsets: this.target.partOffsets!,
+        child: chunk
+      };
+    }
+    if (depth >= 1) {
+      chunk = {
+        kind: 'list',
+        length: this.length,
+        offsets: this.target.geometryOffsets!,
+        child: chunk,
+        validity: {values: this.target.validity}
+      };
+    } else {
+      chunk = {...chunk, validity: {values: this.target.validity}};
+    }
+    return {
+      encoding: this.encoding,
+      dimension: this.dimension,
+      coordinateLayout: this.coordinateLayout,
+      chunks: [chunk]
+    };
+  }
+
+  /** Builds a homogeneous column using an internal measure/write pair. */
+  static build(
+    rows: readonly (GeoArrowGeometryValue | null | undefined)[],
+    options: GeoArrowBuilderOptions
+  ): GeoArrowColumn {
+    const measure = new GeoArrowBuilder({...options, mode: 'measure'});
+    for (const row of rows) measure.append(row);
+    const write = new GeoArrowBuilder({
+      ...options,
+      mode: 'write',
+      target: measure.allocateTarget()
+    });
+    for (const row of rows) write.append(row);
+    return write.finish();
+  }
+
+  private appendNull(rowIndex: number): void {
+    const depth = getBuilderDepth(this.encoding);
+    if (depth === 0) {
+      this.writeCoordinate(new Array(getGeoArrowDimensionSize(this.dimension)).fill(0));
+    } else {
+      this.writeOffset(
+        this.target?.geometryOffsets,
+        rowIndex + 1,
+        depth === 1 ? this.coordinateCount : this.partCount
+      );
+    }
+  }
+
+  private writeCoordinateList(coordinates: readonly (readonly number[])[]): void {
+    for (const coordinate of coordinates) this.writeCoordinate(coordinate);
+  }
+
+  private writeCoordinate(coordinate: readonly number[]): void {
+    const size = getGeoArrowDimensionSize(this.dimension);
+    if (coordinate.length !== size) {
+      throw new Error(`Expected ${size} coordinate values for ${this.dimension}`);
+    }
+    if (this.target)
+      writeCoordinate(this.target.coordinates, this.coordinateCount, coordinate, this.dimension);
+    this.coordinateCount++;
+  }
+
+  private writeOffset(target: GeoArrowOffsets | undefined, index: number, value: number): void {
+    if (!target) return;
+    if (target instanceof BigInt64Array) target[index] = BigInt(value);
+    else target[index] = value;
+  }
+
+  private initializeTargetOffsets(target: GeoArrowBuilderTarget): void {
+    this.writeOffset(target.geometryOffsets, 0, 0);
+    this.writeOffset(target.partOffsets, 0, 0);
+    this.writeOffset(target.ringOffsets, 0, 0);
+  }
+}
+
+/** Allocates exact buffers for one measured builder pass. */
+export function allocateGeoArrowBuilderTarget(
+  measurement: GeoArrowBuilderMeasurement,
+  options: GeoArrowBuilderOptions
+): GeoArrowBuilderTarget {
+  const dimension = options.dimension || 'xy';
+  const size = getGeoArrowDimensionSize(dimension);
+  const FloatArray = options.coordinateType === 'float32' ? Float32Array : Float64Array;
+  const coordinateLayout = options.coordinateLayout || 'interleaved';
+  const coordinates =
+    coordinateLayout === 'interleaved'
+      ? new FloatArray(measurement.coordinateCount * size)
+      : makeSeparatedCoordinateTarget(FloatArray, measurement.coordinateCount, dimension);
+  const OffsetArray = options.offsetType === 'int64' ? BigInt64Array : Int32Array;
+  return {
+    validity: new Uint8Array(Math.ceil(measurement.length / 8)),
+    coordinates,
+    geometryOffsets: measurement.geometryOffsetCount
+      ? new OffsetArray(measurement.geometryOffsetCount)
+      : undefined,
+    partOffsets: measurement.partOffsetCount
+      ? new OffsetArray(measurement.partOffsetCount)
+      : undefined,
+    ringOffsets: measurement.ringOffsetCount
+      ? new OffsetArray(measurement.ringOffsetCount)
+      : undefined
+  };
+}
+
+/** Builds a concrete or dense-union column from materialized rows. */
+export function makeGeoArrowColumnFromGeometryRows(
+  rows: readonly (GeoArrowGeometryValue | null)[],
+  options: GeoArrowColumnFromRowsOptions = {}
+): GeoArrowColumn {
+  const geometryTypes = [...new Set(rows.filter(Boolean).map(row => row!.type))];
+  const dimension = options.dimension || inferRowsDimension(rows);
+  if (options.encoding === 'geoarrow.geometry') {
+    return {
+      encoding: 'geoarrow.geometry',
+      dimension,
+      coordinateLayout: options.coordinateLayout || 'interleaved',
+      chunks: [makeDenseUnionArray(rows, options, dimension)]
+    };
+  }
+  if (geometryTypes.length === 0) {
+    return GeoArrowBuilder.build(rows, {...options, dimension, encoding: 'geoarrow.point'});
+  }
+  if (geometryTypes.length === 1 && geometryTypes[0] !== 'GeometryCollection') {
+    return GeoArrowBuilder.build(rows, {
+      ...options,
+      dimension,
+      encoding: getGeoArrowEncodingForGeometry(geometryTypes[0]) as GeoArrowBuilderEncoding
+    });
+  }
+  if (geometryTypes.length === 1 && geometryTypes[0] === 'GeometryCollection') {
+    return {
+      encoding: 'geoarrow.geometrycollection',
+      dimension,
+      coordinateLayout: options.coordinateLayout || 'interleaved',
+      chunks: [makeGeometryCollectionArray(rows, options, dimension)]
+    };
+  }
+  return {
+    encoding: 'geoarrow.geometry',
+    dimension,
+    coordinateLayout: options.coordinateLayout || 'interleaved',
+    chunks: [makeDenseUnionArray(rows, options, dimension)]
+  };
+}
+
+function makeDenseUnionArray(
+  rows: readonly (GeoArrowGeometryValue | null)[],
+  options: GeoArrowColumnFromRowsOptions,
+  dimension: GeoArrowDimension
+): GeoArrowDenseUnion {
+  const nonNullTypes = [...new Set(rows.filter(Boolean).map(row => row!.type))];
+  const fallbackType = nonNullTypes[0] || 'Point';
+  const childRows = new Map<GeoArrowGeometryValue['type'], GeoArrowGeometryValue[]>();
+  for (const type of nonNullTypes.length ? nonNullTypes : [fallbackType]) childRows.set(type, []);
+  const typeIds = new Int8Array(rows.length);
+  const valueOffsets = new Int32Array(rows.length);
+  const validity = new Uint8Array(Math.ceil(rows.length / 8));
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    const geometry = rows[rowIndex];
+    const type = geometry?.type || fallbackType;
+    const values = childRows.get(type) || [];
+    typeIds[rowIndex] = getGeometryTypeId(type);
+    valueOffsets[rowIndex] = values.length;
+    if (geometry) {
+      values.push(geometry);
+      childRows.set(type, values);
+      setValidityBit(validity, rowIndex);
+    }
+  }
+  const children = [...childRows.entries()]
+    .sort(([left], [right]) => getGeometryTypeId(left) - getGeometryTypeId(right))
+    .map(([type, values]) => {
+      const data =
+        type === 'GeometryCollection'
+          ? makeGeometryCollectionArray(values, options, dimension)
+          : GeoArrowBuilder.build(values, {
+              ...options,
+              dimension,
+              encoding: getGeoArrowEncodingForGeometry(type) as GeoArrowBuilderEncoding
+            }).chunks[0];
+      return {name: type, typeId: getGeometryTypeId(type), data};
+    });
+  return {
+    kind: 'dense-union',
+    length: rows.length,
+    typeIds,
+    valueOffsets,
+    children,
+    validity: {values: validity}
+  };
+}
+
+function makeGeometryCollectionArray(
+  rows: readonly (GeoArrowGeometryValue | null)[],
+  options: GeoArrowColumnFromRowsOptions,
+  dimension: GeoArrowDimension
+): GeoArrowArray {
+  const offsets = new Int32Array(rows.length + 1);
+  const validity = new Uint8Array(Math.ceil(rows.length / 8));
+  const flattened: GeoArrowGeometryValue[] = [];
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    const row = rows[rowIndex];
+    if (row?.type === 'GeometryCollection') {
+      flattened.push(...row.geometries);
+      setValidityBit(validity, rowIndex);
+    }
+    offsets[rowIndex + 1] = flattened.length;
+  }
+  return {
+    kind: 'list',
+    length: rows.length,
+    offsets,
+    child: makeDenseUnionArray(flattened, options, dimension),
+    validity: {values: validity}
+  };
+}
+
+function makeCoordinateArray(
+  coordinates: GeoArrowBuilderTarget['coordinates'],
+  coordinateCount: number,
+  dimension: GeoArrowDimension,
+  layout: GeoArrowCoordinateLayout
+): GeoArrowArray {
+  const size = getGeoArrowDimensionSize(dimension);
+  if (layout === 'interleaved') {
+    const values = coordinates as Float32Array | Float64Array;
+    return {
+      kind: 'fixed-size-list',
+      length: coordinateCount,
+      size,
+      child: {kind: 'primitive', length: coordinateCount * size, values}
+    };
+  }
+  const separated = coordinates as Exclude<
+    GeoArrowBuilderTarget['coordinates'],
+    Float32Array | Float64Array
+  >;
+  const children: Record<string, GeoArrowArray> = {
+    x: {kind: 'primitive', length: coordinateCount, values: separated.x},
+    y: {kind: 'primitive', length: coordinateCount, values: separated.y}
+  };
+  if (separated.z) {
+    children['z'] = {kind: 'primitive', length: coordinateCount, values: separated.z};
+  }
+  if (separated.m) {
+    children['m'] = {kind: 'primitive', length: coordinateCount, values: separated.m};
+  }
+  return {kind: 'struct', length: coordinateCount, children} as GeoArrowStruct;
+}
+
+function makeSeparatedCoordinateTarget(
+  FloatArray: Float32ArrayConstructor | Float64ArrayConstructor,
+  count: number,
+  dimension: GeoArrowDimension
+): Exclude<GeoArrowBuilderTarget['coordinates'], Float32Array | Float64Array> {
+  return {
+    x: new FloatArray(count),
+    y: new FloatArray(count),
+    z: dimension === 'xyz' || dimension === 'xyzm' ? new FloatArray(count) : undefined,
+    m: dimension === 'xym' || dimension === 'xyzm' ? new FloatArray(count) : undefined
+  };
+}
+
+function writeCoordinate(
+  target: GeoArrowBuilderTarget['coordinates'],
+  coordinateIndex: number,
+  coordinate: readonly number[],
+  dimension: GeoArrowDimension
+): void {
+  if (target instanceof Float32Array || target instanceof Float64Array) {
+    target.set(coordinate, coordinateIndex * coordinate.length);
+    return;
+  }
+  target.x[coordinateIndex] = coordinate[0];
+  target.y[coordinateIndex] = coordinate[1];
+  if (dimension === 'xyz') target.z![coordinateIndex] = coordinate[2];
+  else if (dimension === 'xym') target.m![coordinateIndex] = coordinate[2];
+  else if (dimension === 'xyzm') {
+    target.z![coordinateIndex] = coordinate[2];
+    target.m![coordinateIndex] = coordinate[3];
+  }
+}
+
+function setValidityBit(validity: Uint8Array, index: number): void {
+  validity[index >> 3] |= 1 << (index & 7);
+}
+
+function getBuilderDepth(encoding: GeoArrowBuilderEncoding): 0 | 1 | 2 | 3 {
+  switch (encoding) {
+    case 'geoarrow.point':
+      return 0;
+    case 'geoarrow.linestring':
+    case 'geoarrow.multipoint':
+      return 1;
+    case 'geoarrow.polygon':
+    case 'geoarrow.multilinestring':
+      return 2;
+    case 'geoarrow.multipolygon':
+      return 3;
+  }
+}
+
+function getGeometryTypeId(type: GeoArrowGeometryValue['type']): number {
+  return (
+    [
+      'Point',
+      'LineString',
+      'Polygon',
+      'MultiPoint',
+      'MultiLineString',
+      'MultiPolygon',
+      'GeometryCollection'
+    ].indexOf(type) + 1
+  );
+}
+
+function inferRowsDimension(rows: readonly (GeoArrowGeometryValue | null)[]): GeoArrowDimension {
+  let size = 2;
+  const visit = (value: unknown): void => {
+    if (!Array.isArray(value) || value.length === 0) return;
+    if (typeof value[0] === 'number') size = Math.max(size, value.length);
+    else for (const child of value) visit(child);
+  };
+  for (const row of rows) {
+    if (!row) continue;
+    if (row.type === 'GeometryCollection') {
+      for (const geometry of row.geometries) {
+        if (geometry.type !== 'GeometryCollection') visit(geometry.coordinates);
+      }
+    } else visit(row.coordinates);
+  }
+  return size >= 4 ? 'xyzm' : size === 3 ? 'xyz' : 'xy';
+}
+
+function assertTargetCapacity(
+  target: GeoArrowBuilderTarget,
+  measurement: GeoArrowBuilderMeasurement,
+  size: number
+): void {
+  const coordinateLength =
+    target.coordinates instanceof Float32Array || target.coordinates instanceof Float64Array
+      ? target.coordinates.length / size
+      : target.coordinates.x.length;
+  if (
+    coordinateLength < measurement.coordinateCount ||
+    target.validity.length * 8 < measurement.length
+  ) {
+    throw new Error('GeoArrowBuilder target is smaller than its measured output');
+  }
+}

--- a/modules/geoarrow/src/builder.ts
+++ b/modules/geoarrow/src/builder.ts
@@ -538,13 +538,15 @@ function inferRowsDimension(rows: readonly (GeoArrowGeometryValue | null)[]): Ge
     if (typeof value[0] === 'number') size = Math.max(size, value.length);
     else for (const child of value) visit(child);
   };
+  const visitGeometry = (geometry: GeoArrowGeometryValue): void => {
+    if (geometry.type === 'GeometryCollection') {
+      for (const child of geometry.geometries) visitGeometry(child);
+    } else {
+      visit(geometry.coordinates);
+    }
+  };
   for (const row of rows) {
-    if (!row) continue;
-    if (row.type === 'GeometryCollection') {
-      for (const geometry of row.geometries) {
-        if (geometry.type !== 'GeometryCollection') visit(geometry.coordinates);
-      }
-    } else visit(row.coordinates);
+    if (row) visitGeometry(row);
   }
   return size >= 4 ? 'xyzm' : size === 3 ? 'xyz' : 'xy';
 }

--- a/modules/geoarrow/src/codecs.ts
+++ b/modules/geoarrow/src/codecs.ts
@@ -1,0 +1,597 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {
+  GeoArrowColumn,
+  GeoArrowDimension,
+  GeoArrowGeometryValue,
+  GeoArrowSerialized
+} from './types';
+import {getGeoArrowDimensionSize} from './types';
+import {makeGeoArrowColumnFromGeometryRows} from './builder';
+import {getGeoArrowOffset, isGeoArrowValueValid, materializeGeoArrowRows} from './layout';
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+/** Decodes a GeoArrow WKB column into native physical geometry buffers. */
+export function decodeGeoArrowWKB(column: GeoArrowColumn): GeoArrowColumn {
+  if (column.encoding !== 'geoarrow.wkb') throw new Error('Expected a geoarrow.wkb column');
+  const rows = normalizeRowsToDimension(
+    decodeSerializedRows(column, bytes => parseWKB(bytes).geometry),
+    column.dimension
+  );
+  return copyMetadata(
+    column,
+    makeGeoArrowColumnFromGeometryRows(rows, {dimension: column.dimension})
+  );
+}
+
+/** Encodes a native GeoArrow column as variable-width WKB bytes. */
+export function encodeGeoArrowWKB(column: GeoArrowColumn): GeoArrowColumn {
+  if (column.encoding === 'geoarrow.wkb') return column;
+  const rows = materializeGeoArrowRows(column);
+  const values = rows.map(row => (row ? writeWKB(row, column.dimension) : null));
+  return copyMetadata(column, makeSerializedColumn(values, 'geoarrow.wkb', column.dimension));
+}
+
+/** Decodes a GeoArrow WKT column into native physical geometry buffers. */
+export function decodeGeoArrowWKT(column: GeoArrowColumn): GeoArrowColumn {
+  if (column.encoding !== 'geoarrow.wkt') throw new Error('Expected a geoarrow.wkt column');
+  const rows = normalizeRowsToDimension(
+    decodeSerializedRows(column, bytes => parseWKT(textDecoder.decode(bytes))),
+    column.dimension
+  );
+  return copyMetadata(
+    column,
+    makeGeoArrowColumnFromGeometryRows(rows, {dimension: column.dimension})
+  );
+}
+
+/** Encodes a native GeoArrow column as variable-width UTF-8 WKT. */
+export function encodeGeoArrowWKT(column: GeoArrowColumn): GeoArrowColumn {
+  if (column.encoding === 'geoarrow.wkt') return column;
+  const rows = materializeGeoArrowRows(column);
+  const values = rows.map(row =>
+    row ? textEncoder.encode(formatWKT(row, column.dimension)) : null
+  );
+  return copyMetadata(column, makeSerializedColumn(values, 'geoarrow.wkt', column.dimension));
+}
+
+/** Parses one WKB geometry value. */
+export function parseWKB(bytes: Uint8Array): {geometry: GeoArrowGeometryValue; byteLength: number} {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const result = readWKBGeometry(view, 0);
+  if (result.offset !== bytes.byteLength) throw new Error('WKB contains trailing bytes');
+  return {geometry: result.geometry, byteLength: result.offset};
+}
+
+/** Writes one geometry as little-endian ISO WKB. */
+export function writeWKB(
+  geometry: GeoArrowGeometryValue,
+  dimension: GeoArrowDimension = inferGeometryDimension(geometry)
+): Uint8Array {
+  const bytes: number[] = [];
+  writeWKBGeometry(bytes, geometry, dimension);
+  return Uint8Array.from(bytes);
+}
+
+/** Parses one WKT geometry value. */
+export function parseWKT(text: string): GeoArrowGeometryValue {
+  const parser = new WKTParser(text);
+  const geometry = parser.parseGeometry();
+  parser.assertComplete();
+  return geometry;
+}
+
+/** Formats one geometry as WKT. */
+export function formatWKT(
+  geometry: GeoArrowGeometryValue,
+  dimension: GeoArrowDimension = inferGeometryDimension(geometry)
+): string {
+  const dimensionToken = dimension === 'xy' ? '' : ` ${dimension.slice(2).toUpperCase()}`;
+  if (geometry.type === 'GeometryCollection') {
+    if (geometry.geometries.length === 0) return `GEOMETRYCOLLECTION${dimensionToken} EMPTY`;
+    return `GEOMETRYCOLLECTION${dimensionToken} (${geometry.geometries.map(child => formatWKT(child, dimension)).join(', ')})`;
+  }
+  const type = geometry.type.toUpperCase();
+  if (isEmptyCoordinates(geometry.coordinates)) return `${type}${dimensionToken} EMPTY`;
+  return `${type}${dimensionToken} ${formatCoordinateNesting(geometry.coordinates, getGeometryDepth(geometry.type))}`;
+}
+
+function normalizeRowsToDimension(
+  rows: readonly (GeoArrowGeometryValue | null)[],
+  dimension: GeoArrowDimension
+): Array<GeoArrowGeometryValue | null> {
+  const size = getGeoArrowDimensionSize(dimension);
+  const normalizeGeometry = (geometry: GeoArrowGeometryValue): GeoArrowGeometryValue => {
+    if (geometry.type === 'GeometryCollection') {
+      return {...geometry, geometries: geometry.geometries.map(normalizeGeometry)};
+    }
+    return {
+      ...geometry,
+      coordinates: normalizeCoordinateNesting(geometry.coordinates, size)
+    } as GeoArrowGeometryValue;
+  };
+  return rows.map(row => (row ? normalizeGeometry(row) : null));
+}
+
+function normalizeCoordinateNesting(value: readonly unknown[], size: number): unknown {
+  if (value.length === 0) return [];
+  if (typeof value[0] === 'number') {
+    const coordinate = (value as readonly number[]).slice(0, size);
+    while (coordinate.length < size) coordinate.push(0);
+    return coordinate;
+  }
+  return value.map(child => normalizeCoordinateNesting(child as readonly unknown[], size));
+}
+
+function isEmptyCoordinates(value: readonly unknown[]): boolean {
+  if (value.length === 0) return true;
+  if (typeof value[0] === 'number') {
+    return (value as readonly number[]).every(component => !Number.isFinite(component));
+  }
+  return value.every(child => isEmptyCoordinates(child as readonly unknown[]));
+}
+
+function decodeSerializedRows(
+  column: GeoArrowColumn,
+  decoder: (bytes: Uint8Array) => GeoArrowGeometryValue
+): Array<GeoArrowGeometryValue | null> {
+  const rows: Array<GeoArrowGeometryValue | null> = [];
+  for (const chunk of column.chunks) {
+    if (chunk.kind !== 'serialized') throw new Error('Serialized column contains native storage');
+    for (let rowIndex = 0; rowIndex < chunk.length; rowIndex++) {
+      if (!isGeoArrowValueValid(chunk.validity, rowIndex)) {
+        rows.push(null);
+        continue;
+      }
+      const bytes = getSerializedBytes(chunk, rowIndex);
+      rows.push(decoder(bytes));
+    }
+  }
+  return rows;
+}
+
+function getSerializedBytes(array: GeoArrowSerialized, rowIndex: number): Uint8Array {
+  const offsetIndex = (array.offset || 0) + rowIndex;
+  const baseValue = array.offsetBase ?? 0;
+  const base = typeof baseValue === 'bigint' ? Number(baseValue) : baseValue;
+  const first = getGeoArrowOffset(array.offsets, offsetIndex) - base;
+  const last = getGeoArrowOffset(array.offsets, offsetIndex + 1) - base;
+  return array.values.subarray(first, last);
+}
+
+function makeSerializedColumn(
+  rows: readonly (Uint8Array | null)[],
+  encoding: 'geoarrow.wkb' | 'geoarrow.wkt',
+  dimension: GeoArrowDimension
+): GeoArrowColumn {
+  let byteLength = 0;
+  for (const row of rows) byteLength += row?.byteLength || 0;
+  const values = new Uint8Array(byteLength);
+  const offsets = new Int32Array(rows.length + 1);
+  const validity = new Uint8Array(Math.ceil(rows.length / 8));
+  let byteOffset = 0;
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    const row = rows[rowIndex];
+    if (row) {
+      values.set(row, byteOffset);
+      byteOffset += row.byteLength;
+      validity[rowIndex >> 3] |= 1 << (rowIndex & 7);
+    }
+    offsets[rowIndex + 1] = byteOffset;
+  }
+  const chunk: GeoArrowSerialized = {
+    kind: 'serialized',
+    encoding: encoding === 'geoarrow.wkb' ? 'binary' : 'utf8',
+    length: rows.length,
+    offsets,
+    values,
+    validity: {values: validity}
+  };
+  return {encoding, dimension, coordinateLayout: null, chunks: [chunk]};
+}
+
+type WKBReadResult = {geometry: GeoArrowGeometryValue; offset: number};
+
+function readWKBGeometry(view: DataView, startOffset: number): WKBReadResult {
+  let offset = startOffset;
+  assertRemaining(view, offset, 5);
+  const byteOrder = view.getUint8(offset++);
+  if (byteOrder !== 0 && byteOrder !== 1) throw new Error('Invalid WKB byte order');
+  const littleEndian = byteOrder === 1;
+  let rawType = view.getUint32(offset, littleEndian);
+  offset += 4;
+  const hasZFlag = Boolean(rawType & 0x80000000);
+  const hasMFlag = Boolean(rawType & 0x40000000);
+  const hasSrid = Boolean(rawType & 0x20000000);
+  rawType &= 0x1fffffff;
+  let dimensions = 2;
+  if (rawType >= 3000) {
+    dimensions = 4;
+    rawType -= 3000;
+  } else if (rawType >= 2000) {
+    dimensions = 3;
+    rawType -= 2000;
+  } else if (rawType >= 1000) {
+    dimensions = 3;
+    rawType -= 1000;
+  } else {
+    dimensions += Number(hasZFlag) + Number(hasMFlag);
+  }
+  if (hasSrid) {
+    assertRemaining(view, offset, 4);
+    offset += 4;
+  }
+  const readCoordinate = (): number[] => {
+    assertRemaining(view, offset, dimensions * 8);
+    const coordinate = new Array<number>(dimensions);
+    for (let index = 0; index < dimensions; index++) {
+      coordinate[index] = view.getFloat64(offset, littleEndian);
+      offset += 8;
+    }
+    return coordinate;
+  };
+  const readCount = (): number => {
+    assertRemaining(view, offset, 4);
+    const count = view.getUint32(offset, littleEndian);
+    offset += 4;
+    if (count > 100_000_000) throw new Error('WKB element count exceeds resource limit');
+    return count;
+  };
+  const readCoordinates = (): number[][] => {
+    const count = readCount();
+    return Array.from({length: count}, readCoordinate);
+  };
+
+  switch (rawType) {
+    case 1:
+      return {geometry: {type: 'Point', coordinates: readCoordinate()}, offset};
+    case 2:
+      return {geometry: {type: 'LineString', coordinates: readCoordinates()}, offset};
+    case 3: {
+      const rings = Array.from({length: readCount()}, readCoordinates);
+      return {geometry: {type: 'Polygon', coordinates: rings}, offset};
+    }
+    case 4:
+    case 5:
+    case 6:
+    case 7: {
+      const count = readCount();
+      const children: GeoArrowGeometryValue[] = [];
+      for (let index = 0; index < count; index++) {
+        const child = readWKBGeometry(view, offset);
+        children.push(child.geometry);
+        offset = child.offset;
+      }
+      if (rawType === 4) {
+        return {
+          geometry: {
+            type: 'MultiPoint',
+            coordinates: children.map(assertPoint).map(point => point.coordinates)
+          },
+          offset
+        };
+      }
+      if (rawType === 5) {
+        return {
+          geometry: {
+            type: 'MultiLineString',
+            coordinates: children.map(assertLineString).map(line => line.coordinates)
+          },
+          offset
+        };
+      }
+      if (rawType === 6) {
+        return {
+          geometry: {
+            type: 'MultiPolygon',
+            coordinates: children.map(assertPolygon).map(polygon => polygon.coordinates)
+          },
+          offset
+        };
+      }
+      return {geometry: {type: 'GeometryCollection', geometries: children}, offset};
+    }
+    default:
+      throw new Error(`Unsupported WKB geometry type ${rawType}`);
+  }
+}
+
+function writeWKBGeometry(
+  bytes: number[],
+  geometry: GeoArrowGeometryValue,
+  dimension: GeoArrowDimension
+): void {
+  bytes.push(1);
+  const size = getGeoArrowDimensionSize(dimension);
+  const dimensionOffset =
+    dimension === 'xyz' ? 1000 : dimension === 'xym' ? 2000 : dimension === 'xyzm' ? 3000 : 0;
+  writeUint32(bytes, getWKBType(geometry.type) + dimensionOffset);
+  const writeCoordinate = (coordinate: readonly number[]): void => {
+    for (let index = 0; index < size; index++) writeFloat64(bytes, coordinate[index] ?? 0);
+  };
+  const writeCoordinates = (coordinates: readonly (readonly number[])[]): void => {
+    writeUint32(bytes, coordinates.length);
+    for (const coordinate of coordinates) writeCoordinate(coordinate);
+  };
+  switch (geometry.type) {
+    case 'Point':
+      writeCoordinate(geometry.coordinates);
+      break;
+    case 'LineString':
+      writeCoordinates(geometry.coordinates);
+      break;
+    case 'Polygon':
+      writeUint32(bytes, geometry.coordinates.length);
+      for (const ring of geometry.coordinates) writeCoordinates(ring);
+      break;
+    case 'MultiPoint':
+      writeUint32(bytes, geometry.coordinates.length);
+      for (const coordinate of geometry.coordinates)
+        writeWKBGeometry(bytes, {type: 'Point', coordinates: coordinate}, dimension);
+      break;
+    case 'MultiLineString':
+      writeUint32(bytes, geometry.coordinates.length);
+      for (const coordinates of geometry.coordinates)
+        writeWKBGeometry(bytes, {type: 'LineString', coordinates}, dimension);
+      break;
+    case 'MultiPolygon':
+      writeUint32(bytes, geometry.coordinates.length);
+      for (const coordinates of geometry.coordinates)
+        writeWKBGeometry(bytes, {type: 'Polygon', coordinates}, dimension);
+      break;
+    case 'GeometryCollection':
+      writeUint32(bytes, geometry.geometries.length);
+      for (const child of geometry.geometries) writeWKBGeometry(bytes, child, dimension);
+      break;
+  }
+}
+
+class WKTParser {
+  private readonly tokens: string[];
+  private index = 0;
+  private dimensionSize = 2;
+
+  constructor(text: string) {
+    this.tokens =
+      text.match(/[A-Za-z_]+|[(),]|[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?/g) || [];
+  }
+
+  parseGeometry(): GeoArrowGeometryValue {
+    const type = this.takeWord().toUpperCase();
+    if (['Z', 'M', 'ZM'].includes(this.peek().toUpperCase())) {
+      const dimension = this.take().toUpperCase();
+      this.dimensionSize = dimension === 'ZM' ? 4 : 3;
+    }
+    if (this.peek().toUpperCase() === 'EMPTY') {
+      this.take();
+      return makeEmptyGeometry(type);
+    }
+    if (type === 'GEOMETRYCOLLECTION') {
+      this.expect('(');
+      const geometries: GeoArrowGeometryValue[] = [];
+      if (this.peek() !== ')') {
+        do geometries.push(this.parseGeometry());
+        while (this.takeIf(','));
+      }
+      this.expect(')');
+      return {type: 'GeometryCollection', geometries};
+    }
+    const depth = getWKTDepth(type);
+    const coordinates = this.parseCoordinateNesting(depth);
+    return makeGeometry(type, coordinates);
+  }
+
+  assertComplete(): void {
+    if (this.index !== this.tokens.length) throw new Error(`Unexpected WKT token ${this.peek()}`);
+  }
+
+  private parseCoordinateNesting(depth: number): unknown {
+    this.expect('(');
+    if (depth === 0) {
+      const coordinate = this.readCoordinate();
+      this.expect(')');
+      return coordinate;
+    }
+    const values: unknown[] = [];
+    if (this.peek() !== ')') {
+      do {
+        if (depth === 1 && this.peek() !== '(') values.push(this.readCoordinate());
+        else values.push(this.parseCoordinateNesting(depth - 1));
+      } while (this.takeIf(','));
+    }
+    this.expect(')');
+    return values;
+  }
+
+  private readCoordinate(): number[] {
+    const values: number[] = [];
+    while (values.length < this.dimensionSize && isNumberToken(this.peek())) {
+      values.push(Number(this.take()));
+    }
+    if (values.length < 2) throw new Error('WKT coordinate requires at least two numbers');
+    return values;
+  }
+
+  private peek(): string {
+    return this.tokens[this.index] || '';
+  }
+
+  private take(): string {
+    if (this.index >= this.tokens.length) throw new Error('Unexpected end of WKT');
+    return this.tokens[this.index++];
+  }
+
+  private takeWord(): string {
+    const token = this.take();
+    if (!/^[A-Za-z_]+$/.test(token)) throw new Error(`Expected WKT geometry type, found ${token}`);
+    return token;
+  }
+
+  private takeIf(token: string): boolean {
+    if (this.peek() !== token) return false;
+    this.index++;
+    return true;
+  }
+
+  private expect(token: string): void {
+    const actual = this.take();
+    if (actual !== token) throw new Error(`Expected WKT token ${token}, found ${actual}`);
+  }
+}
+
+function formatCoordinateNesting(value: readonly unknown[], depth: number): string {
+  if (depth === 0) return `(${(value as readonly number[]).map(formatNumber).join(' ')})`;
+  return `(${value
+    .map(child => {
+      if (depth === 1) return (child as readonly number[]).map(formatNumber).join(' ');
+      return formatCoordinateNesting(child as readonly unknown[], depth - 1);
+    })
+    .join(', ')})`;
+}
+
+function formatNumber(value: number): string {
+  if (!Number.isFinite(value)) return 'NaN';
+  return String(value);
+}
+
+function getGeometryDepth(
+  type: Exclude<GeoArrowGeometryValue['type'], 'GeometryCollection'>
+): number {
+  switch (type) {
+    case 'Point':
+      return 0;
+    case 'LineString':
+    case 'MultiPoint':
+      return 1;
+    case 'Polygon':
+    case 'MultiLineString':
+      return 2;
+    case 'MultiPolygon':
+      return 3;
+  }
+}
+
+function getWKTDepth(type: string): number {
+  switch (type) {
+    case 'POINT':
+      return 0;
+    case 'LINESTRING':
+      return 1;
+    case 'POLYGON':
+      return 2;
+    case 'MULTIPOINT':
+      return 1;
+    case 'MULTILINESTRING':
+      return 2;
+    case 'MULTIPOLYGON':
+      return 3;
+    default:
+      throw new Error(`Unsupported WKT geometry type ${type}`);
+  }
+}
+
+function makeGeometry(type: string, coordinates: unknown): GeoArrowGeometryValue {
+  const canonical = type[0] + type.slice(1).toLowerCase();
+  const names: Record<string, GeoArrowGeometryValue['type']> = {
+    Point: 'Point',
+    Linestring: 'LineString',
+    Polygon: 'Polygon',
+    Multipoint: 'MultiPoint',
+    Multilinestring: 'MultiLineString',
+    Multipolygon: 'MultiPolygon'
+  };
+  const geometryType = names[canonical];
+  if (!geometryType) throw new Error(`Unsupported WKT geometry type ${type}`);
+  return {type: geometryType, coordinates} as GeoArrowGeometryValue;
+}
+
+function makeEmptyGeometry(type: string): GeoArrowGeometryValue {
+  if (type === 'GEOMETRYCOLLECTION') return {type: 'GeometryCollection', geometries: []};
+  if (type === 'POINT') return {type: 'Point', coordinates: [Number.NaN, Number.NaN]};
+  return makeGeometry(type, []);
+}
+
+function getWKBType(type: GeoArrowGeometryValue['type']): number {
+  return (
+    [
+      'Point',
+      'LineString',
+      'Polygon',
+      'MultiPoint',
+      'MultiLineString',
+      'MultiPolygon',
+      'GeometryCollection'
+    ].indexOf(type) + 1
+  );
+}
+
+function writeUint32(bytes: number[], value: number): void {
+  bytes.push(value & 255, (value >>> 8) & 255, (value >>> 16) & 255, (value >>> 24) & 255);
+}
+
+function writeFloat64(bytes: number[], value: number): void {
+  const buffer = new ArrayBuffer(8);
+  new DataView(buffer).setFloat64(0, value, true);
+  bytes.push(...new Uint8Array(buffer));
+}
+
+function assertRemaining(view: DataView, offset: number, length: number): void {
+  if (offset + length > view.byteLength) throw new Error('Unexpected end of WKB');
+}
+
+function assertPoint(
+  value: GeoArrowGeometryValue
+): Extract<GeoArrowGeometryValue, {type: 'Point'}> {
+  if (value.type !== 'Point') throw new Error('WKB MultiPoint contains a non-Point child');
+  return value;
+}
+
+function assertLineString(
+  value: GeoArrowGeometryValue
+): Extract<GeoArrowGeometryValue, {type: 'LineString'}> {
+  if (value.type !== 'LineString')
+    throw new Error('WKB MultiLineString contains a non-LineString child');
+  return value;
+}
+
+function assertPolygon(
+  value: GeoArrowGeometryValue
+): Extract<GeoArrowGeometryValue, {type: 'Polygon'}> {
+  if (value.type !== 'Polygon') throw new Error('WKB MultiPolygon contains a non-Polygon child');
+  return value;
+}
+
+function isNumberToken(token: string): boolean {
+  return token !== '' && Number.isFinite(Number(token));
+}
+
+function inferGeometryDimension(geometry: GeoArrowGeometryValue): GeoArrowDimension {
+  const size = getGeometryDimensionSize(geometry);
+  return size >= 4 ? 'xyzm' : size === 3 ? 'xyz' : 'xy';
+}
+
+function getGeometryDimensionSize(geometry: GeoArrowGeometryValue): number {
+  if (geometry.type === 'GeometryCollection') {
+    return Math.max(2, ...geometry.geometries.map(getGeometryDimensionSize));
+  }
+  return getCoordinateDimension(geometry.coordinates);
+}
+
+function getCoordinateDimension(value: readonly unknown[]): number {
+  if (value.length === 0) return 2;
+  if (typeof value[0] === 'number') return value.length;
+  return Math.max(2, ...value.map(child => getCoordinateDimension(child as readonly unknown[])));
+}
+
+function copyMetadata(source: GeoArrowColumn, target: GeoArrowColumn): GeoArrowColumn {
+  return {
+    ...target,
+    spatialReference: source.spatialReference,
+    edges: source.edges,
+    metadata: source.metadata
+  };
+}

--- a/modules/geoarrow/src/codecs.ts
+++ b/modules/geoarrow/src/codecs.ts
@@ -356,8 +356,7 @@ class WKTParser {
   private dimensionSize = 2;
 
   constructor(text: string) {
-    this.tokens =
-      text.match(/[A-Za-z_]+|[(),]|[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?/g) || [];
+    this.tokens = tokenizeWKT(text);
   }
 
   parseGeometry(): GeoArrowGeometryValue {
@@ -441,6 +440,23 @@ class WKTParser {
     const actual = this.take();
     if (actual !== token) throw new Error(`Expected WKT token ${token}, found ${actual}`);
   }
+}
+
+function tokenizeWKT(text: string): string[] {
+  const tokens: string[] = [];
+  const tokenPattern = /[A-Za-z_]+|[(),]|[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?/gy;
+  let index = 0;
+  while (index < text.length) {
+    while (index < text.length && /\s/.test(text[index])) index++;
+    if (index === text.length) break;
+    tokenPattern.lastIndex = index;
+    const match = tokenPattern.exec(text);
+    if (!match)
+      throw new Error(`Unexpected WKT character ${JSON.stringify(text[index])} at ${index}`);
+    tokens.push(match[0]);
+    index = tokenPattern.lastIndex;
+  }
+  return tokens;
 }
 
 function formatCoordinateNesting(value: readonly unknown[], depth: number): string {

--- a/modules/geoarrow/src/index.ts
+++ b/modules/geoarrow/src/index.ts
@@ -1,0 +1,97 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export type {
+  GeoArrowArray,
+  GeoArrowArrayBase,
+  GeoArrowBox,
+  GeoArrowBounds,
+  GeoArrowColumn,
+  GeoArrowCoordinateLayout,
+  GeoArrowCoordinateMapper,
+  GeoArrowDenseUnion,
+  GeoArrowDenseUnionChild,
+  GeoArrowDimension,
+  GeoArrowEncoding,
+  GeoArrowFixedSizeList,
+  GeoArrowGeometryValue,
+  GeoArrowList,
+  GeoArrowNumericArray,
+  GeoArrowOffsets,
+  GeoArrowPrimitive,
+  GeoArrowSerialized,
+  GeoArrowStruct,
+  GeoArrowValidity
+} from './types';
+export {
+  getGeoArrowDimensionSize,
+  getGeoArrowEncodingForGeometry,
+  getGeoArrowGeometryType
+} from './types';
+
+export type {
+  GeoArrowColumnInspection,
+  GeoArrowValidationIssue,
+  GeoArrowValidationResult
+} from './layout';
+export {
+  getGeoArrowRowCount,
+  getGeoArrowTransferList,
+  getGeoArrowVertexCount,
+  inspectGeoArrowColumn,
+  isGeoArrowValueValid,
+  sliceGeoArrowArray,
+  sliceGeoArrowColumn,
+  validateGeoArrowColumn,
+  visitGeoArrowCoordinates
+} from './layout';
+
+export type {
+  GeoArrowBuilderEncoding,
+  GeoArrowBuilderMeasurement,
+  GeoArrowBuilderModeOptions,
+  GeoArrowBuilderOptions,
+  GeoArrowColumnFromRowsOptions,
+  GeoArrowBuilderTarget
+} from './builder';
+export {
+  allocateGeoArrowBuilderTarget,
+  GeoArrowBuilder,
+  makeGeoArrowColumnFromGeometryRows
+} from './builder';
+
+export type {
+  ConvertGeoArrowColumnOptions,
+  GeoArrowResourceLimitOptions,
+  GeoArrowRingOrientation,
+  MapGeoArrowCoordinatesOptions,
+  RewindGeoArrowOptions
+} from './kernels';
+export {
+  assertGeoArrowResourceLimits,
+  convertGeoArrowColumn,
+  getGeoArrowBounds,
+  interleaveGeoArrowCoordinates,
+  mapGeoArrowCoordinates,
+  mapGeoArrowCoordinatesInto,
+  normalizeGeoArrowUnion,
+  rewindGeoArrow
+} from './kernels';
+
+export {
+  decodeGeoArrowWKB,
+  decodeGeoArrowWKT,
+  encodeGeoArrowWKB,
+  encodeGeoArrowWKT,
+  formatWKT,
+  parseWKB,
+  parseWKT,
+  writeWKB
+} from './codecs';
+
+export type {
+  GeoArrowTessellation,
+  TessellateGeoArrowPolygonsOptions
+} from './tessellate';
+export {tessellateGeoArrowPolygons} from './tessellate';

--- a/modules/geoarrow/src/kernels.ts
+++ b/modules/geoarrow/src/kernels.ts
@@ -357,16 +357,20 @@ function convertGeometryFamily(
   sourceDimension: GeoArrowDimension,
   targetDimension: GeoArrowDimension
 ): GeoArrowGeometryValue {
-  const coordinates =
-    geometry.type === 'GeometryCollection'
-      ? undefined
-      : mapCoordinateNesting(geometry.coordinates, coordinate =>
-          resizeCoordinate(coordinate, sourceDimension, targetDimension)
-        );
+  if (geometry.type === 'GeometryCollection') {
+    const geometries = geometry.geometries.map(child =>
+      convertGeometryFamily(child, 'geoarrow.geometry', sourceDimension, targetDimension)
+    );
+    if (encoding === 'geoarrow.geometry' || encoding === 'geoarrow.geometrycollection') {
+      return {...geometry, geometries};
+    }
+    throw new Error(`${geometry.type} cannot be represented as ${encoding}`);
+  }
+  const coordinates = mapCoordinateNesting(geometry.coordinates, coordinate =>
+    resizeCoordinate(coordinate, sourceDimension, targetDimension)
+  );
   if (encoding === 'geoarrow.geometry') {
-    return geometry.type === 'GeometryCollection'
-      ? geometry
-      : ({...geometry, coordinates} as GeoArrowGeometryValue);
+    return {...geometry, coordinates} as GeoArrowGeometryValue;
   }
   const target = encoding.replace('geoarrow.', '');
   if (geometry.type.toLowerCase() !== target) {

--- a/modules/geoarrow/src/kernels.ts
+++ b/modules/geoarrow/src/kernels.ts
@@ -1,0 +1,459 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {
+  GeoArrowArray,
+  GeoArrowBounds,
+  GeoArrowColumn,
+  GeoArrowCoordinateLayout,
+  GeoArrowCoordinateMapper,
+  GeoArrowDimension,
+  GeoArrowEncoding,
+  GeoArrowGeometryValue
+} from './types';
+import {getGeoArrowDimensionSize} from './types';
+import {makeGeoArrowColumnFromGeometryRows} from './builder';
+import {
+  getGeoArrowRowCount,
+  getGeoArrowVertexCount,
+  isGeoArrowValueValid,
+  materializeGeoArrowRows,
+  visitGeoArrowCoordinates
+} from './layout';
+
+/** Resource limits applied before potentially expensive materialization or conversion. */
+export type GeoArrowResourceLimitOptions = Readonly<{
+  maximumRows?: number;
+  maximumCoordinates?: number;
+  maximumChunks?: number;
+  maximumNestingDepth?: number;
+  maximumOutputBytes?: number;
+}>;
+
+/** Coordinate-map options. */
+export type MapGeoArrowCoordinatesOptions = Readonly<{
+  dimension?: GeoArrowDimension;
+  coordinateLayout?: GeoArrowCoordinateLayout;
+  limits?: GeoArrowResourceLimitOptions;
+}>;
+
+/** Conversion options for native physical layouts. */
+export type ConvertGeoArrowColumnOptions = Readonly<{
+  encoding?: GeoArrowEncoding;
+  dimension?: GeoArrowDimension;
+  coordinateLayout?: GeoArrowCoordinateLayout;
+  limits?: GeoArrowResourceLimitOptions;
+}>;
+
+/** Ring orientation requested by {@link rewindGeoArrow}. */
+export type GeoArrowRingOrientation = 'clockwise' | 'counter-clockwise';
+
+/** Rewind options. */
+export type RewindGeoArrowOptions = Readonly<{
+  outer?: GeoArrowRingOrientation;
+  limits?: GeoArrowResourceLimitOptions;
+}>;
+
+/** Returns XY bounds, or null when the column contains no finite coordinates. */
+export function getGeoArrowBounds(column: GeoArrowColumn): GeoArrowBounds | null {
+  if (column.encoding === 'geoarrow.box') return getGeoArrowBoxBounds(column);
+  let minimumX = Number.POSITIVE_INFINITY;
+  let minimumY = Number.POSITIVE_INFINITY;
+  let maximumX = Number.NEGATIVE_INFINITY;
+  let maximumY = Number.NEGATIVE_INFINITY;
+  visitGeoArrowCoordinates(column, coordinate => {
+    const x = coordinate[0];
+    const y = coordinate[1];
+    if (Number.isFinite(x) && Number.isFinite(y)) {
+      minimumX = Math.min(minimumX, x);
+      minimumY = Math.min(minimumY, y);
+      maximumX = Math.max(maximumX, x);
+      maximumY = Math.max(maximumY, y);
+    }
+    return coordinate;
+  });
+  return Number.isFinite(minimumX) ? [minimumX, minimumY, maximumX, maximumY] : null;
+}
+
+function getGeoArrowBoxBounds(column: GeoArrowColumn): GeoArrowBounds | null {
+  let minimumX = Number.POSITIVE_INFINITY;
+  let minimumY = Number.POSITIVE_INFINITY;
+  let maximumX = Number.NEGATIVE_INFINITY;
+  let maximumY = Number.NEGATIVE_INFINITY;
+  for (const chunk of column.chunks) {
+    if (chunk.kind !== 'struct') continue;
+    const xmin = chunk.children['xmin'];
+    const ymin = chunk.children['ymin'];
+    const xmax = chunk.children['xmax'];
+    const ymax = chunk.children['ymax'];
+    if (!xmin || !ymin || !xmax || !ymax) continue;
+    for (let rowIndex = 0; rowIndex < chunk.length; rowIndex++) {
+      if (!isGeoArrowValueValid(chunk.validity, rowIndex)) continue;
+      const structIndex = (chunk.offset || 0) + rowIndex;
+      const bounds = [
+        readPrimitiveNumber(xmin, structIndex),
+        readPrimitiveNumber(ymin, structIndex),
+        readPrimitiveNumber(xmax, structIndex),
+        readPrimitiveNumber(ymax, structIndex)
+      ];
+      if (bounds.every(Number.isFinite)) {
+        minimumX = Math.min(minimumX, bounds[0]);
+        minimumY = Math.min(minimumY, bounds[1]);
+        maximumX = Math.max(maximumX, bounds[2]);
+        maximumY = Math.max(maximumY, bounds[3]);
+      }
+    }
+  }
+  return Number.isFinite(minimumX) ? [minimumX, minimumY, maximumX, maximumY] : null;
+}
+
+function readPrimitiveNumber(array: GeoArrowArray, index: number): number {
+  if (array.kind !== 'primitive' || !isGeoArrowValueValid(array.validity, index)) return Number.NaN;
+  const valueIndex = (array.offset || 0) + index * (array.stride || 1);
+  return Number(array.values[valueIndex]);
+}
+
+/** Maps every coordinate into newly allocated physical buffers while preserving column semantics. */
+export function mapGeoArrowCoordinates(
+  column: GeoArrowColumn,
+  mapper: GeoArrowCoordinateMapper,
+  options: MapGeoArrowCoordinatesOptions = {}
+): GeoArrowColumn {
+  assertGeoArrowResourceLimits(column, options.limits);
+  const rows = materializeGeoArrowRows(column);
+  let rowIndex = 0;
+  const mappedRows = rows.map(row => {
+    const mapped = row
+      ? mapGeometryCoordinates(row, coordinate => mapper(coordinate, rowIndex))
+      : null;
+    rowIndex++;
+    return mapped;
+  });
+  const result = makeGeoArrowColumnFromGeometryRows(mappedRows, {
+    dimension: options.dimension || column.dimension,
+    coordinateLayout: options.coordinateLayout || column.coordinateLayout || 'interleaved'
+  });
+  return copyColumnMetadata(column, result);
+}
+
+/**
+ * Maps coordinates and copies the result into caller-provided destination buffers.
+ *
+ * The destination must have the same physical topology as the mapped result. Topology, validity,
+ * offsets, and metadata in the destination are never replaced.
+ */
+export function mapGeoArrowCoordinatesInto(
+  target: GeoArrowColumn,
+  source: GeoArrowColumn,
+  mapper: GeoArrowCoordinateMapper,
+  options: Omit<MapGeoArrowCoordinatesOptions, 'coordinateLayout'> = {}
+): GeoArrowColumn {
+  const mapped = mapGeoArrowCoordinates(source, mapper, {
+    ...options,
+    coordinateLayout: target.coordinateLayout || undefined
+  });
+  const sourceLeaves = collectCoordinateLeaves(mapped);
+  const targetLeaves = collectCoordinateLeaves(target);
+  if (sourceLeaves.length !== targetLeaves.length) {
+    throw new Error('GeoArrow destination has different coordinate topology');
+  }
+  for (let index = 0; index < sourceLeaves.length; index++) {
+    const sourceLeaf = sourceLeaves[index];
+    const targetLeaf = targetLeaves[index];
+    if (sourceLeaf.length !== targetLeaf.length) {
+      throw new Error('GeoArrow destination coordinate buffer has a different length');
+    }
+    targetLeaf.set(sourceLeaf as never);
+  }
+  return target;
+}
+
+/** Converts separated native coordinates to interleaved tuples. Identity is returned unchanged. */
+export function interleaveGeoArrowCoordinates(column: GeoArrowColumn): GeoArrowColumn {
+  if (column.coordinateLayout === 'interleaved') return column;
+  if (!column.coordinateLayout) return column;
+  return mapGeoArrowCoordinates(column, coordinate => coordinate, {
+    coordinateLayout: 'interleaved'
+  });
+}
+
+/** Normalizes dense-union children by ascending type ID without changing dispatch buffers. */
+export function normalizeGeoArrowUnion(column: GeoArrowColumn): GeoArrowColumn {
+  if (column.encoding !== 'geoarrow.geometry') return column;
+  let changed = false;
+  const chunks = column.chunks.map(chunk => {
+    if (chunk.kind !== 'dense-union') return chunk;
+    const children = [...chunk.children].sort((left, right) => left.typeId - right.typeId);
+    changed ||= children.some((child, index) => child !== chunk.children[index]);
+    return children.every((child, index) => child === chunk.children[index])
+      ? chunk
+      : {...chunk, children};
+  });
+  return changed ? {...column, chunks} : column;
+}
+
+/** Converts between concrete/mixed encodings, dimensions, and coordinate layouts. */
+export function convertGeoArrowColumn(
+  column: GeoArrowColumn,
+  options: ConvertGeoArrowColumnOptions = {}
+): GeoArrowColumn {
+  const encoding = options.encoding || column.encoding;
+  const dimension = options.dimension || column.dimension;
+  const coordinateLayout = options.coordinateLayout || column.coordinateLayout;
+  if (
+    encoding === column.encoding &&
+    dimension === column.dimension &&
+    coordinateLayout === column.coordinateLayout
+  ) {
+    return column;
+  }
+  if (encoding === 'geoarrow.wkb' || encoding === 'geoarrow.wkt') {
+    throw new Error('Use encodeGeoArrowWKB or encodeGeoArrowWKT for serialized output');
+  }
+  assertGeoArrowResourceLimits(column, options.limits);
+  const rows = materializeGeoArrowRows(column).map(row =>
+    row ? convertGeometryFamily(row, encoding, column.dimension, dimension) : null
+  );
+  const result = makeGeoArrowColumnFromGeometryRows(rows, {
+    encoding: encoding === 'geoarrow.geometry' ? encoding : undefined,
+    dimension,
+    coordinateLayout: coordinateLayout || 'interleaved'
+  });
+  if (result.encoding !== encoding && encoding !== 'geoarrow.geometry') {
+    throw new Error(`Rows cannot be represented as ${encoding}`);
+  }
+  return copyColumnMetadata(column, result);
+}
+
+/** Rewinds polygon rings without changing non-polygon rows. */
+export function rewindGeoArrow(
+  column: GeoArrowColumn,
+  options: RewindGeoArrowOptions = {}
+): GeoArrowColumn {
+  assertGeoArrowResourceLimits(column, options.limits);
+  const outerClockwise = (options.outer || 'counter-clockwise') === 'clockwise';
+  let changed = false;
+  const rows = materializeGeoArrowRows(column).map(row => {
+    if (!row) return null;
+    const rewound = rewindGeometry(row, outerClockwise);
+    changed ||= rewound !== row;
+    return rewound;
+  });
+  if (!changed) return column;
+  const result = makeGeoArrowColumnFromGeometryRows(rows, {
+    dimension: column.dimension,
+    coordinateLayout: column.coordinateLayout || 'interleaved'
+  });
+  return copyColumnMetadata(column, result);
+}
+
+/** Throws when a column exceeds configured work or output limits. */
+export function assertGeoArrowResourceLimits(
+  column: GeoArrowColumn,
+  options: GeoArrowResourceLimitOptions = {}
+): void {
+  const rows = getGeoArrowRowCount(column);
+  if (rows > (options.maximumRows ?? Number.POSITIVE_INFINITY)) {
+    throw new Error(`GeoArrow row count ${rows} exceeds maximumRows`);
+  }
+  if (column.chunks.length > (options.maximumChunks ?? Number.POSITIVE_INFINITY)) {
+    throw new Error(`GeoArrow chunk count ${column.chunks.length} exceeds maximumChunks`);
+  }
+  const coordinates = getGeoArrowVertexCount(column);
+  if (coordinates > (options.maximumCoordinates ?? Number.POSITIVE_INFINITY)) {
+    throw new Error(`GeoArrow coordinate count ${coordinates} exceeds maximumCoordinates`);
+  }
+  if (options.maximumNestingDepth !== undefined) {
+    const depth = Math.max(0, ...column.chunks.map(getArrayDepth));
+    if (depth > options.maximumNestingDepth) {
+      throw new Error(`GeoArrow nesting depth ${depth} exceeds maximumNestingDepth`);
+    }
+  }
+  if (options.maximumOutputBytes !== undefined) {
+    const estimatedBytes = coordinates * getGeoArrowDimensionSize(column.dimension) * 8;
+    if (estimatedBytes > options.maximumOutputBytes) {
+      throw new Error(`GeoArrow estimated output ${estimatedBytes} exceeds maximumOutputBytes`);
+    }
+  }
+}
+
+function mapGeometryCoordinates(
+  geometry: GeoArrowGeometryValue,
+  mapper: (coordinate: readonly number[]) => readonly number[]
+): GeoArrowGeometryValue {
+  if (geometry.type === 'GeometryCollection') {
+    return {
+      ...geometry,
+      geometries: geometry.geometries.map(child => mapGeometryCoordinates(child, mapper))
+    };
+  }
+  return {
+    ...geometry,
+    coordinates: mapCoordinateNesting(geometry.coordinates, mapper)
+  } as GeoArrowGeometryValue;
+}
+
+function mapCoordinateNesting(
+  value: readonly unknown[],
+  mapper: (coordinate: readonly number[]) => readonly number[]
+): unknown {
+  if (value.length === 0) return [];
+  if (typeof value[0] === 'number') return [...mapper(value as readonly number[])];
+  return value.map(child => mapCoordinateNesting(child as readonly unknown[], mapper));
+}
+
+function rewindGeometry(
+  geometry: GeoArrowGeometryValue,
+  outerClockwise: boolean
+): GeoArrowGeometryValue {
+  if (geometry.type === 'GeometryCollection') {
+    const geometries = geometry.geometries.map(child => rewindGeometry(child, outerClockwise));
+    return geometries.some((child, index) => child !== geometry.geometries[index])
+      ? {...geometry, geometries}
+      : geometry;
+  }
+  if (geometry.type === 'Polygon') {
+    const coordinates = rewindPolygon(geometry.coordinates, outerClockwise);
+    return coordinates === geometry.coordinates ? geometry : {...geometry, coordinates};
+  }
+  if (geometry.type === 'MultiPolygon') {
+    const coordinates = geometry.coordinates.map(polygon => rewindPolygon(polygon, outerClockwise));
+    return coordinates.every((polygon, index) => polygon === geometry.coordinates[index])
+      ? geometry
+      : {...geometry, coordinates};
+  }
+  return geometry;
+}
+
+function rewindPolygon(
+  rings: readonly (readonly (readonly number[])[])[],
+  outerClockwise: boolean
+): readonly (readonly (readonly number[])[])[] {
+  let changed = false;
+  const result = rings.map((ring, ringIndex) => {
+    const shouldBeClockwise = ringIndex === 0 ? outerClockwise : !outerClockwise;
+    const isClockwise = getRingSignedArea(ring) < 0;
+    if (isClockwise === shouldBeClockwise) return ring;
+    changed = true;
+    return [...ring].reverse();
+  });
+  return changed ? result : rings;
+}
+
+function getRingSignedArea(ring: readonly (readonly number[])[]): number {
+  let area = 0;
+  for (let index = 0; index < ring.length; index++) {
+    const current = ring[index];
+    const next = ring[(index + 1) % ring.length];
+    area += current[0] * next[1] - next[0] * current[1];
+  }
+  return area / 2;
+}
+
+function convertGeometryFamily(
+  geometry: GeoArrowGeometryValue,
+  encoding: GeoArrowEncoding,
+  sourceDimension: GeoArrowDimension,
+  targetDimension: GeoArrowDimension
+): GeoArrowGeometryValue {
+  const coordinates =
+    geometry.type === 'GeometryCollection'
+      ? undefined
+      : mapCoordinateNesting(geometry.coordinates, coordinate =>
+          resizeCoordinate(coordinate, sourceDimension, targetDimension)
+        );
+  if (encoding === 'geoarrow.geometry') {
+    return geometry.type === 'GeometryCollection'
+      ? geometry
+      : ({...geometry, coordinates} as GeoArrowGeometryValue);
+  }
+  const target = encoding.replace('geoarrow.', '');
+  if (geometry.type.toLowerCase() !== target) {
+    throw new Error(`${geometry.type} cannot be represented as ${encoding}`);
+  }
+  return {...geometry, coordinates} as GeoArrowGeometryValue;
+}
+
+function resizeCoordinate(
+  coordinate: readonly number[],
+  sourceDimension: GeoArrowDimension,
+  targetDimension: GeoArrowDimension
+): number[] {
+  const sourceNames = getDimensionNames(sourceDimension);
+  const targetNames = getDimensionNames(targetDimension);
+  return targetNames.map(name => {
+    const sourceIndex = sourceNames.indexOf(name);
+    return sourceIndex >= 0 ? (coordinate[sourceIndex] ?? 0) : 0;
+  });
+}
+
+function getDimensionNames(dimension: GeoArrowDimension): Array<'x' | 'y' | 'z' | 'm'> {
+  switch (dimension) {
+    case 'xy':
+      return ['x', 'y'];
+    case 'xyz':
+      return ['x', 'y', 'z'];
+    case 'xym':
+      return ['x', 'y', 'm'];
+    case 'xyzm':
+      return ['x', 'y', 'z', 'm'];
+  }
+}
+
+function copyColumnMetadata(source: GeoArrowColumn, target: GeoArrowColumn): GeoArrowColumn {
+  return {
+    ...target,
+    spatialReference: source.spatialReference,
+    edges: source.edges,
+    metadata: source.metadata
+  };
+}
+
+function collectCoordinateLeaves(column: GeoArrowColumn): Array<Float32Array | Float64Array> {
+  const leaves: Array<Float32Array | Float64Array> = [];
+  for (const chunk of column.chunks) collectArrayCoordinateLeaves(chunk, leaves);
+  return leaves;
+}
+
+function collectArrayCoordinateLeaves(
+  array: GeoArrowArray,
+  leaves: Array<Float32Array | Float64Array>
+): void {
+  switch (array.kind) {
+    case 'primitive':
+      if (array.values instanceof Float32Array || array.values instanceof Float64Array) {
+        leaves.push(array.values);
+      }
+      break;
+    case 'fixed-size-list':
+    case 'list':
+      collectArrayCoordinateLeaves(array.child, leaves);
+      break;
+    case 'struct':
+      for (const name of ['x', 'y', 'z', 'm']) {
+        const child = array.children[name];
+        if (child) collectArrayCoordinateLeaves(child, leaves);
+      }
+      break;
+    case 'dense-union':
+      for (const child of array.children) collectArrayCoordinateLeaves(child.data, leaves);
+      break;
+    default:
+      break;
+  }
+}
+
+function getArrayDepth(array: GeoArrowArray): number {
+  switch (array.kind) {
+    case 'list':
+    case 'fixed-size-list':
+      return 1 + getArrayDepth(array.child);
+    case 'struct':
+      return 1 + Math.max(0, ...Object.values(array.children).map(getArrayDepth));
+    case 'dense-union':
+      return 1 + Math.max(0, ...array.children.map(child => getArrayDepth(child.data)));
+    default:
+      return 1;
+  }
+}

--- a/modules/geoarrow/src/layout.ts
+++ b/modules/geoarrow/src/layout.ts
@@ -460,6 +460,15 @@ function validateArray(
       break;
     }
     case 'fixed-size-list': {
+      const offset = array.offset ?? 0;
+      const validOffset = Number.isSafeInteger(offset) && offset >= 0;
+      if (!validOffset) {
+        issues.push({
+          code: 'invalid-offset',
+          path,
+          message: 'Fixed-size list offset must be a non-negative safe integer.'
+        });
+      }
       if (!Number.isSafeInteger(array.size) || array.size < 1) {
         issues.push({
           code: 'invalid-length',
@@ -467,8 +476,8 @@ function validateArray(
           message: 'Fixed-size list size must be positive.'
         });
       }
-      const childEnd = ((array.offset || 0) + array.length) * array.size;
-      if (childEnd > array.child.length) {
+      const childEnd = (offset + array.length) * array.size;
+      if (validOffset && childEnd > array.child.length) {
         issues.push({code: 'invalid-child', path, message: 'Fixed-size list child is too short.'});
       }
       validateArray(array.child, `${path}.child`, issues);

--- a/modules/geoarrow/src/layout.ts
+++ b/modules/geoarrow/src/layout.ts
@@ -1,0 +1,824 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {
+  GeoArrowArray,
+  GeoArrowColumn,
+  GeoArrowCoordinateMapper,
+  GeoArrowDenseUnion,
+  GeoArrowEncoding,
+  GeoArrowGeometryValue,
+  GeoArrowList,
+  GeoArrowOffsets,
+  GeoArrowValidity
+} from './types';
+import {
+  getGeoArrowDimensionSize,
+  getGeoArrowEncodingForGeometry,
+  getGeoArrowGeometryType
+} from './types';
+
+/** Stable validation diagnostic for a physical GeoArrow descriptor. */
+export type GeoArrowValidationIssue = Readonly<{
+  code:
+    | 'invalid-length'
+    | 'invalid-validity'
+    | 'invalid-offset'
+    | 'invalid-stride'
+    | 'invalid-child'
+    | 'invalid-union'
+    | 'invalid-layout'
+    | 'unsafe-offset';
+  path: string;
+  message: string;
+}>;
+
+/** Validation result for a physical GeoArrow descriptor. */
+export type GeoArrowValidationResult = Readonly<{
+  valid: boolean;
+  issues: readonly GeoArrowValidationIssue[];
+}>;
+
+/** Value-independent and inexpensive facts about a GeoArrow column. */
+export type GeoArrowColumnInspection = Readonly<{
+  encoding: GeoArrowEncoding;
+  rowCount: number;
+  chunkCount: number;
+  nullCount: number;
+  coordinateCount: number;
+  storageKinds: readonly GeoArrowArray['kind'][];
+  valid: boolean;
+  issues: readonly GeoArrowValidationIssue[];
+}>;
+
+/** Returns whether one logical value is valid at a nesting level. */
+export function isGeoArrowValueValid(
+  validity: GeoArrowValidity | undefined,
+  index: number
+): boolean {
+  if (!validity) return true;
+  const bitIndex = (validity.bitOffset || 0) + index;
+  return Boolean(validity.values[bitIndex >> 3] & (1 << (bitIndex & 7)));
+}
+
+/** Returns the total number of logical rows across chunks. */
+export function getGeoArrowRowCount(column: GeoArrowColumn): number {
+  return column.chunks.reduce((count, chunk) => count + chunk.length, 0);
+}
+
+/** Visits coordinates without materializing row geometry objects. */
+export function visitGeoArrowCoordinates(
+  column: GeoArrowColumn,
+  visitor: GeoArrowCoordinateMapper
+): void {
+  let rowOffset = 0;
+  for (const chunk of column.chunks) {
+    visitChunkCoordinates(chunk, column.encoding, rowOffset, visitor);
+    rowOffset += chunk.length;
+  }
+}
+
+/** Returns a zero-copy logical slice of a column, preserving chunk boundaries. */
+export function sliceGeoArrowColumn(
+  column: GeoArrowColumn,
+  begin = 0,
+  end = getGeoArrowRowCount(column)
+): GeoArrowColumn {
+  const rowCount = getGeoArrowRowCount(column);
+  const first = normalizeSliceIndex(begin, rowCount);
+  const last = Math.max(first, normalizeSliceIndex(end, rowCount));
+  if (first === 0 && last === rowCount) return column;
+
+  const chunks: GeoArrowArray[] = [];
+  let chunkStart = 0;
+  for (const chunk of column.chunks) {
+    const chunkEnd = chunkStart + chunk.length;
+    const localFirst = Math.max(0, first - chunkStart);
+    const localLast = Math.min(chunk.length, last - chunkStart);
+    if (localLast > localFirst) {
+      chunks.push(sliceGeoArrowArray(chunk, localFirst, localLast));
+    }
+    chunkStart = chunkEnd;
+    if (chunkStart >= last) break;
+  }
+  return {...column, chunks};
+}
+
+/** Returns a zero-copy logical slice of one physical array. */
+export function sliceGeoArrowArray(
+  array: GeoArrowArray,
+  begin: number,
+  end: number
+): GeoArrowArray {
+  if (begin === 0 && end === array.length) return array;
+  const length = end - begin;
+  const validity = array.validity
+    ? {...array.validity, bitOffset: (array.validity.bitOffset || 0) + begin}
+    : undefined;
+  switch (array.kind) {
+    case 'primitive':
+      return {
+        ...array,
+        length,
+        offset: (array.offset || 0) + begin * (array.stride || 1),
+        validity
+      };
+    case 'fixed-size-list':
+      return {...array, length, offset: (array.offset || 0) + begin, validity};
+    case 'list':
+    case 'serialized':
+      return {...array, length, offset: (array.offset || 0) + begin, validity};
+    case 'struct':
+      return {...array, length, offset: (array.offset || 0) + begin, validity};
+    case 'dense-union':
+      return {...array, length, offset: (array.offset || 0) + begin, validity};
+  }
+}
+
+/** Validates physical bounds, list offsets, union dispatch, and declared coordinate layout. */
+export function validateGeoArrowColumn(column: GeoArrowColumn): GeoArrowValidationResult {
+  const issues: GeoArrowValidationIssue[] = [];
+  for (let chunkIndex = 0; chunkIndex < column.chunks.length; chunkIndex++) {
+    validateArray(column.chunks[chunkIndex], `chunks[${chunkIndex}]`, issues);
+  }
+  validateColumnLayout(column, issues);
+  return {valid: issues.length === 0, issues};
+}
+
+/** Inspects a column without decoding serialized geometry or creating row objects. */
+export function inspectGeoArrowColumn(column: GeoArrowColumn): GeoArrowColumnInspection {
+  const validation = validateGeoArrowColumn(column);
+  const storageKinds: GeoArrowArray['kind'][] = [];
+  let nullCount = 0;
+  for (const chunk of column.chunks) {
+    collectStorageKinds(chunk, storageKinds);
+    for (let rowIndex = 0; rowIndex < chunk.length; rowIndex++) {
+      if (!isGeoArrowValueValid(chunk.validity, rowIndex)) nullCount++;
+    }
+  }
+  return {
+    encoding: column.encoding,
+    rowCount: getGeoArrowRowCount(column),
+    chunkCount: column.chunks.length,
+    nullCount,
+    coordinateCount: getGeoArrowVertexCount(column),
+    storageKinds,
+    valid: validation.valid,
+    issues: validation.issues
+  };
+}
+
+/** Counts coordinate tuples without materializing geometry objects. */
+export function getGeoArrowVertexCount(column: GeoArrowColumn): number {
+  if (
+    column.encoding === 'geoarrow.wkb' ||
+    column.encoding === 'geoarrow.wkt' ||
+    column.encoding === 'geoarrow.box'
+  ) {
+    return 0;
+  }
+  let count = 0;
+  visitGeoArrowCoordinates(column, coordinate => {
+    count++;
+    return coordinate;
+  });
+  return count;
+}
+
+/** Collects unique transferable ArrayBuffers borrowed by a column. */
+export function getGeoArrowTransferList(column: GeoArrowColumn): ArrayBuffer[] {
+  const buffers = new Set<ArrayBuffer>();
+  for (const chunk of column.chunks) collectArrayBuffers(chunk, buffers);
+  return [...buffers];
+}
+
+/** Materializes column rows for codecs and structural algorithms. */
+export function materializeGeoArrowRows(
+  column: GeoArrowColumn
+): Array<GeoArrowGeometryValue | null> {
+  if (column.encoding === 'geoarrow.wkb' || column.encoding === 'geoarrow.wkt') {
+    throw new Error('Serialized GeoArrow columns must be decoded before materialization');
+  }
+  const rows: Array<GeoArrowGeometryValue | null> = [];
+  for (const chunk of column.chunks) {
+    for (let rowIndex = 0; rowIndex < chunk.length; rowIndex++) {
+      rows.push(materializeGeometryRow(chunk, rowIndex, column.encoding));
+    }
+  }
+  return rows;
+}
+
+/** Materializes one row from a physical array. */
+export function materializeGeometryRow(
+  array: GeoArrowArray,
+  rowIndex: number,
+  encoding: GeoArrowEncoding
+): GeoArrowGeometryValue | null {
+  if (!isGeoArrowValueValid(array.validity, rowIndex)) return null;
+  if (encoding === 'geoarrow.geometry') {
+    if (array.kind !== 'dense-union') return null;
+    return materializeUnionRow(array, rowIndex);
+  }
+  if (encoding === 'geoarrow.geometrycollection') {
+    if (array.kind !== 'list') return null;
+    const [first, last] = getListRange(array, rowIndex);
+    const geometries: GeoArrowGeometryValue[] = [];
+    for (let index = first; index < last; index++) {
+      if (array.child.kind !== 'dense-union') continue;
+      const geometry = materializeUnionRow(array.child, index);
+      if (geometry) geometries.push(geometry);
+    }
+    return {type: 'GeometryCollection', geometries};
+  }
+  const geometryType = getGeoArrowGeometryType(encoding);
+  if (!geometryType || geometryType === 'GeometryCollection') return null;
+  const depth = getEncodingDepth(encoding);
+  const coordinates = readNestedCoordinates(array, rowIndex, depth);
+  if (!coordinates) return null;
+  return {type: geometryType, coordinates} as GeoArrowGeometryValue;
+}
+
+/** Returns a safe numeric offset. */
+export function getGeoArrowOffset(offsets: GeoArrowOffsets, index: number): number {
+  const value = offsets[index];
+  const numericValue = typeof value === 'bigint' ? Number(value) : value;
+  if (!Number.isSafeInteger(numericValue)) {
+    throw new Error(`GeoArrow offset ${String(value)} exceeds JavaScript's safe integer range`);
+  }
+  return numericValue;
+}
+
+/** Returns the child range for one list row. */
+export function getListRange(list: GeoArrowList, rowIndex: number): [number, number] {
+  const offsetIndex = (list.offset || 0) + rowIndex;
+  const baseValue = list.offsetBase ?? 0;
+  const base = typeof baseValue === 'bigint' ? Number(baseValue) : baseValue;
+  return [
+    getGeoArrowOffset(list.offsets, offsetIndex) - base,
+    getGeoArrowOffset(list.offsets, offsetIndex + 1) - base
+  ];
+}
+
+function visitChunkCoordinates(
+  array: GeoArrowArray,
+  encoding: GeoArrowEncoding,
+  rowOffset: number,
+  visitor: GeoArrowCoordinateMapper
+): void {
+  for (let rowIndex = 0; rowIndex < array.length; rowIndex++) {
+    if (!isGeoArrowValueValid(array.validity, rowIndex)) continue;
+    if (encoding === 'geoarrow.geometry' && array.kind === 'dense-union') {
+      visitUnionRowCoordinates(array, rowIndex, rowOffset + rowIndex, visitor);
+      continue;
+    }
+    if (encoding === 'geoarrow.geometrycollection' && array.kind === 'list') {
+      const [first, last] = getListRange(array, rowIndex);
+      if (array.child.kind === 'dense-union') {
+        for (let index = first; index < last; index++) {
+          visitUnionRowCoordinates(array.child, index, rowOffset + rowIndex, visitor);
+        }
+      }
+      continue;
+    }
+    const depth = getEncodingDepth(encoding);
+    visitNestedCoordinates(array, rowIndex, depth, rowOffset + rowIndex, visitor);
+  }
+}
+
+function visitUnionRowCoordinates(
+  union: GeoArrowDenseUnion,
+  rowIndex: number,
+  sourceRowIndex: number,
+  visitor: GeoArrowCoordinateMapper
+): void {
+  if (!isGeoArrowValueValid(union.validity, rowIndex)) return;
+  const physicalIndex = (union.offset || 0) + rowIndex;
+  const typeId = union.typeIds[physicalIndex];
+  const valueOffset = union.valueOffsets[physicalIndex];
+  const child = union.children.find(candidate => candidate.typeId === typeId);
+  if (!child) return;
+  const encoding = getEncodingFromChildName(child.name);
+  if (encoding === 'geoarrow.geometrycollection' && child.data.kind === 'list') {
+    const [first, last] = getListRange(child.data, valueOffset);
+    if (child.data.child.kind === 'dense-union') {
+      for (let index = first; index < last; index++) {
+        visitUnionRowCoordinates(child.data.child, index, sourceRowIndex, visitor);
+      }
+    }
+    return;
+  }
+  visitNestedCoordinates(
+    child.data,
+    valueOffset,
+    getEncodingDepth(encoding),
+    sourceRowIndex,
+    visitor
+  );
+}
+
+function visitNestedCoordinates(
+  array: GeoArrowArray,
+  index: number,
+  depth: number,
+  rowIndex: number,
+  visitor: GeoArrowCoordinateMapper
+): void {
+  if (depth === 0) {
+    const coordinate = readCoordinate(array, index);
+    if (coordinate) visitor(coordinate, rowIndex);
+    return;
+  }
+  if (array.kind !== 'list' || !isGeoArrowValueValid(array.validity, index)) return;
+  const [first, last] = getListRange(array, index);
+  for (let childIndex = first; childIndex < last; childIndex++) {
+    visitNestedCoordinates(array.child, childIndex, depth - 1, rowIndex, visitor);
+  }
+}
+
+function readNestedCoordinates(array: GeoArrowArray, index: number, depth: number): unknown {
+  if (depth === 0) return readCoordinate(array, index);
+  if (array.kind !== 'list' || !isGeoArrowValueValid(array.validity, index)) return null;
+  const [first, last] = getListRange(array, index);
+  const values: unknown[] = [];
+  for (let childIndex = first; childIndex < last; childIndex++) {
+    const value = readNestedCoordinates(array.child, childIndex, depth - 1);
+    if (value !== null) values.push(value);
+  }
+  return values;
+}
+
+function readCoordinate(array: GeoArrowArray, index: number): number[] | null {
+  if (!isGeoArrowValueValid(array.validity, index)) return null;
+  if (array.kind === 'fixed-size-list') {
+    const listIndex = (array.offset || 0) + index;
+    const coordinate: number[] = [];
+    for (let component = 0; component < array.size; component++) {
+      coordinate.push(readPrimitive(array.child, listIndex * array.size + component));
+    }
+    return coordinate;
+  }
+  if (array.kind === 'struct') {
+    const structIndex = (array.offset || 0) + index;
+    const coordinate: number[] = [];
+    for (const name of ['x', 'y', 'z', 'm']) {
+      const child = array.children[name];
+      if (child) coordinate.push(readPrimitive(child, structIndex));
+    }
+    return coordinate.length >= 2 ? coordinate : null;
+  }
+  return null;
+}
+
+function readPrimitive(array: GeoArrowArray, index: number): number {
+  if (array.kind !== 'primitive') throw new Error('GeoArrow coordinate child must be primitive');
+  const valueIndex = (array.offset || 0) + index * (array.stride || 1);
+  return Number(array.values[valueIndex]);
+}
+
+function materializeUnionRow(
+  union: GeoArrowDenseUnion,
+  rowIndex: number
+): GeoArrowGeometryValue | null {
+  if (!isGeoArrowValueValid(union.validity, rowIndex)) return null;
+  const physicalIndex = (union.offset || 0) + rowIndex;
+  const typeId = union.typeIds[physicalIndex];
+  const valueOffset = union.valueOffsets[physicalIndex];
+  const child = union.children.find(candidate => candidate.typeId === typeId);
+  if (!child || valueOffset < 0 || valueOffset >= child.data.length) return null;
+  return materializeGeometryRow(child.data, valueOffset, getEncodingFromChildName(child.name));
+}
+
+function getEncodingFromChildName(name: string): GeoArrowEncoding {
+  const normalized = name.replace(/[^a-z]/gi, '').toLowerCase();
+  switch (normalized) {
+    case 'point':
+      return 'geoarrow.point';
+    case 'linestring':
+      return 'geoarrow.linestring';
+    case 'polygon':
+      return 'geoarrow.polygon';
+    case 'multipoint':
+      return 'geoarrow.multipoint';
+    case 'multilinestring':
+      return 'geoarrow.multilinestring';
+    case 'multipolygon':
+      return 'geoarrow.multipolygon';
+    case 'geometrycollection':
+      return 'geoarrow.geometrycollection';
+    default:
+      throw new Error(`Unknown GeoArrow dense-union child ${name}`);
+  }
+}
+
+function getEncodingDepth(encoding: GeoArrowEncoding): 0 | 1 | 2 | 3 {
+  switch (encoding) {
+    case 'geoarrow.point':
+      return 0;
+    case 'geoarrow.linestring':
+    case 'geoarrow.multipoint':
+      return 1;
+    case 'geoarrow.polygon':
+    case 'geoarrow.multilinestring':
+      return 2;
+    case 'geoarrow.multipolygon':
+      return 3;
+    default:
+      return 0;
+  }
+}
+
+function validateArray(
+  array: GeoArrowArray,
+  path: string,
+  issues: GeoArrowValidationIssue[]
+): void {
+  if (!Number.isSafeInteger(array.length) || array.length < 0) {
+    issues.push({
+      code: 'invalid-length',
+      path,
+      message: 'Length must be a non-negative safe integer.'
+    });
+    return;
+  }
+  validateValidity(array.validity, array.length, path, issues);
+  switch (array.kind) {
+    case 'primitive': {
+      const stride = array.stride || 1;
+      const offset = array.offset || 0;
+      if (!Number.isSafeInteger(stride) || stride < 1) {
+        issues.push({code: 'invalid-stride', path, message: 'Primitive stride must be positive.'});
+      }
+      const requiredLength = array.length === 0 ? offset : offset + (array.length - 1) * stride + 1;
+      if (offset < 0 || requiredLength > array.values.length) {
+        issues.push({
+          code: 'invalid-length',
+          path,
+          message: 'Primitive values do not cover the logical range.'
+        });
+      }
+      break;
+    }
+    case 'fixed-size-list': {
+      if (!Number.isSafeInteger(array.size) || array.size < 1) {
+        issues.push({
+          code: 'invalid-length',
+          path,
+          message: 'Fixed-size list size must be positive.'
+        });
+      }
+      const childEnd = ((array.offset || 0) + array.length) * array.size;
+      if (childEnd > array.child.length) {
+        issues.push({code: 'invalid-child', path, message: 'Fixed-size list child is too short.'});
+      }
+      validateArray(array.child, `${path}.child`, issues);
+      break;
+    }
+    case 'list':
+      validateList(array, path, issues);
+      validateArray(array.child, `${path}.child`, issues);
+      break;
+    case 'struct':
+      if (Object.keys(array.children).length === 0) {
+        issues.push({code: 'invalid-child', path, message: 'Struct must contain children.'});
+      }
+      for (const [name, child] of Object.entries(array.children)) {
+        if ((array.offset || 0) + array.length > child.length) {
+          issues.push({
+            code: 'invalid-child',
+            path: `${path}.${name}`,
+            message: 'Struct child is too short.'
+          });
+        }
+        validateArray(child, `${path}.${name}`, issues);
+      }
+      break;
+    case 'dense-union': {
+      const end = (array.offset || 0) + array.length;
+      if (end > array.typeIds.length || end > array.valueOffsets.length) {
+        issues.push({
+          code: 'invalid-union',
+          path,
+          message: 'Dense-union dispatch buffers are too short.'
+        });
+      }
+      const childIds = new Set<number>();
+      for (const child of array.children) {
+        if (childIds.has(child.typeId)) {
+          issues.push({
+            code: 'invalid-union',
+            path,
+            message: `Duplicate dense-union type ID ${child.typeId}.`
+          });
+        }
+        childIds.add(child.typeId);
+        validateArray(child.data, `${path}.${child.name}`, issues);
+      }
+      for (let index = array.offset || 0; index < end; index++) {
+        if (!isGeoArrowValueValid(array.validity, index - (array.offset || 0))) continue;
+        const child = array.children.find(candidate => candidate.typeId === array.typeIds[index]);
+        const valueOffset = array.valueOffsets[index];
+        if (!child || valueOffset < 0 || valueOffset >= child.data.length) {
+          issues.push({
+            code: 'invalid-union',
+            path: `${path}[${index}]`,
+            message: 'Dense-union row references an invalid child value.'
+          });
+        }
+      }
+      break;
+    }
+    case 'serialized': {
+      validateOffsets(
+        array.offsets,
+        array.offset || 0,
+        array.length,
+        array.values.length,
+        array.offsetBase,
+        path,
+        issues
+      );
+      break;
+    }
+  }
+}
+
+function validateList(list: GeoArrowList, path: string, issues: GeoArrowValidationIssue[]): void {
+  validateOffsets(
+    list.offsets,
+    list.offset || 0,
+    list.length,
+    list.child.length,
+    list.offsetBase,
+    path,
+    issues
+  );
+}
+
+function validateOffsets(
+  offsets: GeoArrowOffsets,
+  offset: number,
+  length: number,
+  childLength: number,
+  offsetBase: number | bigint | undefined,
+  path: string,
+  issues: GeoArrowValidationIssue[]
+): void {
+  if (offset < 0 || offset + length >= offsets.length) {
+    issues.push({code: 'invalid-offset', path, message: 'Offset buffer is too short.'});
+    return;
+  }
+  const base = typeof offsetBase === 'bigint' ? Number(offsetBase) : offsetBase || 0;
+  let previous: number;
+  try {
+    previous = getGeoArrowOffset(offsets, offset) - base;
+  } catch (error) {
+    issues.push({code: 'unsafe-offset', path, message: (error as Error).message});
+    return;
+  }
+  for (let index = 1; index <= length; index++) {
+    let current: number;
+    try {
+      current = getGeoArrowOffset(offsets, offset + index) - base;
+    } catch (error) {
+      issues.push({code: 'unsafe-offset', path, message: (error as Error).message});
+      return;
+    }
+    if (current < previous || current < 0 || current > childLength) {
+      issues.push({
+        code: 'invalid-offset',
+        path,
+        message: 'Offsets must be monotonic and within child storage.'
+      });
+      return;
+    }
+    previous = current;
+  }
+}
+
+function validateValidity(
+  validity: GeoArrowValidity | undefined,
+  length: number,
+  path: string,
+  issues: GeoArrowValidationIssue[]
+): void {
+  if (!validity) return;
+  const bitOffset = validity.bitOffset || 0;
+  if (bitOffset < 0 || bitOffset + length > validity.values.length * 8) {
+    issues.push({code: 'invalid-validity', path, message: 'Validity bitmap is too short.'});
+  }
+}
+
+function validateColumnLayout(column: GeoArrowColumn, issues: GeoArrowValidationIssue[]): void {
+  if (column.encoding === 'geoarrow.wkb' || column.encoding === 'geoarrow.wkt') {
+    for (const [index, chunk] of column.chunks.entries()) {
+      const expectedEncoding = column.encoding === 'geoarrow.wkb' ? 'binary' : 'utf8';
+      if (chunk.kind !== 'serialized' || chunk.encoding !== expectedEncoding) {
+        issues.push({
+          code: 'invalid-layout',
+          path: `chunks[${index}]`,
+          message: `Serialized encoding requires ${expectedEncoding} storage.`
+        });
+      }
+    }
+    return;
+  }
+  if (column.encoding === 'geoarrow.box') {
+    for (const [index, chunk] of column.chunks.entries()) {
+      if (chunk.kind !== 'struct') {
+        addInvalidLayout(`chunks[${index}]`, 'Box encoding requires struct storage.', issues);
+        continue;
+      }
+      const requiredNames =
+        column.dimension === 'xy'
+          ? ['xmin', 'ymin', 'xmax', 'ymax']
+          : column.dimension === 'xyz'
+            ? ['xmin', 'ymin', 'zmin', 'xmax', 'ymax', 'zmax']
+            : column.dimension === 'xym'
+              ? ['xmin', 'ymin', 'mmin', 'xmax', 'ymax', 'mmax']
+              : ['xmin', 'ymin', 'zmin', 'mmin', 'xmax', 'ymax', 'zmax', 'mmax'];
+      for (const name of requiredNames) {
+        if (chunk.children[name]?.kind !== 'primitive') {
+          addInvalidLayout(
+            `chunks[${index}].${name}`,
+            `Box storage requires primitive ${name}.`,
+            issues
+          );
+        }
+      }
+    }
+    return;
+  }
+  if (!column.coordinateLayout) {
+    addInvalidLayout('coordinateLayout', 'Native geometry requires a coordinate layout.', issues);
+    return;
+  }
+  for (const [index, chunk] of column.chunks.entries()) {
+    validateGeometryLayout(chunk, column.encoding, column, `chunks[${index}]`, issues);
+  }
+}
+
+function validateGeometryLayout(
+  array: GeoArrowArray,
+  encoding: GeoArrowEncoding,
+  column: GeoArrowColumn,
+  path: string,
+  issues: GeoArrowValidationIssue[]
+): void {
+  if (encoding === 'geoarrow.geometry') {
+    if (array.kind !== 'dense-union') {
+      addInvalidLayout(path, 'Mixed geometry encoding requires dense-union storage.', issues);
+      return;
+    }
+    validateUnionLayouts(array, column, path, issues);
+    return;
+  }
+  if (encoding === 'geoarrow.geometrycollection') {
+    if (array.kind !== 'list' || array.child.kind !== 'dense-union') {
+      addInvalidLayout(path, 'GeometryCollection requires list-of-dense-union storage.', issues);
+      return;
+    }
+    validateUnionLayouts(array.child, column, `${path}.child`, issues);
+    return;
+  }
+  let coordinateArray = array;
+  const depth = getEncodingDepth(encoding);
+  for (let level = 0; level < depth; level++) {
+    if (coordinateArray.kind !== 'list') {
+      addInvalidLayout(path, `${encoding} requires ${depth} variable-list levels.`, issues);
+      return;
+    }
+    coordinateArray = coordinateArray.child;
+  }
+  validateCoordinateLayout(coordinateArray, column, path, issues);
+}
+
+function validateUnionLayouts(
+  union: GeoArrowDenseUnion,
+  column: GeoArrowColumn,
+  path: string,
+  issues: GeoArrowValidationIssue[]
+): void {
+  for (const child of union.children) {
+    let encoding: GeoArrowEncoding;
+    try {
+      encoding = getEncodingFromChildName(child.name);
+    } catch (error) {
+      addInvalidLayout(`${path}.${child.name}`, (error as Error).message, issues);
+      continue;
+    }
+    validateGeometryLayout(child.data, encoding, column, `${path}.${child.name}`, issues);
+  }
+}
+
+function validateCoordinateLayout(
+  array: GeoArrowArray,
+  column: GeoArrowColumn,
+  path: string,
+  issues: GeoArrowValidationIssue[]
+): void {
+  const dimensionSize = getGeoArrowDimensionSize(column.dimension);
+  if (column.coordinateLayout === 'interleaved') {
+    if (
+      array.kind !== 'fixed-size-list' ||
+      array.size !== dimensionSize ||
+      array.child.kind !== 'primitive'
+    ) {
+      addInvalidLayout(
+        path,
+        `Interleaved ${column.dimension} coordinates require fixed-size-list<${dimensionSize}> primitive storage.`,
+        issues
+      );
+    }
+    return;
+  }
+  if (array.kind !== 'struct') {
+    addInvalidLayout(
+      path,
+      `Separated ${column.dimension} coordinates require struct storage.`,
+      issues
+    );
+    return;
+  }
+  const requiredNames =
+    column.dimension === 'xy'
+      ? ['x', 'y']
+      : column.dimension === 'xyz'
+        ? ['x', 'y', 'z']
+        : column.dimension === 'xym'
+          ? ['x', 'y', 'm']
+          : ['x', 'y', 'z', 'm'];
+  for (const name of requiredNames) {
+    if (array.children[name]?.kind !== 'primitive') {
+      addInvalidLayout(
+        `${path}.${name}`,
+        `Separated coordinates require primitive ${name}.`,
+        issues
+      );
+    }
+  }
+}
+
+function addInvalidLayout(path: string, message: string, issues: GeoArrowValidationIssue[]): void {
+  issues.push({code: 'invalid-layout', path, message});
+}
+
+function collectStorageKinds(array: GeoArrowArray, kinds: GeoArrowArray['kind'][]): void {
+  kinds.push(array.kind);
+  switch (array.kind) {
+    case 'fixed-size-list':
+    case 'list':
+      collectStorageKinds(array.child, kinds);
+      break;
+    case 'struct':
+      for (const child of Object.values(array.children)) collectStorageKinds(child, kinds);
+      break;
+    case 'dense-union':
+      for (const child of array.children) collectStorageKinds(child.data, kinds);
+      break;
+    default:
+      break;
+  }
+}
+
+function collectArrayBuffers(array: GeoArrowArray, buffers: Set<ArrayBuffer>): void {
+  if (array.validity) addBuffer(array.validity.values.buffer, buffers);
+  switch (array.kind) {
+    case 'primitive':
+      addBuffer(array.values.buffer, buffers);
+      break;
+    case 'fixed-size-list':
+      collectArrayBuffers(array.child, buffers);
+      break;
+    case 'list':
+      addBuffer(array.offsets.buffer, buffers);
+      collectArrayBuffers(array.child, buffers);
+      break;
+    case 'struct':
+      for (const child of Object.values(array.children)) collectArrayBuffers(child, buffers);
+      break;
+    case 'dense-union':
+      addBuffer(array.typeIds.buffer, buffers);
+      addBuffer(array.valueOffsets.buffer, buffers);
+      for (const child of array.children) collectArrayBuffers(child.data, buffers);
+      break;
+    case 'serialized':
+      addBuffer(array.offsets.buffer, buffers);
+      addBuffer(array.values.buffer, buffers);
+      break;
+  }
+}
+
+function addBuffer(buffer: ArrayBufferLike, buffers: Set<ArrayBuffer>): void {
+  if (buffer instanceof ArrayBuffer) buffers.add(buffer);
+}
+
+function normalizeSliceIndex(index: number, length: number): number {
+  const normalized = index < 0 ? Math.max(0, length + index) : Math.min(length, index);
+  return Math.max(0, Math.trunc(normalized));
+}
+
+/** Returns a concrete encoding for a geometry value. */
+export function getEncodingForGeometryValue(geometry: GeoArrowGeometryValue): GeoArrowEncoding {
+  return getGeoArrowEncodingForGeometry(geometry.type);
+}

--- a/modules/geoarrow/src/tessellate.ts
+++ b/modules/geoarrow/src/tessellate.ts
@@ -1,0 +1,133 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {earcut} from '@math.gl/polygon';
+import type {GeoArrowColumn, GeoArrowGeometryValue} from './types';
+import {getGeoArrowDimensionSize} from './types';
+import {materializeGeoArrowRows} from './layout';
+import {assertGeoArrowResourceLimits, type GeoArrowResourceLimitOptions} from './kernels';
+
+/** Options for polygon tessellation. */
+export type TessellateGeoArrowPolygonsOptions = Readonly<{
+  /** Number of values emitted for each output vertex. Defaults to the input dimension. */
+  positionSize?: 2 | 3 | 4;
+  /** Value added to every source row index. */
+  sourceRowOffset?: number;
+  limits?: GeoArrowResourceLimitOptions;
+}>;
+
+/** Flat, renderer-ready output for polygon and multipolygon rows. */
+export type GeoArrowTessellation = Readonly<{
+  positions: Float32Array;
+  /** Source column row for every emitted vertex. */
+  sourceRowIndices: Uint32Array;
+  indices: Uint16Array | Uint32Array;
+  sourceDimension: 2 | 3 | 4;
+  positionSize: 2 | 3 | 4;
+  rowCount: number;
+  polygonCount: number;
+  vertexCount: number;
+  triangleCount: number;
+}>;
+
+/**
+ * Tessellates Polygon and MultiPolygon values with stable source-row attribution.
+ *
+ * Non-polygon members of mixed columns and geometry collections are skipped. Closing coordinates
+ * are removed before triangulation and all input descriptors remain borrowed and untouched.
+ */
+export function tessellateGeoArrowPolygons(
+  column: GeoArrowColumn,
+  options: TessellateGeoArrowPolygonsOptions = {}
+): GeoArrowTessellation {
+  assertGeoArrowResourceLimits(column, options.limits);
+  const rows = materializeGeoArrowRows(column);
+  const sourceDimension = getGeoArrowDimensionSize(column.dimension);
+  const positionSize = options.positionSize || sourceDimension;
+  const sourceRowOffset = options.sourceRowOffset || 0;
+  const positions: number[] = [];
+  const sourceRowIndices: number[] = [];
+  const indices: number[] = [];
+  let polygonCount = 0;
+
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    const row = rows[rowIndex];
+    if (row) {
+      visitPolygons(row, polygon => {
+        const vertexOffset = positions.length / positionSize;
+        const flatCoordinates: number[] = [];
+        const holeIndices: number[] = [];
+        let localVertexCount = 0;
+
+        for (let ringIndex = 0; ringIndex < polygon.length; ringIndex++) {
+          const ring = removeClosingCoordinate(polygon[ringIndex]);
+          if (ring.length < 3) continue;
+          if (localVertexCount > 0) holeIndices.push(localVertexCount);
+          for (const coordinate of ring) {
+            for (let component = 0; component < sourceDimension; component++) {
+              flatCoordinates.push(coordinate[component] ?? 0);
+            }
+            for (let component = 0; component < positionSize; component++) {
+              positions.push(coordinate[component] ?? 0);
+            }
+            sourceRowIndices.push(sourceRowOffset + rowIndex);
+            localVertexCount++;
+          }
+        }
+
+        if (localVertexCount >= 3) {
+          const localIndices = earcut(flatCoordinates, holeIndices, sourceDimension);
+          for (const index of localIndices) indices.push(vertexOffset + index);
+          polygonCount++;
+        }
+      });
+    }
+  }
+
+  const vertexCount = positions.length / positionSize;
+  const IndexArray = vertexCount <= 65535 ? Uint16Array : Uint32Array;
+  return {
+    positions: Float32Array.from(positions),
+    sourceRowIndices: Uint32Array.from(sourceRowIndices),
+    indices: IndexArray.from(indices),
+    sourceDimension,
+    positionSize,
+    rowCount: rows.length,
+    polygonCount,
+    vertexCount,
+    triangleCount: indices.length / 3
+  };
+}
+
+function visitPolygons(
+  geometry: GeoArrowGeometryValue,
+  visitor: (polygon: readonly (readonly (readonly number[])[])[]) => void
+): void {
+  switch (geometry.type) {
+    case 'Polygon':
+      visitor(geometry.coordinates);
+      break;
+    case 'MultiPolygon':
+      for (const polygon of geometry.coordinates) visitor(polygon);
+      break;
+    case 'GeometryCollection':
+      for (const child of geometry.geometries) visitPolygons(child, visitor);
+      break;
+    default:
+      break;
+  }
+}
+
+function removeClosingCoordinate(
+  ring: readonly (readonly number[])[]
+): readonly (readonly number[])[] {
+  if (ring.length < 2) return ring;
+  const first = ring[0];
+  const last = ring[ring.length - 1];
+  if (first.length !== last.length) return ring;
+  for (let index = 0; index < first.length; index++) {
+    if (first[index] !== last[index]) return ring;
+  }
+  return ring.slice(0, -1);
+}

--- a/modules/geoarrow/src/types.ts
+++ b/modules/geoarrow/src/types.ts
@@ -1,0 +1,212 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {SpatialReference} from '@math.gl/crs';
+import type {TypedArray} from '@math.gl/types';
+
+/** GeoArrow concrete, mixed, bounding-box, and serialized encodings. */
+export type GeoArrowEncoding =
+  | 'geoarrow.point'
+  | 'geoarrow.linestring'
+  | 'geoarrow.polygon'
+  | 'geoarrow.multipoint'
+  | 'geoarrow.multilinestring'
+  | 'geoarrow.multipolygon'
+  | 'geoarrow.geometry'
+  | 'geoarrow.geometrycollection'
+  | 'geoarrow.box'
+  | 'geoarrow.wkb'
+  | 'geoarrow.wkt';
+
+/** Semantic coordinate dimensions. M is never interpreted as Z. */
+export type GeoArrowDimension = 'xy' | 'xyz' | 'xym' | 'xyzm';
+
+/** Physical coordinate organization for native geometries. */
+export type GeoArrowCoordinateLayout = 'interleaved' | 'separated';
+
+/** Supported list-offset buffers. */
+export type GeoArrowOffsets = Int32Array | BigInt64Array;
+
+/** Numeric physical storage accepted by GeoArrow descriptors. */
+export type GeoArrowNumericArray = TypedArray | BigInt64Array | BigUint64Array;
+
+/** Borrowed validity bitmap. Set bits are valid rows. */
+export type GeoArrowValidity = Readonly<{
+  values: Uint8Array;
+  /** Bit position corresponding to logical row zero. */
+  bitOffset?: number;
+}>;
+
+/** Properties shared by all physical arrays. */
+export type GeoArrowArrayBase = Readonly<{
+  /** Number of logical values represented by this array. */
+  length: number;
+  /** Optional borrowed validity bitmap for this nesting level. */
+  validity?: GeoArrowValidity;
+}>;
+
+/** Primitive scalar storage, optionally strided within a typed array. */
+export type GeoArrowPrimitive = GeoArrowArrayBase &
+  Readonly<{
+    kind: 'primitive';
+    values: GeoArrowNumericArray;
+    /** Scalar offset of logical value zero. */
+    offset?: number;
+    /** Scalars between consecutive logical values. Defaults to one. */
+    stride?: number;
+  }>;
+
+/** Fixed-size list storage, used for interleaved coordinate tuples. */
+export type GeoArrowFixedSizeList = GeoArrowArrayBase &
+  Readonly<{
+    kind: 'fixed-size-list';
+    size: number;
+    child: GeoArrowArray;
+    /** Logical list offset into the child. */
+    offset?: number;
+  }>;
+
+/** Variable-size list storage. */
+export type GeoArrowList = GeoArrowArrayBase &
+  Readonly<{
+    kind: 'list';
+    offsets: GeoArrowOffsets;
+    /** Index of logical row zero in `offsets`. */
+    offset?: number;
+    /** Value subtracted from offsets before indexing the supplied child view. */
+    offsetBase?: number | bigint;
+    child: GeoArrowArray;
+  }>;
+
+/** Named separated children, used for separated coordinates and boxes. */
+export type GeoArrowStruct = GeoArrowArrayBase &
+  Readonly<{
+    kind: 'struct';
+    children: Readonly<Record<string, GeoArrowArray>>;
+    /** Logical struct offset applied to every child. */
+    offset?: number;
+  }>;
+
+/** Struct storage used by `geoarrow.box` minimum/maximum ordinate columns. */
+export type GeoArrowBox = GeoArrowStruct;
+
+/** One dense-union child and its stable type ID. */
+export type GeoArrowDenseUnionChild = Readonly<{
+  name: string;
+  typeId: number;
+  data: GeoArrowArray;
+}>;
+
+/** Dense-union storage for mixed geometry families. */
+export type GeoArrowDenseUnion = GeoArrowArrayBase &
+  Readonly<{
+    kind: 'dense-union';
+    typeIds: Int8Array | Uint8Array;
+    valueOffsets: Int32Array;
+    children: readonly GeoArrowDenseUnionChild[];
+    /** Logical row offset into typeIds and valueOffsets. */
+    offset?: number;
+  }>;
+
+/** Variable-width binary or UTF-8 storage for WKB and WKT. */
+export type GeoArrowSerialized = GeoArrowArrayBase &
+  Readonly<{
+    kind: 'serialized';
+    encoding: 'binary' | 'utf8';
+    offsets: GeoArrowOffsets;
+    values: Uint8Array;
+    /** Index of logical row zero in `offsets`. */
+    offset?: number;
+    /** Value subtracted from offsets before indexing `values`. */
+    offsetBase?: number | bigint;
+  }>;
+
+/** Arrow-compatible physical array tree without Arrow runtime classes. */
+export type GeoArrowArray =
+  | GeoArrowPrimitive
+  | GeoArrowFixedSizeList
+  | GeoArrowList
+  | GeoArrowStruct
+  | GeoArrowDenseUnion
+  | GeoArrowSerialized;
+
+/** One logical GeoArrow geometry column backed by borrowed chunks. */
+export type GeoArrowColumn = Readonly<{
+  encoding: GeoArrowEncoding;
+  dimension: GeoArrowDimension;
+  coordinateLayout: GeoArrowCoordinateLayout | null;
+  chunks: readonly GeoArrowArray[];
+  spatialReference?: SpatialReference | null;
+  edges?: 'planar' | 'spherical';
+  metadata?: Readonly<Record<string, unknown>>;
+}>;
+
+/** Materialized geometry value used at codec and builder boundaries. */
+export type GeoArrowGeometryValue =
+  | Readonly<{type: 'Point'; coordinates: readonly number[]}>
+  | Readonly<{type: 'LineString'; coordinates: readonly (readonly number[])[]}>
+  | Readonly<{type: 'Polygon'; coordinates: readonly (readonly (readonly number[])[])[]}>
+  | Readonly<{type: 'MultiPoint'; coordinates: readonly (readonly number[])[]}>
+  | Readonly<{
+      type: 'MultiLineString';
+      coordinates: readonly (readonly (readonly number[])[])[];
+    }>
+  | Readonly<{
+      type: 'MultiPolygon';
+      coordinates: readonly (readonly (readonly (readonly number[])[])[])[];
+    }>
+  | Readonly<{type: 'GeometryCollection'; geometries: readonly GeoArrowGeometryValue[]}>;
+
+/** Coordinate callback used by mapping kernels. */
+export type GeoArrowCoordinateMapper = (
+  coordinate: readonly number[],
+  rowIndex: number
+) => readonly number[];
+
+/** Four-value XY bounds. */
+export type GeoArrowBounds = readonly [number, number, number, number];
+
+/** Returns the number of coordinate components for a semantic dimension. */
+export function getGeoArrowDimensionSize(dimension: GeoArrowDimension): 2 | 3 | 4 {
+  switch (dimension) {
+    case 'xy':
+      return 2;
+    case 'xyz':
+    case 'xym':
+      return 3;
+    case 'xyzm':
+      return 4;
+  }
+}
+
+/** Returns the concrete geometry family associated with an encoding. */
+export function getGeoArrowGeometryType(
+  encoding: GeoArrowEncoding
+): Exclude<GeoArrowGeometryValue['type'], 'GeometryCollection'> | 'GeometryCollection' | null {
+  switch (encoding) {
+    case 'geoarrow.point':
+      return 'Point';
+    case 'geoarrow.linestring':
+      return 'LineString';
+    case 'geoarrow.polygon':
+      return 'Polygon';
+    case 'geoarrow.multipoint':
+      return 'MultiPoint';
+    case 'geoarrow.multilinestring':
+      return 'MultiLineString';
+    case 'geoarrow.multipolygon':
+      return 'MultiPolygon';
+    case 'geoarrow.geometrycollection':
+      return 'GeometryCollection';
+    default:
+      return null;
+  }
+}
+
+/** Returns the canonical concrete encoding for a materialized geometry family. */
+export function getGeoArrowEncodingForGeometry(
+  type: GeoArrowGeometryValue['type']
+): GeoArrowEncoding {
+  return `geoarrow.${type.toLowerCase()}` as GeoArrowEncoding;
+}

--- a/modules/geoarrow/src/worker.ts
+++ b/modules/geoarrow/src/worker.ts
@@ -1,0 +1,20 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {GeoArrowColumn} from './types';
+import {getGeoArrowTransferList} from './layout';
+
+export {getGeoArrowTransferList} from './layout';
+export type {GeoArrowColumn} from './types';
+
+/** A column and the unique borrowed buffers that may be transferred with it. */
+export type GeoArrowTransfer = Readonly<{
+  column: GeoArrowColumn;
+  transferList: ArrayBuffer[];
+}>;
+
+/** Prepares an explicit structured-clone transfer payload without detaching any buffers. */
+export function prepareGeoArrowTransfer(column: GeoArrowColumn): GeoArrowTransfer {
+  return {column, transferList: getGeoArrowTransferList(column)};
+}

--- a/modules/geoarrow/test/codecs.spec.ts
+++ b/modules/geoarrow/test/codecs.spec.ts
@@ -126,6 +126,8 @@ test('serialized identity and malformed inputs are handled', () => {
   expect(() => parseWKB(new Uint8Array([1, 1, 0]))).toThrow(/end of WKB/);
   expect(() => parseWKT('POLYGON (0 0, 1 1)')).toThrow();
   expect(() => parseWKT('NOTAGEOMETRY (0 0)')).toThrow(/Unsupported/);
+  expect(() => parseWKT('POINT @ (1 2)')).toThrow(/Unexpected WKT character/);
+  expect(() => parseWKT('POINT (1; 2)')).toThrow(/Unexpected WKT character/);
 });
 
 test('WKB accepts big-endian and EWKB Z/SRID headers', () => {

--- a/modules/geoarrow/test/codecs.spec.ts
+++ b/modules/geoarrow/test/codecs.spec.ts
@@ -1,0 +1,230 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {
+  decodeGeoArrowWKB,
+  decodeGeoArrowWKT,
+  encodeGeoArrowWKB,
+  encodeGeoArrowWKT,
+  formatWKT,
+  makeGeoArrowColumnFromGeometryRows,
+  parseWKB,
+  parseWKT,
+  writeWKB,
+  type GeoArrowColumn,
+  type GeoArrowDimension,
+  type GeoArrowGeometryValue
+} from '../src/index';
+import {materializeGeoArrowRows} from '../src/layout';
+
+const geometries: GeoArrowGeometryValue[] = [
+  {type: 'Point', coordinates: [1, 2]},
+  {
+    type: 'LineString',
+    coordinates: [
+      [0, 0],
+      [1, 2]
+    ]
+  },
+  {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [0, 0],
+        [2, 0],
+        [0, 2],
+        [0, 0]
+      ]
+    ]
+  },
+  {
+    type: 'MultiPoint',
+    coordinates: [
+      [0, 0],
+      [1, 2]
+    ]
+  },
+  {
+    type: 'MultiLineString',
+    coordinates: [
+      [
+        [0, 0],
+        [1, 2]
+      ],
+      [
+        [3, 4],
+        [5, 6]
+      ]
+    ]
+  },
+  {
+    type: 'MultiPolygon',
+    coordinates: [
+      [
+        [
+          [0, 0],
+          [2, 0],
+          [0, 2],
+          [0, 0]
+        ]
+      ]
+    ]
+  },
+  {
+    type: 'GeometryCollection',
+    geometries: [
+      {type: 'Point', coordinates: [1, 2]},
+      {
+        type: 'LineString',
+        coordinates: [
+          [3, 4],
+          [5, 6]
+        ]
+      }
+    ]
+  }
+];
+
+test('WKB and WKT round-trip every geometry family', () => {
+  for (const geometry of geometries) {
+    expect(parseWKB(writeWKB(geometry)).geometry).toEqual(geometry);
+    expect(parseWKT(formatWKT(geometry))).toEqual(geometry);
+  }
+});
+
+test('column codecs preserve nulls, declared dimensions and metadata', () => {
+  for (const dimension of ['xy', 'xyz', 'xym', 'xyzm'] as GeoArrowDimension[]) {
+    const size = dimension === 'xy' ? 2 : dimension === 'xyzm' ? 4 : 3;
+    const point: GeoArrowGeometryValue = {
+      type: 'Point',
+      coordinates: Array.from({length: size}, (_, index) => index + 1)
+    };
+    const source = {
+      ...makeGeoArrowColumnFromGeometryRows([point, null], {dimension}),
+      metadata: {fixture: true}
+    };
+    for (const encoded of [encodeGeoArrowWKB(source), encodeGeoArrowWKT(source)]) {
+      const decoded =
+        encoded.encoding === 'geoarrow.wkb'
+          ? decodeGeoArrowWKB(encoded)
+          : decodeGeoArrowWKT(encoded);
+      expect(decoded.dimension).toBe(dimension);
+      expect(decoded.metadata).toBe(source.metadata);
+      expect(materializeGeoArrowRows(decoded)).toEqual([point, null]);
+    }
+  }
+});
+
+test('serialized identity and malformed inputs are handled', () => {
+  const source = makeGeoArrowColumnFromGeometryRows([{type: 'Point', coordinates: [1, 2]}]);
+  const wkb = encodeGeoArrowWKB(source);
+  const wkt = encodeGeoArrowWKT(source);
+  expect(encodeGeoArrowWKB(wkb)).toBe(wkb);
+  expect(encodeGeoArrowWKT(wkt)).toBe(wkt);
+  expect(() => parseWKB(new Uint8Array([1, 1, 0]))).toThrow(/end of WKB/);
+  expect(() => parseWKT('POLYGON (0 0, 1 1)')).toThrow();
+  expect(() => parseWKT('NOTAGEOMETRY (0 0)')).toThrow(/Unsupported/);
+});
+
+test('WKB accepts big-endian and EWKB Z/SRID headers', () => {
+  const bigEndian = new Uint8Array(21);
+  const bigEndianView = new DataView(bigEndian.buffer);
+  bigEndianView.setUint8(0, 0);
+  bigEndianView.setUint32(1, 1, false);
+  bigEndianView.setFloat64(5, 12.5, false);
+  bigEndianView.setFloat64(13, -4.25, false);
+  expect(parseWKB(bigEndian).geometry).toEqual({type: 'Point', coordinates: [12.5, -4.25]});
+
+  const ewkb = new Uint8Array(33);
+  const ewkbView = new DataView(ewkb.buffer);
+  ewkbView.setUint8(0, 1);
+  ewkbView.setUint32(1, 0xa0000001, true);
+  ewkbView.setUint32(5, 4326, true);
+  ewkbView.setFloat64(9, 1, true);
+  ewkbView.setFloat64(17, 2, true);
+  ewkbView.setFloat64(25, 3, true);
+  expect(parseWKB(ewkb).geometry).toEqual({type: 'Point', coordinates: [1, 2, 3]});
+});
+
+test('WKT accepts empties and both MultiPoint syntaxes', () => {
+  expect(parseWKT('LINESTRING EMPTY')).toEqual({type: 'LineString', coordinates: []});
+  expect(formatWKT(parseWKT('POINT EMPTY'))).toBe('POINT EMPTY');
+  expect(formatWKT(parseWKT('GEOMETRYCOLLECTION EMPTY'))).toBe('GEOMETRYCOLLECTION EMPTY');
+  expect(parseWKT('MULTIPOINT (1 2, 3 4)')).toEqual({
+    type: 'MultiPoint',
+    coordinates: [
+      [1, 2],
+      [3, 4]
+    ]
+  });
+  expect(parseWKT('MULTIPOINT ((1 2), (3 4))')).toEqual({
+    type: 'MultiPoint',
+    coordinates: [
+      [1, 2],
+      [3, 4]
+    ]
+  });
+});
+
+test('serialized mixed-dimension collections normalize to the declared column dimension', () => {
+  const point = writeWKB({type: 'Point', coordinates: [1, 2]}, 'xy');
+  const line = writeWKB(
+    {
+      type: 'LineString',
+      coordinates: [
+        [3, 4, 5, 6],
+        [7, 8, 9, 10]
+      ]
+    },
+    'xyzm'
+  );
+  const wkbBytes = Uint8Array.from([1, 7, 0, 0, 0, 2, 0, 0, 0, ...point, ...line]);
+  const wktBytes = new TextEncoder().encode(
+    'GEOMETRYCOLLECTION ZM (POINT (1 2), LINESTRING ZM (3 4 5 6, 7 8 9 10))'
+  );
+  const columns: GeoArrowColumn[] = [
+    makeSerializedFixture('geoarrow.wkb', 'binary', wkbBytes),
+    makeSerializedFixture('geoarrow.wkt', 'utf8', wktBytes)
+  ];
+  for (const serialized of columns) {
+    const decoded =
+      serialized.encoding === 'geoarrow.wkb'
+        ? decodeGeoArrowWKB(serialized)
+        : decodeGeoArrowWKT(serialized);
+    const collection = materializeGeoArrowRows(decoded)[0] as Extract<
+      GeoArrowGeometryValue,
+      {type: 'GeometryCollection'}
+    >;
+    expect(collection.geometries[0]).toEqual({type: 'Point', coordinates: [1, 2, 0, 0]});
+    expect(collection.geometries[1]).toEqual({
+      type: 'LineString',
+      coordinates: [
+        [3, 4, 5, 6],
+        [7, 8, 9, 10]
+      ]
+    });
+  }
+});
+
+function makeSerializedFixture(
+  encoding: 'geoarrow.wkb' | 'geoarrow.wkt',
+  physicalEncoding: 'binary' | 'utf8',
+  values: Uint8Array
+): GeoArrowColumn {
+  return {
+    encoding,
+    dimension: 'xyzm',
+    coordinateLayout: null,
+    chunks: [
+      {
+        kind: 'serialized',
+        encoding: physicalEncoding,
+        length: 1,
+        offsets: new Int32Array([0, values.length]),
+        values
+      }
+    ]
+  };
+}

--- a/modules/geoarrow/test/kernels.spec.ts
+++ b/modules/geoarrow/test/kernels.spec.ts
@@ -75,6 +75,49 @@ test('conversion forces dense unions and never reinterprets M as Z', () => {
   expect(materializeGeoArrowRows(mixed)).toEqual([{type: 'Point', coordinates: [1, 2, 99]}]);
 });
 
+test('dimension conversion recurses through nested geometry collections', () => {
+  const source = makeGeoArrowColumnFromGeometryRows([
+    {
+      type: 'GeometryCollection',
+      geometries: [
+        {type: 'Point', coordinates: [1, 2]},
+        {
+          type: 'GeometryCollection',
+          geometries: [{type: 'LineString', coordinates: [[3, 4]]}]
+        }
+      ]
+    }
+  ]);
+  const converted = convertGeoArrowColumn(source, {dimension: 'xyz'});
+  expect(materializeGeoArrowRows(converted)).toEqual([
+    {
+      type: 'GeometryCollection',
+      geometries: [
+        {type: 'Point', coordinates: [1, 2, 0]},
+        {
+          type: 'GeometryCollection',
+          geometries: [{type: 'LineString', coordinates: [[3, 4, 0]]}]
+        }
+      ]
+    }
+  ]);
+});
+
+test('dimension inference recurses through nested geometry collections', () => {
+  const geometry: GeoArrowGeometryValue = {
+    type: 'GeometryCollection',
+    geometries: [
+      {
+        type: 'GeometryCollection',
+        geometries: [{type: 'Point', coordinates: [1, 2, 3]}]
+      }
+    ]
+  };
+  const column = makeGeoArrowColumnFromGeometryRows([geometry]);
+  expect(column.dimension).toBe('xyz');
+  expect(materializeGeoArrowRows(column)).toEqual([geometry]);
+});
+
 test('winding normalization changes only rings with the wrong orientation', () => {
   const polygon: GeoArrowGeometryValue = {
     type: 'Polygon',

--- a/modules/geoarrow/test/kernels.spec.ts
+++ b/modules/geoarrow/test/kernels.spec.ts
@@ -1,0 +1,225 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {
+  assertGeoArrowResourceLimits,
+  convertGeoArrowColumn,
+  getGeoArrowBounds,
+  getGeoArrowVertexCount,
+  interleaveGeoArrowCoordinates,
+  makeGeoArrowColumnFromGeometryRows,
+  mapGeoArrowCoordinates,
+  mapGeoArrowCoordinatesInto,
+  rewindGeoArrow,
+  tessellateGeoArrowPolygons,
+  type GeoArrowGeometryValue
+} from '../src/index';
+import {materializeGeoArrowRows} from '../src/layout';
+
+test('coordinate mapping, into mapping and layout conversion are deterministic', () => {
+  const source = makeGeoArrowColumnFromGeometryRows(
+    [
+      {
+        type: 'LineString',
+        coordinates: [
+          [1, 2],
+          [3, 4]
+        ]
+      }
+    ],
+    {coordinateLayout: 'separated'}
+  );
+  const mapped = mapGeoArrowCoordinates(source, coordinate => [
+    coordinate[0] + 10,
+    coordinate[1] - 1
+  ]);
+  expect(getGeoArrowBounds(mapped)).toEqual([11, 1, 13, 3]);
+  const target = mapGeoArrowCoordinates(source, () => [0, 0]);
+  expect(
+    mapGeoArrowCoordinatesInto(target, source, coordinate => [coordinate[0] * 2, coordinate[1] * 3])
+  ).toBe(target);
+  expect(getGeoArrowBounds(target)).toEqual([2, 6, 6, 12]);
+  expect(interleaveGeoArrowCoordinates(source).coordinateLayout).toBe('interleaved');
+});
+
+test('conversion round trips preserve geometry values', () => {
+  let seed = 0x12345678;
+  const random = (): number => {
+    seed = (1664525 * seed + 1013904223) >>> 0;
+    return seed / 0x100000000;
+  };
+  for (let iteration = 0; iteration < 50; iteration++) {
+    const points = Array.from({length: 1 + Math.floor(random() * 20)}, () => [
+      random() * 20 - 10,
+      random() * 20 - 10
+    ]);
+    const source = makeGeoArrowColumnFromGeometryRows([{type: 'LineString', coordinates: points}]);
+    const separated = convertGeoArrowColumn(source, {coordinateLayout: 'separated'});
+    const roundTrip = convertGeoArrowColumn(separated, {coordinateLayout: 'interleaved'});
+    expect(materializeGeoArrowRows(roundTrip)).toEqual(materializeGeoArrowRows(source));
+    expect(getGeoArrowBounds(roundTrip)).toEqual(getGeoArrowBounds(source));
+  }
+});
+
+test('conversion forces dense unions and never reinterprets M as Z', () => {
+  const xym = makeGeoArrowColumnFromGeometryRows([{type: 'Point', coordinates: [1, 2, 99]}], {
+    dimension: 'xym'
+  });
+  const xyz = convertGeoArrowColumn(xym, {dimension: 'xyz'});
+  expect(materializeGeoArrowRows(xyz)).toEqual([{type: 'Point', coordinates: [1, 2, 0]}]);
+  const mixed = convertGeoArrowColumn(xym, {encoding: 'geoarrow.geometry'});
+  expect(mixed.encoding).toBe('geoarrow.geometry');
+  expect(mixed.chunks[0].kind).toBe('dense-union');
+  expect(materializeGeoArrowRows(mixed)).toEqual([{type: 'Point', coordinates: [1, 2, 99]}]);
+});
+
+test('winding normalization changes only rings with the wrong orientation', () => {
+  const polygon: GeoArrowGeometryValue = {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [0, 0],
+        [0, 4],
+        [4, 4],
+        [4, 0],
+        [0, 0]
+      ],
+      [
+        [1, 1],
+        [2, 1],
+        [2, 2],
+        [1, 2],
+        [1, 1]
+      ]
+    ]
+  };
+  const source = makeGeoArrowColumnFromGeometryRows([polygon]);
+  const rewound = rewindGeoArrow(source, {outer: 'counter-clockwise'});
+  const row = materializeGeoArrowRows(rewound)[0] as Extract<
+    GeoArrowGeometryValue,
+    {type: 'Polygon'}
+  >;
+  expect(signedArea(row.coordinates[0])).toBeGreaterThan(0);
+  expect(signedArea(row.coordinates[1])).toBeLessThan(0);
+  expect(rewindGeoArrow(rewound, {outer: 'counter-clockwise'})).toBe(rewound);
+});
+
+test('polygon tessellation returns exact positions, source rows and indices', () => {
+  const source = makeGeoArrowColumnFromGeometryRows([
+    {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0, 0],
+          [2, 0],
+          [2, 2],
+          [0, 2],
+          [0, 0]
+        ]
+      ]
+    },
+    null,
+    {
+      type: 'MultiPolygon',
+      coordinates: [
+        [
+          [
+            [3, 0],
+            [4, 0],
+            [3, 1],
+            [3, 0]
+          ]
+        ]
+      ]
+    }
+  ]);
+  const result = tessellateGeoArrowPolygons(source, {positionSize: 3, sourceRowOffset: 10});
+  expect(Array.from(result.positions)).toEqual([
+    0, 0, 0, 2, 0, 0, 2, 2, 0, 0, 2, 0, 3, 0, 0, 4, 0, 0, 3, 1, 0
+  ]);
+  expect(Array.from(result.sourceRowIndices)).toEqual([10, 10, 10, 10, 12, 12, 12]);
+  expect(Array.from(result.indices)).toEqual([2, 3, 0, 0, 1, 2, 5, 6, 4]);
+  expect(result).toMatchObject({polygonCount: 2, vertexCount: 7, triangleCount: 3, rowCount: 3});
+});
+
+test('ported tessellation fixtures preserve holes and normalize separated ZM storage', () => {
+  const polygon: GeoArrowGeometryValue = {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [0, 0, 1, 10],
+        [4, 0, 2, 20],
+        [4, 4, 3, 30],
+        [0, 4, 4, 40]
+      ],
+      [
+        [1, 1, 5, 50],
+        [1, 3, 6, 60],
+        [3, 3, 7, 70],
+        [3, 1, 8, 80]
+      ]
+    ]
+  };
+  const separated = makeGeoArrowColumnFromGeometryRows([polygon], {
+    dimension: 'xyzm',
+    coordinateLayout: 'separated'
+  });
+  const interleaved = makeGeoArrowColumnFromGeometryRows([polygon], {
+    dimension: 'xyzm',
+    coordinateLayout: 'interleaved'
+  });
+  const separatedResult = tessellateGeoArrowPolygons(separated);
+  const interleavedResult = tessellateGeoArrowPolygons(interleaved);
+
+  expect(separatedResult.sourceDimension).toBe(4);
+  expect(Array.from(separatedResult.positions)).toEqual(Array.from(interleavedResult.positions));
+  expect(Array.from(separatedResult.indices)).toEqual(Array.from(interleavedResult.indices));
+  expect(separatedResult.vertexCount).toBe(8);
+  for (let index = 0; index < separatedResult.indices.length; index += 3) {
+    const a = separatedResult.indices[index] * 4;
+    const b = separatedResult.indices[index + 1] * 4;
+    const c = separatedResult.indices[index + 2] * 4;
+    const x =
+      (separatedResult.positions[a] + separatedResult.positions[b] + separatedResult.positions[c]) /
+      3;
+    const y =
+      (separatedResult.positions[a + 1] +
+        separatedResult.positions[b + 1] +
+        separatedResult.positions[c + 1]) /
+      3;
+    expect(x > 1 && x < 3 && y > 1 && y < 3).toBe(false);
+  }
+});
+
+test('resource limits fail before materializing expensive work', () => {
+  const source = makeGeoArrowColumnFromGeometryRows([
+    {
+      type: 'LineString',
+      coordinates: [
+        [0, 0],
+        [1, 1],
+        [2, 2]
+      ]
+    }
+  ]);
+  expect(() => assertGeoArrowResourceLimits(source, {maximumRows: 0})).toThrow(/maximumRows/);
+  expect(() => assertGeoArrowResourceLimits(source, {maximumCoordinates: 2})).toThrow(
+    /maximumCoordinates/
+  );
+  expect(() => assertGeoArrowResourceLimits(source, {maximumOutputBytes: 1})).toThrow(
+    /maximumOutputBytes/
+  );
+  expect(getGeoArrowVertexCount(source)).toBe(3);
+});
+
+function signedArea(ring: readonly (readonly number[])[]): number {
+  let area = 0;
+  for (let index = 0; index < ring.length; index++) {
+    const current = ring[index];
+    const next = ring[(index + 1) % ring.length];
+    area += current[0] * next[1] - next[0] * current[1];
+  }
+  return area / 2;
+}

--- a/modules/geoarrow/test/layout.spec.ts
+++ b/modules/geoarrow/test/layout.spec.ts
@@ -1,0 +1,298 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {
+  convertGeoArrowColumn,
+  GeoArrowBuilder,
+  getGeoArrowBounds,
+  getGeoArrowTransferList,
+  getGeoArrowVertexCount,
+  inspectGeoArrowColumn,
+  interleaveGeoArrowCoordinates,
+  makeGeoArrowColumnFromGeometryRows,
+  sliceGeoArrowColumn,
+  validateGeoArrowColumn,
+  type GeoArrowColumn,
+  type GeoArrowDimension,
+  type GeoArrowGeometryValue
+} from '../src/index';
+import {prepareGeoArrowTransfer} from '../src/worker';
+
+const concreteFixtures: GeoArrowGeometryValue[] = [
+  {type: 'Point', coordinates: [1, 2]},
+  {
+    type: 'LineString',
+    coordinates: [
+      [0, 0],
+      [1, 1]
+    ]
+  },
+  {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [0, 0],
+        [2, 0],
+        [2, 2],
+        [0, 0]
+      ]
+    ]
+  },
+  {
+    type: 'MultiPoint',
+    coordinates: [
+      [0, 0],
+      [1, 1]
+    ]
+  },
+  {
+    type: 'MultiLineString',
+    coordinates: [
+      [
+        [0, 0],
+        [1, 1]
+      ],
+      [
+        [2, 2],
+        [3, 3]
+      ]
+    ]
+  },
+  {
+    type: 'MultiPolygon',
+    coordinates: [
+      [
+        [
+          [0, 0],
+          [2, 0],
+          [2, 2],
+          [0, 0]
+        ]
+      ]
+    ]
+  }
+];
+
+test('GeoArrowBuilder writes all concrete geometry families', () => {
+  for (const fixture of concreteFixtures) {
+    const column = makeGeoArrowColumnFromGeometryRows([fixture, null]);
+    const inspection = inspectGeoArrowColumn(column);
+    expect(inspection.valid, fixture.type).toBe(true);
+    expect(inspection.rowCount).toBe(2);
+    expect(inspection.nullCount).toBe(1);
+    expect(inspection.coordinateCount).toBeGreaterThan(0);
+  }
+});
+
+test('GeoArrowBuilder measure and write passes have exact parity', () => {
+  const rows: Array<GeoArrowGeometryValue | null> = [
+    {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0, 0, 5, 9],
+          [4, 0, 6, 9],
+          [0, 4, 7, 9],
+          [0, 0, 5, 9]
+        ]
+      ]
+    },
+    null,
+    {type: 'Polygon', coordinates: []}
+  ];
+  const options = {
+    encoding: 'geoarrow.polygon' as const,
+    dimension: 'xyzm' as const,
+    coordinateLayout: 'separated' as const,
+    offsetType: 'int64' as const
+  };
+  const measure = new GeoArrowBuilder({...options, mode: 'measure'});
+  rows.forEach(row => measure.append(row));
+  const target = measure.allocateTarget();
+  const write = new GeoArrowBuilder({...options, mode: 'write', target});
+  rows.forEach(row => write.append(row));
+  const column = write.finish();
+
+  expect(measure.getMeasurement()).toEqual(write.getMeasurement());
+  expect(target.geometryOffsets).toBeInstanceOf(BigInt64Array);
+  expect(validateGeoArrowColumn(column).valid).toBe(true);
+  expect(getGeoArrowBounds(column)).toEqual([0, 0, 4, 4]);
+  expect(getGeoArrowVertexCount(column)).toBe(4);
+});
+
+test('dimensions, coordinate layouts and Int32/Int64 offsets conform', () => {
+  const dimensions: GeoArrowDimension[] = ['xy', 'xyz', 'xym', 'xyzm'];
+  for (const dimension of dimensions) {
+    const size = dimension === 'xy' ? 2 : dimension === 'xyzm' ? 4 : 3;
+    const coordinate = Array.from({length: size}, (_, index) => index + 1);
+    for (const coordinateLayout of ['interleaved', 'separated'] as const) {
+      for (const offsetType of ['int32', 'int64'] as const) {
+        const column = GeoArrowBuilder.build(
+          [{type: 'LineString', coordinates: [coordinate, coordinate]}],
+          {encoding: 'geoarrow.linestring', dimension, coordinateLayout, offsetType}
+        );
+        expect(validateGeoArrowColumn(column).valid).toBe(true);
+        expect(getGeoArrowVertexCount(column)).toBe(2);
+        const interleaved = interleaveGeoArrowCoordinates(column);
+        expect(interleaved.coordinateLayout).toBe('interleaved');
+        expect(getGeoArrowBounds(interleaved)).toEqual([1, 2, 1, 2]);
+      }
+    }
+  }
+});
+
+test('identity conversion and full slices preserve descriptor and buffer identity', () => {
+  const column = GeoArrowBuilder.build([{type: 'Point', coordinates: [1, 2]}], {
+    encoding: 'geoarrow.point'
+  });
+  const buffers = getGeoArrowTransferList(column);
+  expect(convertGeoArrowColumn(column)).toBe(column);
+  expect(interleaveGeoArrowCoordinates(column)).toBe(column);
+  expect(sliceGeoArrowColumn(column)).toBe(column);
+  expect(getGeoArrowTransferList(column)[0]).toBe(buffers[0]);
+  const transfer = prepareGeoArrowTransfer(column);
+  expect(transfer.column).toBe(column);
+  expect(transfer.transferList).toEqual(buffers);
+});
+
+test('sliced validity bitmaps, chunks, nulls and empties are honored', () => {
+  const first = GeoArrowBuilder.build(
+    [
+      {type: 'Point', coordinates: [0, 0]},
+      null,
+      {type: 'Point', coordinates: [2, 2]},
+      {type: 'Point', coordinates: [3, 3]}
+    ],
+    {encoding: 'geoarrow.point'}
+  );
+  const second = GeoArrowBuilder.build([{type: 'Point', coordinates: [4, 4]}, null], {
+    encoding: 'geoarrow.point'
+  });
+  const chunked: GeoArrowColumn = {...first, chunks: [...first.chunks, ...second.chunks]};
+  const sliced = sliceGeoArrowColumn(chunked, 1, 5);
+  expect(inspectGeoArrowColumn(sliced)).toMatchObject({
+    rowCount: 4,
+    nullCount: 1,
+    coordinateCount: 3
+  });
+  expect(getGeoArrowBounds(sliced)).toEqual([2, 2, 4, 4]);
+});
+
+test('dense unions and geometry collections dispatch without row-shape assumptions', () => {
+  const column = makeGeoArrowColumnFromGeometryRows([
+    {type: 'Point', coordinates: [1, 2]},
+    null,
+    {
+      type: 'LineString',
+      coordinates: [
+        [3, 4],
+        [5, 6]
+      ]
+    },
+    {
+      type: 'GeometryCollection',
+      geometries: [
+        {type: 'Point', coordinates: [7, 8]},
+        {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [0, 0],
+              [1, 0],
+              [0, 1],
+              [0, 0]
+            ]
+          ]
+        }
+      ]
+    }
+  ]);
+  expect(column.encoding).toBe('geoarrow.geometry');
+  expect(validateGeoArrowColumn(column).valid).toBe(true);
+  expect(inspectGeoArrowColumn(column)).toMatchObject({rowCount: 4, nullCount: 1});
+  expect(getGeoArrowVertexCount(column)).toBe(8);
+  expect(getGeoArrowBounds(column)).toEqual([0, 0, 7, 8]);
+});
+
+test('validation reports malformed layouts and unsafe offsets', () => {
+  const malformed: GeoArrowColumn = {
+    encoding: 'geoarrow.linestring',
+    dimension: 'xy',
+    coordinateLayout: 'interleaved',
+    chunks: [
+      {
+        kind: 'list',
+        length: 1,
+        offsets: new Int32Array([0, 3]),
+        child: {
+          kind: 'fixed-size-list',
+          length: 1,
+          size: 2,
+          child: {kind: 'primitive', length: 2, values: new Float64Array(2)}
+        },
+        validity: {values: new Uint8Array(0)}
+      }
+    ]
+  };
+  const validation = validateGeoArrowColumn(malformed);
+  expect(validation.valid).toBe(false);
+  expect(validation.issues.map(issue => issue.code)).toContain('invalid-validity');
+  expect(validation.issues.map(issue => issue.code)).toContain('invalid-offset');
+
+  const wrongPoint: GeoArrowColumn = {
+    encoding: 'geoarrow.point',
+    dimension: 'xy',
+    coordinateLayout: 'interleaved',
+    chunks: [{kind: 'primitive', length: 1, values: new Float64Array([1])}]
+  };
+  expect(validateGeoArrowColumn(wrongPoint).issues.map(issue => issue.code)).toContain(
+    'invalid-layout'
+  );
+
+  const unsafeOffsets: GeoArrowColumn = {
+    encoding: 'geoarrow.linestring',
+    dimension: 'xy',
+    coordinateLayout: 'interleaved',
+    chunks: [
+      {
+        kind: 'list',
+        length: 1,
+        offsets: new BigInt64Array([BigInt(Number.MAX_SAFE_INTEGER) + 1n, 0n]),
+        child: {
+          kind: 'fixed-size-list',
+          length: 0,
+          size: 2,
+          child: {kind: 'primitive', length: 0, values: new Float64Array(0)}
+        }
+      }
+    ]
+  };
+  expect(validateGeoArrowColumn(unsafeOffsets).issues.map(issue => issue.code)).toContain(
+    'unsafe-offset'
+  );
+});
+
+test('box descriptors validate and contribute bounds without coordinate materialization', () => {
+  const column: GeoArrowColumn = {
+    encoding: 'geoarrow.box',
+    dimension: 'xy',
+    coordinateLayout: 'separated',
+    chunks: [
+      {
+        kind: 'struct',
+        length: 2,
+        children: {
+          xmin: {kind: 'primitive', length: 2, values: new Float64Array([1, -5])},
+          ymin: {kind: 'primitive', length: 2, values: new Float64Array([2, -4])},
+          xmax: {kind: 'primitive', length: 2, values: new Float64Array([3, 8])},
+          ymax: {kind: 'primitive', length: 2, values: new Float64Array([4, 9])}
+        }
+      }
+    ]
+  };
+  expect(validateGeoArrowColumn(column).valid).toBe(true);
+  expect(getGeoArrowBounds(column)).toEqual([-5, -4, 8, 9]);
+  expect(getGeoArrowVertexCount(column)).toBe(0);
+});

--- a/modules/geoarrow/test/layout.spec.ts
+++ b/modules/geoarrow/test/layout.spec.ts
@@ -272,6 +272,26 @@ test('validation reports malformed layouts and unsafe offsets', () => {
   expect(validateGeoArrowColumn(unsafeOffsets).issues.map(issue => issue.code)).toContain(
     'unsafe-offset'
   );
+
+  for (const offset of [-1, 0.5]) {
+    const invalidFixedSizeList: GeoArrowColumn = {
+      encoding: 'geoarrow.point',
+      dimension: 'xy',
+      coordinateLayout: 'interleaved',
+      chunks: [
+        {
+          kind: 'fixed-size-list',
+          length: 1,
+          size: 2,
+          offset,
+          child: {kind: 'primitive', length: 2, values: new Float64Array([1, 2])}
+        }
+      ]
+    };
+    expect(validateGeoArrowColumn(invalidFixedSizeList).issues.map(issue => issue.code)).toContain(
+      'invalid-offset'
+    );
+  }
 });
 
 test('box descriptors validate and contribute bounds without coordinate materialization', () => {

--- a/modules/geoarrow/tsconfig.json
+++ b/modules/geoarrow/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {"composite": true, "rootDir": "src", "outDir": "dist"},
+  "references": [
+    {"path": "../types"},
+    {"path": "../crs"},
+    {"path": "../core"},
+    {"path": "../polygon"}
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "bootstrap": "yarn && ocular-bootstrap && yarn build",
     "build": "ocular-clean && time ocular-build",
     "check:crs-types": "npx tsc --project test/types/crs/tsconfig.json",
+    "check:geoarrow-boundary": "node modules/geoarrow/scripts/check-package-boundary.mjs",
     "check:projjson-types": "node scripts/generate-projjson-types.mjs --check",
     "generate:projjson-types": "node scripts/generate-projjson-types.mjs",
     "cover": "yarn test-coverage",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -65,6 +65,8 @@
       "@math.gl/geoid/test/*": ["./modules/geoid/test/*"],
       "@math.gl/geospatial/*": ["./modules/geospatial/src/*"],
       "@math.gl/geospatial/test/*": ["./modules/geospatial/test/*"],
+      "@math.gl/geoarrow/*": ["./modules/geoarrow/src/*"],
+      "@math.gl/geoarrow/test/*": ["./modules/geoarrow/test/*"],
       "@math.gl/geometry-utils/*": ["./modules/geometry-utils/src/*"],
       "@math.gl/geometry-utils/test/*": ["./modules/geometry-utils/test/*"],
       "@math.gl/polygon/*": ["./modules/polygon/src/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4275,6 +4275,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@math.gl/geoarrow@workspace:modules/geoarrow":
+  version: 0.0.0-use.local
+  resolution: "@math.gl/geoarrow@workspace:modules/geoarrow"
+  dependencies:
+    "@math.gl/crs": "npm:5.0.0-alpha.1"
+    "@math.gl/polygon": "npm:5.0.0-alpha.1"
+    "@math.gl/types": "npm:5.0.0-alpha.1"
+  languageName: unknown
+  linkType: soft
+
 "@math.gl/geoid@workspace:modules/geoid":
   version: 0.0.0-use.local
   resolution: "@math.gl/geoid@workspace:modules/geoid"
@@ -4321,7 +4331,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@math.gl/polygon@workspace:modules/polygon":
+"@math.gl/polygon@npm:5.0.0-alpha.1, @math.gl/polygon@workspace:modules/polygon":
   version: 0.0.0-use.local
   resolution: "@math.gl/polygon@workspace:modules/polygon"
   dependencies:


### PR DESCRIPTION
## Summary

- add `@math.gl/geoarrow`, an Arrow-independent package for borrowed, immutable columnar geometry descriptors
- implement synchronous validation, inspection, traversal, slicing, vertex counting, bounds, coordinate mapping, layout conversion, winding normalization, dense-union normalization, and transfer-list kernels
- add a two-pass `GeoArrowBuilder`, WKB/WKT codecs, and polygon/multipolygon tessellation over plain buffers
- expose optional worker helpers through `@math.gl/geoarrow/worker` while keeping the root API synchronous
- add a package-boundary check that rejects `apache-arrow` references in source, declarations, runtime dependencies, and peer dependencies
- document physical layouts, API contracts, migration paths, ownership rules, identity guarantees, and interoperability patterns

## WKB/WKT boundary

The initial codecs live in `@math.gl/geoarrow` because their current public contract reads or produces GeoArrow column descriptors. A follow-up `@math.gl/wkb` package should extract the format-level parser/encoder behind geometry events or neutral plain descriptors, leaving `@math.gl/geoarrow` as a thin columnar adapter. This keeps the first release reusable without prematurely coupling a general WKB package to GeoArrow's physical ABI.

## Verification

- `yarn install --immutable`
- `yarn build`
- `yarn lint`
- `yarn check:geoarrow-boundary`
- `yarn test-node` — 835 passed, 129 skipped
- `yarn test-headless` — 836 passed, 128 skipped

The PR is one commit based directly on `origin/master`.
