### PR TITLE
docs: document v5 release requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # CHANGELOG
 
-## v5.0.0-alpha.1
+## Unreleased
 
 - feat(wkb): Add dependency-free WKB, EWKB, and WKT geometry codecs and move format parsing out of
-  GeoArrow
+  GeoArrow (#120)
+- feat(core): Add convenience methods to `Quaternion` and `Matrix4` (#54)
 - feat(geoarrow): Add runtime-independent physical descriptors, columnar kernels, codecs, builder,
-  polygon tessellation, and worker-transfer support
+  polygon tessellation, and worker-transfer support (#119)
+- feat(dggs): Consolidate lightweight grid adapters and cell detection in `@math.gl/dggs` (#59)
+
+## v5.0.0-alpha.1
+
 - chore: Improve coverage reporting (#118)
 - feat: Use lowercase string literals for public API constants (#116)
 - feat(proj): Add lightweight EPSG3857 utilities (#117)

--- a/docs/developer-guide/get-started.md
+++ b/docs/developer-guide/get-started.md
@@ -12,6 +12,12 @@ npm install @math.gl/core
 
 Type definitions are provided with each module. There is no need to install any separate types.
 
+math.gl v5 declarations require TypeScript 6.0 or later. The public typed-array definitions refer
+to TypeScript's `es2025.float16` library so that `Float16Array` can be represented accurately. This
+is a type-level requirement only: math.gl does not require or install a runtime `Float16Array`
+implementation. See the [array types guide](../modules/types/api-reference/array-types.md) for
+runtime detection and fallback helpers.
+
 ## ESM modules
 
 Since v4.0, math.gl is published as ES modules, but with a CommonJS named export. This setup should work automatically for most applications and bundlers.

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -4,6 +4,12 @@
 
 Version 5 removes APIs that were deprecated in earlier releases and tightens the dependency boundaries between core classes. The class entry point remains tree-shakeable; low-level gl-matrix-compatible functions now use focused subpath imports.
 
+### TypeScript and runtime support
+
+- Upgrade TypeScript consumers to TypeScript 6.0 or later before installing math.gl v5. The v5 declarations reference TypeScript's `es2025.float16` library to type `Float16Array` accurately.
+- `Float16Array` remains optional at runtime. math.gl detects native or polyfilled support and exposes a `Uint16Array` fallback; it does not install a polyfill.
+- The emitted JavaScript continues to target ES2020. Version 5 does not otherwise raise the runtime policy of evergreen browsers and active or maintenance Node.js LTS releases.
+
 ### Rotation and coordinate conversions
 
 - Replace `euler.getQuaternion()` and `euler.toQuaternion()` with the destination-owned `new Quaternion().fromEuler(euler)`. To reuse an allocation, call `quaternion.fromEuler(euler)` on an existing quaternion.
@@ -51,6 +57,13 @@ import {mat4, vec3} from '@math.gl/core';
 ```
 
 The available subpaths are `@math.gl/core/mat3`, `/mat4`, `/quat`, `/vec2`, `/vec3`, and `/vec4`. Keeping these namespaces out of the root entry point substantially reduces the cost of retaining every root export.
+
+### CRS and proj4 definitions
+
+- Use `CRSDefinition`, PROJJSON types, syntax codecs, and spatial-reference descriptors from the new proj4-independent `@math.gl/crs` package. Authority codes, WKT, and PROJ definitions remain strings, while PROJJSON is the typed semantic object model.
+- `@math.gl/proj4` now uses proj4js 2.20.9. Existing string definitions continue to work. Its `Proj4CRSDefinition` object type intentionally accepts only the `GeographicCRS`, `GeodeticCRS`, `ProjectedCRS`, and `BoundCRS` PROJJSON variants that proj4js can execute.
+- Check broader CRS metadata with `checkProj4CRSCompatibility()` before constructing a projection. `CompoundCRS` and `VerticalCRS` remain valid `@math.gl/crs` definitions but are not directly executable by proj4js; horizontal extraction from a compound definition must be requested explicitly.
+- Axis-order enforcement remains opt-in through `enforceAxis: true`. Register NTv2 grids with `Proj4Projection.registerDatumGrid()` before using definitions that reference them.
 
 ### DGGS packages
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -47,11 +47,11 @@
 
 ## v5.0 (In development)
 
-Target Release Date: Q2, 2026.
+Status: prerelease development.
 
 Highlights:
 
-- TypeScript 6 compatibility.
+- TypeScript 6.0 or later is required for TypeScript consumers; emitted JavaScript continues to target ES2020.
 - New `@math.gl/geometry` CPU primitive mesh and tessellation module.
 - glTF 2.1 box, capsule, cylinder, plane and sphere analytic shapes in `@math.gl/culling`.
 - New expression evaluator module


### PR DESCRIPTION
## Summary

- separate post-`v5.0.0-alpha.1` changes into an Unreleased changelog section
- document TypeScript 6 as the v5 declaration-consumer requirement while clarifying that runtime `Float16Array` remains optional and JavaScript still targets ES2020
- add v4-to-v5 CRS/proj4 migration guidance and replace the stale Q2 2026 target date with prerelease status

## Validation

- `yarn lint`
- `yarn build`
- pre-commit suite: 81 test files passed, 854 tests passed, 125 skipped
- `yarn workspace project-website build`
