### PR TITLE
feat(wkb): add direct buffer traversal and builder

### DIFF
--- a/modules/wkb/README.md
+++ b/modules/wkb/README.md
@@ -97,6 +97,77 @@ const measured = writeWKB({type: 'Point', coordinates: [1, 2, 9]}, 'xym');
 does not emit an EWKB SRID; carry CRS/SRID metadata outside the neutral geometry value or in a
 higher-level container.
 
+### Inspect and scan without decoding
+
+Use `inspectWKBHeader` when routing or classifying data. It reads only the endian flag, type code,
+dimension flags, and optional EWKB SRID; the coordinate payload does not need to be present.
+
+```typescript
+import {inspectWKBHeader, scanWKB} from '@math.gl/wkb';
+
+const header = inspectWKBHeader(bytes);
+console.log(header.geometryType, header.dimension, header.srid);
+
+const statistics = scanWKB(bytes, {maximumElements: 1_000_000});
+console.log(statistics.coordinateCount);
+console.log(statistics.geometryCounts);
+console.log(statistics.bounds); // XYZM-aware finite bounds
+```
+
+`scanWKB` validates exactly one complete value and reports its byte length, geometry families,
+per-family counts, coordinate and ring counts, maximum nesting depth, and finite coordinate bounds.
+It accepts sliced typed-array views and mixed-endian nested geometries.
+
+### Visit coordinates directly
+
+`visitWKB` exposes the same validated traversal through callbacks. Coordinate values are passed as
+individual numbers rather than temporary coordinate arrays.
+
+```typescript
+import {visitWKB} from '@math.gl/wkb';
+
+visitWKB(bytes, {
+  geometry: (header, count, depth) => {
+    console.log(header.geometryType, count, depth);
+  },
+  ring: (pointCount, ringIndex) => {
+    console.log(pointCount, ringIndex);
+  },
+  coordinate: (x, y, z, m, dimension, byteOffset) => {
+    // Inspect, copy, transform, or aggregate directly from the source buffer.
+  }
+});
+```
+
+The visitor does not detach or mutate the input and does not create `WellKnownGeometry` rows.
+
+### Two-pass caller-buffer writing
+
+`WKBBuilder` supports the same geometry event sequence in measurement and write modes. Write mode
+accepts an existing buffer, a sliced typed-array view, and an optional destination offset.
+
+```typescript
+import {WKBBuilder} from '@math.gl/wkb';
+
+function emitLine(builder: WKBBuilder): void {
+  builder.beginLineString(2);
+  builder.writeCoordinate(0, 0, 5);
+  builder.writeCoordinate(10, 20, 6);
+}
+
+const measure = new WKBBuilder({mode: 'measure', dimension: 'xyz'});
+emitLine(measure);
+
+const target = new Uint8Array(measure.finishGeometry());
+const writer = new WKBBuilder({mode: 'write', target, dimension: 'xyz'});
+emitLine(writer);
+```
+
+Builder options include little- or big-endian output, XY/XYZ/XYM/XYZM dimensions, EWKB SRID, and
+coordinate transformation. `WKBBuilder.buildGeometryArray()` additionally returns plain Int32
+offsets, contiguous bytes, and an optional validity bitmap for columnar adapters. It never creates
+Arrow objects.
+
 ## WKT
 
 ```typescript
@@ -142,6 +213,10 @@ boundary check from referencing GeoArrow or Apache Arrow.
 
 - `parseWKB(bytes, options?)`
 - `writeWKB(geometry, dimension?)`
+- `inspectWKBHeader(bytes, byteOffset?)`
+- `visitWKB(bytes, visitor, options?)`
+- `scanWKB(bytes, options?)`
+- `WKBBuilder`
 - `parseWKT(text)`
 - `formatWKT(geometry, dimension?)`
 - `getWellKnownDimensionSize(dimension)`
@@ -150,3 +225,8 @@ boundary check from referencing GeoArrow or Apache Arrow.
 - `WellKnownDimension`
 - `WKBParseOptions`
 - `WKBParseResult`
+- `WKBHeader`
+- `WKBVisitor`
+- `WKBScanResult`
+- `WKBBuilderOptions`
+- `WKBGeometryArray`

--- a/modules/wkb/src/index.ts
+++ b/modules/wkb/src/index.ts
@@ -11,4 +11,27 @@ export {
 export type {WKBParseOptions, WKBParseResult} from './wkb';
 export {parseWKB, writeWKB} from './wkb';
 
+export type {
+  WKBBounds,
+  WKBDialect,
+  WKBGeometryCounts,
+  WKBGeometryType,
+  WKBHeader,
+  WKBScanResult,
+  WKBTraversalOptions,
+  WKBVisitor
+} from './wkb-reader';
+export {inspectWKBHeader, scanWKB, visitWKB} from './wkb-reader';
+
+export type {
+  WKBBuilderBaseOptions,
+  WKBBuilderMeasureOptions,
+  WKBBuilderOptions,
+  WKBBuilderWriteOptions,
+  WKBCoordinateTransform,
+  WKBGeometryArray,
+  WKBGeometryWriter
+} from './wkb-builder';
+export {WKBBuilder} from './wkb-builder';
+
 export {formatWKT, parseWKT} from './wkt';

--- a/modules/wkb/src/wkb-builder.ts
+++ b/modules/wkb/src/wkb-builder.ts
@@ -1,0 +1,367 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {WellKnownDimension} from './types';
+import type {WKBGeometryType} from './wkb-reader';
+
+/** Function that writes one WKB geometry into a builder. */
+export type WKBGeometryWriter = (builder: WKBBuilder) => void;
+
+/** Transforms one complete coordinate before it is written. */
+export type WKBCoordinateTransform = (
+  coordinate: readonly number[],
+  dimension: WellKnownDimension
+) => readonly number[];
+
+/** Options shared by WKB measuring and writing modes. */
+export type WKBBuilderBaseOptions = Readonly<{
+  /** Coordinate dimension written by every geometry header. Defaults to `xy`. */
+  dimension?: WellKnownDimension;
+  /** Byte order written by every geometry header. Defaults to little endian. */
+  byteOrder?: 'little-endian' | 'big-endian';
+  /** Optional EWKB spatial reference identifier. */
+  srid?: number;
+  /** Optional coordinate transform applied during writing and measurement. */
+  transform?: WKBCoordinateTransform;
+}>;
+
+/** Options for a builder that only measures byte length. */
+export type WKBBuilderMeasureOptions = WKBBuilderBaseOptions & Readonly<{mode: 'measure'}>;
+
+/** Options for a builder that writes into caller-owned storage. */
+export type WKBBuilderWriteOptions = WKBBuilderBaseOptions &
+  Readonly<{
+    mode: 'write';
+    target: ArrayBufferLike | ArrayBufferView;
+    /** Starting byte offset within `target`. Defaults to zero. */
+    byteOffset?: number;
+  }>;
+
+/** Constructor options for {@link WKBBuilder}. */
+export type WKBBuilderOptions = WKBBuilderMeasureOptions | WKBBuilderWriteOptions;
+
+/** Plain offset, value, and validity buffers suitable for Arrow Binary adapters. */
+export type WKBGeometryArray = Readonly<{
+  valueOffsets: Int32Array;
+  values: Uint8Array;
+  nullBitmap?: Uint8Array;
+  nullCount: number;
+}>;
+
+const GEOMETRY_TYPE_CODES: Readonly<Record<WKBGeometryType, number>> = {
+  Point: 1,
+  LineString: 2,
+  Polygon: 3,
+  MultiPoint: 4,
+  MultiLineString: 5,
+  MultiPolygon: 6,
+  GeometryCollection: 7
+};
+
+/**
+ * Incremental WKB writer with matching measure and caller-buffer write modes.
+ *
+ * Callers run the same event sequence once in `measure` mode and once in `write`
+ * mode. No Arrow or GeoJSON objects are created by the builder.
+ */
+export class WKBBuilder {
+  readonly mode: 'measure' | 'write';
+  readonly dimension: WellKnownDimension;
+  readonly littleEndian: boolean;
+  readonly srid?: number;
+  readonly transform?: WKBCoordinateTransform;
+
+  private readonly dataView: DataView | null;
+  private readonly startByteOffset: number;
+  private readonly endByteOffset: number;
+  private byteOffset: number;
+
+  constructor(options: WKBBuilderOptions) {
+    this.mode = options.mode;
+    this.dimension = options.dimension ?? 'xy';
+    this.littleEndian = options.byteOrder !== 'big-endian';
+    this.srid = options.srid;
+    this.transform = options.transform;
+    validateSrid(this.srid);
+
+    if (options.mode === 'write') {
+      const dataView = getTargetDataView(options.target);
+      const byteOffset = options.byteOffset ?? 0;
+      if (!Number.isSafeInteger(byteOffset) || byteOffset < 0 || byteOffset > dataView.byteLength) {
+        throw new Error('WKBBuilder byteOffset is outside the target');
+      }
+      this.dataView = dataView;
+      this.startByteOffset = byteOffset;
+      this.endByteOffset = dataView.byteLength;
+      this.byteOffset = byteOffset;
+    } else {
+      this.dataView = null;
+      this.startByteOffset = 0;
+      this.endByteOffset = Number.POSITIVE_INFINITY;
+      this.byteOffset = 0;
+    }
+  }
+
+  /** Begins a geometry and writes its count field when required. */
+  beginGeometry(type: WKBGeometryType, count?: number): void {
+    switch (type) {
+      case 'Point':
+        this.beginPoint();
+        break;
+      case 'LineString':
+        this.beginLineString(count ?? 0);
+        break;
+      case 'Polygon':
+        this.beginPolygon(count ?? 0);
+        break;
+      case 'MultiPoint':
+        this.beginMultiPoint(count ?? 0);
+        break;
+      case 'MultiLineString':
+        this.beginMultiLineString(count ?? 0);
+        break;
+      case 'MultiPolygon':
+        this.beginMultiPolygon(count ?? 0);
+        break;
+      case 'GeometryCollection':
+        this.writeHeader('GeometryCollection');
+        this.writeUint32(count ?? 0);
+        break;
+    }
+  }
+
+  /** Begins one point geometry. */
+  beginPoint(): void {
+    this.writeHeader('Point');
+  }
+
+  /** Begins one linestring geometry. */
+  beginLineString(pointCount: number): void {
+    this.writeHeader('LineString');
+    this.writeUint32(pointCount);
+  }
+
+  /** Begins one polygon geometry. */
+  beginPolygon(ringCount: number): void {
+    this.writeHeader('Polygon');
+    this.writeUint32(ringCount);
+  }
+
+  /** Begins one linear ring inside a polygon. */
+  beginLinearRing(pointCount: number): void {
+    this.writeUint32(pointCount);
+  }
+
+  /** Begins one multipoint geometry. */
+  beginMultiPoint(pointCount: number): void {
+    this.writeHeader('MultiPoint');
+    this.writeUint32(pointCount);
+  }
+
+  /** Begins one multilinestring geometry. */
+  beginMultiLineString(lineCount: number): void {
+    this.writeHeader('MultiLineString');
+    this.writeUint32(lineCount);
+  }
+
+  /** Begins one multipolygon geometry. */
+  beginMultiPolygon(polygonCount: number): void {
+    this.writeHeader('MultiPolygon');
+    this.writeUint32(polygonCount);
+  }
+
+  /** Writes one coordinate using the builder's semantic dimension. */
+  writeCoordinate(x: number, y: number, z?: number, m?: number): void {
+    let coordinate = makeCoordinate(this.dimension, x, y, z, m);
+    if (this.transform) coordinate = this.transform(coordinate, this.dimension);
+    const coordinateSize = getDimensionSize(this.dimension);
+    for (let index = 0; index < coordinateSize; index++) {
+      this.writeFloat64(coordinate[index] ?? Number.NaN);
+    }
+  }
+
+  /** Returns the number of bytes measured or written. */
+  finishGeometry(): number {
+    return this.byteOffset - this.startByteOffset;
+  }
+
+  /** Measures geometry callbacks and returns contiguous Binary offsets. */
+  static measureGeometryArray(
+    geometryWriters: readonly (WKBGeometryWriter | null | undefined)[],
+    options: WKBBuilderBaseOptions = {}
+  ): Int32Array {
+    const valueOffsets = new Int32Array(geometryWriters.length + 1);
+    for (let geometryIndex = 0; geometryIndex < geometryWriters.length; geometryIndex++) {
+      const geometryWriter = geometryWriters[geometryIndex];
+      const byteLength = geometryWriter ? measureGeometry(geometryWriter, options) : 0;
+      const nextOffset = valueOffsets[geometryIndex] + byteLength;
+      if (nextOffset > 0x7fffffff) throw new Error('WKB geometry array exceeds Int32 offsets');
+      valueOffsets[geometryIndex + 1] = nextOffset;
+    }
+    return valueOffsets;
+  }
+
+  /** Writes geometry callbacks into an existing contiguous values buffer. */
+  static writeGeometryArray(
+    geometryWriters: readonly (WKBGeometryWriter | null | undefined)[],
+    valueOffsets: Int32Array,
+    values: Uint8Array,
+    options: WKBBuilderBaseOptions = {}
+  ): Uint8Array {
+    if (valueOffsets.length !== geometryWriters.length + 1) {
+      throw new Error('WKB valueOffsets length must equal geometry count plus one');
+    }
+    if (valueOffsets[valueOffsets.length - 1] > values.byteLength) {
+      throw new Error('WKB values buffer is smaller than its final offset');
+    }
+    for (let geometryIndex = 0; geometryIndex < geometryWriters.length; geometryIndex++) {
+      const geometryWriter = geometryWriters[geometryIndex];
+      if (!geometryWriter) continue;
+      const builder = new WKBBuilder({
+        mode: 'write',
+        target: values,
+        byteOffset: valueOffsets[geometryIndex],
+        ...options
+      });
+      geometryWriter(builder);
+      const byteLength = builder.finishGeometry();
+      if (valueOffsets[geometryIndex] + byteLength !== valueOffsets[geometryIndex + 1]) {
+        throw new Error('WKB measure and write passes produced different byte lengths');
+      }
+    }
+    return values;
+  }
+
+  /** Builds plain offsets, values, and validity buffers in two passes. */
+  static buildGeometryArray(
+    geometryWriters: readonly (WKBGeometryWriter | null | undefined)[],
+    options: WKBBuilderBaseOptions = {}
+  ): WKBGeometryArray {
+    const valueOffsets = WKBBuilder.measureGeometryArray(geometryWriters, options);
+    const values = new Uint8Array(valueOffsets[valueOffsets.length - 1]);
+    WKBBuilder.writeGeometryArray(geometryWriters, valueOffsets, values, options);
+    const {nullBitmap, nullCount} = makeNullBitmap(geometryWriters);
+    return {
+      valueOffsets,
+      values,
+      ...(nullCount > 0 ? {nullBitmap} : {}),
+      nullCount
+    };
+  }
+
+  private writeHeader(geometryType: WKBGeometryType): void {
+    this.writeUint8(this.littleEndian ? 1 : 0);
+    this.writeUint32(getWKBTypeCode(geometryType, this.dimension, this.srid !== undefined));
+    if (this.srid !== undefined) this.writeUint32(this.srid);
+  }
+
+  private writeUint8(value: number): void {
+    this.ensureSize(1);
+    this.dataView?.setUint8(this.byteOffset, value);
+    this.byteOffset++;
+  }
+
+  private writeUint32(value: number): void {
+    if (!Number.isSafeInteger(value) || value < 0 || value > 0xffffffff) {
+      throw new Error('WKB count must be an unsigned 32-bit integer');
+    }
+    this.ensureSize(4);
+    this.dataView?.setUint32(this.byteOffset, value, this.littleEndian);
+    this.byteOffset += 4;
+  }
+
+  private writeFloat64(value: number): void {
+    this.ensureSize(8);
+    this.dataView?.setFloat64(this.byteOffset, value, this.littleEndian);
+    this.byteOffset += 8;
+  }
+
+  private ensureSize(byteLength: number): void {
+    if (this.byteOffset + byteLength > this.endByteOffset) {
+      throw new Error('WKBBuilder target buffer overflow');
+    }
+  }
+}
+
+function measureGeometry(
+  geometryWriter: WKBGeometryWriter,
+  options: WKBBuilderBaseOptions
+): number {
+  const builder = new WKBBuilder({mode: 'measure', ...options});
+  geometryWriter(builder);
+  return builder.finishGeometry();
+}
+
+function getTargetDataView(target: ArrayBufferLike | ArrayBufferView): DataView {
+  return ArrayBuffer.isView(target)
+    ? new DataView(target.buffer, target.byteOffset, target.byteLength)
+    : new DataView(target);
+}
+
+function getWKBTypeCode(
+  geometryType: WKBGeometryType,
+  dimension: WellKnownDimension,
+  hasSrid: boolean
+): number {
+  const geometryCode = GEOMETRY_TYPE_CODES[geometryType];
+  if (hasSrid) {
+    const dimensionFlags =
+      dimension === 'xyz'
+        ? 0x80000000
+        : dimension === 'xym'
+          ? 0x40000000
+          : dimension === 'xyzm'
+            ? 0xc0000000
+            : 0;
+    return (geometryCode | dimensionFlags | 0x20000000) >>> 0;
+  }
+  const dimensionOffset =
+    dimension === 'xyz' ? 1000 : dimension === 'xym' ? 2000 : dimension === 'xyzm' ? 3000 : 0;
+  return geometryCode + dimensionOffset;
+}
+
+function makeCoordinate(
+  dimension: WellKnownDimension,
+  x: number,
+  y: number,
+  z?: number,
+  m?: number
+): readonly number[] {
+  switch (dimension) {
+    case 'xy':
+      return [x, y];
+    case 'xyz':
+      return [x, y, z ?? Number.NaN];
+    case 'xym':
+      return [x, y, m ?? Number.NaN];
+    case 'xyzm':
+      return [x, y, z ?? Number.NaN, m ?? Number.NaN];
+  }
+}
+
+function getDimensionSize(dimension: WellKnownDimension): 2 | 3 | 4 {
+  return dimension === 'xy' ? 2 : dimension === 'xyzm' ? 4 : 3;
+}
+
+function validateSrid(srid: number | undefined): void {
+  if (srid !== undefined && (!Number.isSafeInteger(srid) || srid < 0 || srid > 0xffffffff)) {
+    throw new Error('WKBBuilder srid must be an unsigned 32-bit integer');
+  }
+}
+
+function makeNullBitmap(geometryWriters: readonly (WKBGeometryWriter | null | undefined)[]): {
+  nullBitmap: Uint8Array;
+  nullCount: number;
+} {
+  const nullBitmap = new Uint8Array(Math.ceil(geometryWriters.length / 8));
+  let nullCount = 0;
+  for (let geometryIndex = 0; geometryIndex < geometryWriters.length; geometryIndex++) {
+    if (geometryWriters[geometryIndex]) {
+      nullBitmap[geometryIndex >> 3] |= 1 << (geometryIndex & 7);
+    } else {
+      nullCount++;
+    }
+  }
+  return {nullBitmap, nullCount};
+}

--- a/modules/wkb/src/wkb-reader.ts
+++ b/modules/wkb/src/wkb-reader.ts
@@ -1,0 +1,400 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {WellKnownDimension, WellKnownGeometry} from './types';
+import {getWellKnownDimensionSize} from './types';
+
+/** Geometry family encoded by a WKB header. */
+export type WKBGeometryType = WellKnownGeometry['type'];
+
+/** WKB dialect identified from one geometry header. */
+export type WKBDialect = 'wkb' | 'iso-wkb' | 'ewkb';
+
+/** Immutable facts decoded from one WKB geometry header. */
+export type WKBHeader = Readonly<{
+  geometryType: WKBGeometryType;
+  dimension: WellKnownDimension;
+  dialect: WKBDialect;
+  littleEndian: boolean;
+  /** Offset of the endian byte, relative to the supplied input view. */
+  byteOffset: number;
+  /** Offset of the geometry body, relative to the supplied input view. */
+  bodyByteOffset: number;
+  /** Number of bytes occupied by the header. */
+  byteLength: number;
+  /** EWKB spatial reference identifier, when present. */
+  srid?: number;
+}>;
+
+/** Defensive limits shared by WKB traversal and scanning. */
+export type WKBTraversalOptions = Readonly<{
+  /** Maximum recursive geometry nesting. Defaults to 64. */
+  maximumDepth?: number;
+  /** Maximum total declared list elements. Defaults to 100 million. */
+  maximumElements?: number;
+}>;
+
+/** Direct callbacks invoked while traversing WKB bytes without materializing geometry rows. */
+export type WKBVisitor = Readonly<{
+  /** Called at the start of each geometry. `count` is points, rings, or child geometries. */
+  geometry?: (header: WKBHeader, count: number | undefined, depth: number) => void;
+  /** Called at the start of each polygon ring. */
+  ring?: (pointCount: number, ringIndex: number, depth: number) => void;
+  /**
+   * Called for each coordinate without allocating a coordinate array.
+   * Missing Z or M ordinates are passed as `undefined`.
+   */
+  coordinate?: (
+    x: number,
+    y: number,
+    z: number | undefined,
+    m: number | undefined,
+    dimension: WellKnownDimension,
+    byteOffset: number,
+    depth: number
+  ) => void;
+}>;
+
+/** Finite coordinate bounds collected by {@link scanWKB}. */
+export type WKBBounds = Readonly<{
+  xmin: number;
+  ymin: number;
+  xmax: number;
+  ymax: number;
+  zmin?: number;
+  zmax?: number;
+  mmin?: number;
+  mmax?: number;
+}>;
+
+/** Per-family geometry counts collected by {@link scanWKB}. */
+export type WKBGeometryCounts = Readonly<Record<WKBGeometryType, number>>;
+
+/** Structural statistics collected without materializing geometry rows. */
+export type WKBScanResult = Readonly<{
+  header: WKBHeader;
+  byteLength: number;
+  coordinateCount: number;
+  ringCount: number;
+  geometryCount: number;
+  maximumDepth: number;
+  geometryTypes: readonly WKBGeometryType[];
+  geometryCounts: WKBGeometryCounts;
+  bounds?: WKBBounds;
+}>;
+
+type MutableBounds = {
+  xmin?: number;
+  ymin?: number;
+  xmax?: number;
+  ymax?: number;
+  zmin?: number;
+  zmax?: number;
+  mmin?: number;
+  mmax?: number;
+};
+
+type TraversalState = {
+  maximumDepth: number;
+  maximumElements: number;
+  elementCount: number;
+  visitor: WKBVisitor;
+};
+
+const GEOMETRY_TYPES: readonly WKBGeometryType[] = [
+  'Point',
+  'LineString',
+  'Polygon',
+  'MultiPoint',
+  'MultiLineString',
+  'MultiPolygon',
+  'GeometryCollection'
+];
+
+/** Inspects one WKB/ISO WKB/EWKB header without reading its coordinate payload. */
+export function inspectWKBHeader(
+  input: ArrayBufferLike | ArrayBufferView,
+  byteOffset = 0
+): WKBHeader {
+  return inspectWKBHeaderView(getDataView(input), byteOffset);
+}
+
+/**
+ * Traverses exactly one WKB geometry without constructing coordinate or geometry objects.
+ * Returns the number of bytes consumed.
+ */
+export function visitWKB(
+  input: ArrayBufferLike | ArrayBufferView,
+  visitor: WKBVisitor,
+  options: WKBTraversalOptions = {}
+): number {
+  const view = getDataView(input);
+  const state: TraversalState = {
+    maximumDepth: validateLimit(options.maximumDepth, 64, 'maximumDepth'),
+    maximumElements: validateLimit(options.maximumElements, 100_000_000, 'maximumElements'),
+    elementCount: 0,
+    visitor
+  };
+  const byteLength = visitGeometry(view, 0, state, 0).byteOffset;
+  if (byteLength !== view.byteLength) throw new Error('WKB contains trailing bytes');
+  return byteLength;
+}
+
+/** Collects geometry counts and XYZM bounds without materializing geometry rows. */
+export function scanWKB(
+  input: ArrayBufferLike | ArrayBufferView,
+  options: WKBTraversalOptions = {}
+): WKBScanResult {
+  const header = inspectWKBHeader(input);
+  const geometryCounts: Record<WKBGeometryType, number> = {
+    Point: 0,
+    LineString: 0,
+    Polygon: 0,
+    MultiPoint: 0,
+    MultiLineString: 0,
+    MultiPolygon: 0,
+    GeometryCollection: 0
+  };
+  const geometryTypes = new Set<WKBGeometryType>();
+  const bounds: MutableBounds = {};
+  let coordinateCount = 0;
+  let ringCount = 0;
+  let geometryCount = 0;
+  let maximumDepth = 0;
+
+  const byteLength = visitWKB(
+    input,
+    {
+      geometry: (geometryHeader, _count, depth) => {
+        geometryCounts[geometryHeader.geometryType]++;
+        geometryTypes.add(geometryHeader.geometryType);
+        geometryCount++;
+        maximumDepth = Math.max(maximumDepth, depth);
+      },
+      ring: () => ringCount++,
+      coordinate: (x, y, z, m) => {
+        coordinateCount++;
+        updateBounds(bounds, 'x', x);
+        updateBounds(bounds, 'y', y);
+        if (z !== undefined) updateBounds(bounds, 'z', z);
+        if (m !== undefined) updateBounds(bounds, 'm', m);
+      }
+    },
+    options
+  );
+
+  const concreteBounds = makeBounds(bounds);
+  return {
+    header,
+    byteLength,
+    coordinateCount,
+    ringCount,
+    geometryCount,
+    maximumDepth,
+    geometryTypes: GEOMETRY_TYPES.filter(type => geometryTypes.has(type)),
+    geometryCounts,
+    ...(concreteBounds ? {bounds: concreteBounds} : {})
+  };
+}
+
+function visitGeometry(
+  view: DataView,
+  byteOffset: number,
+  state: TraversalState,
+  depth: number,
+  expectedType?: WKBGeometryType
+): {byteOffset: number; header: WKBHeader} {
+  if (depth > state.maximumDepth) throw new Error('WKB geometry nesting exceeds maximumDepth');
+  const header = inspectWKBHeaderView(view, byteOffset);
+  if (expectedType && header.geometryType !== expectedType) {
+    throw new Error(`WKB ${expectedType} collection contains a ${header.geometryType} child`);
+  }
+  byteOffset = header.bodyByteOffset;
+
+  switch (header.geometryType) {
+    case 'Point':
+      state.visitor.geometry?.(header, undefined, depth);
+      byteOffset = visitCoordinate(view, byteOffset, header, state.visitor, depth);
+      break;
+    case 'LineString': {
+      const pointCount = readCount(view, byteOffset, header.littleEndian, state);
+      byteOffset += 4;
+      state.visitor.geometry?.(header, pointCount, depth);
+      byteOffset = visitCoordinateSequence(view, byteOffset, pointCount, header, state, depth);
+      break;
+    }
+    case 'Polygon': {
+      const ringCount = readCount(view, byteOffset, header.littleEndian, state);
+      byteOffset += 4;
+      state.visitor.geometry?.(header, ringCount, depth);
+      for (let ringIndex = 0; ringIndex < ringCount; ringIndex++) {
+        const pointCount = readCount(view, byteOffset, header.littleEndian, state);
+        byteOffset += 4;
+        state.visitor.ring?.(pointCount, ringIndex, depth);
+        byteOffset = visitCoordinateSequence(view, byteOffset, pointCount, header, state, depth);
+      }
+      break;
+    }
+    case 'MultiPoint':
+    case 'MultiLineString':
+    case 'MultiPolygon':
+    case 'GeometryCollection': {
+      const childCount = readCount(view, byteOffset, header.littleEndian, state);
+      byteOffset += 4;
+      state.visitor.geometry?.(header, childCount, depth);
+      const childType =
+        header.geometryType === 'MultiPoint'
+          ? 'Point'
+          : header.geometryType === 'MultiLineString'
+            ? 'LineString'
+            : header.geometryType === 'MultiPolygon'
+              ? 'Polygon'
+              : undefined;
+      for (let childIndex = 0; childIndex < childCount; childIndex++) {
+        byteOffset = visitGeometry(view, byteOffset, state, depth + 1, childType).byteOffset;
+      }
+      break;
+    }
+  }
+  return {byteOffset, header};
+}
+
+function visitCoordinateSequence(
+  view: DataView,
+  byteOffset: number,
+  pointCount: number,
+  header: WKBHeader,
+  state: TraversalState,
+  depth: number
+): number {
+  for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+    byteOffset = visitCoordinate(view, byteOffset, header, state.visitor, depth);
+  }
+  return byteOffset;
+}
+
+function visitCoordinate(
+  view: DataView,
+  byteOffset: number,
+  header: WKBHeader,
+  visitor: WKBVisitor,
+  depth: number
+): number {
+  const coordinateByteLength = getWellKnownDimensionSize(header.dimension) * 8;
+  assertRemaining(view, byteOffset, coordinateByteLength);
+  const x = view.getFloat64(byteOffset, header.littleEndian);
+  const y = view.getFloat64(byteOffset + 8, header.littleEndian);
+  const third =
+    header.dimension === 'xy' ? undefined : view.getFloat64(byteOffset + 16, header.littleEndian);
+  const fourth =
+    header.dimension === 'xyzm' ? view.getFloat64(byteOffset + 24, header.littleEndian) : undefined;
+  const z = header.dimension === 'xyz' || header.dimension === 'xyzm' ? third : undefined;
+  const m = header.dimension === 'xym' ? third : fourth;
+  visitor.coordinate?.(x, y, z, m, header.dimension, byteOffset, depth);
+  return byteOffset + coordinateByteLength;
+}
+
+function inspectWKBHeaderView(view: DataView, byteOffset: number): WKBHeader {
+  const startByteOffset = byteOffset;
+  assertRemaining(view, byteOffset, 5);
+  const byteOrder = view.getUint8(byteOffset++);
+  if (byteOrder !== 0 && byteOrder !== 1) throw new Error('Invalid WKB byte order');
+  const littleEndian = byteOrder === 1;
+  const typeCode = view.getUint32(byteOffset, littleEndian);
+  byteOffset += 4;
+
+  const hasZ = Boolean(typeCode & 0x80000000);
+  const hasM = Boolean(typeCode & 0x40000000);
+  const hasSrid = Boolean(typeCode & 0x20000000);
+  let geometryCode = typeCode & 0x1fffffff;
+  let dimension: WellKnownDimension;
+  if (geometryCode >= 3000 && geometryCode < 4000) {
+    dimension = 'xyzm';
+    geometryCode -= 3000;
+  } else if (geometryCode >= 2000 && geometryCode < 3000) {
+    dimension = 'xym';
+    geometryCode -= 2000;
+  } else if (geometryCode >= 1000 && geometryCode < 2000) {
+    dimension = 'xyz';
+    geometryCode -= 1000;
+  } else {
+    dimension = hasZ && hasM ? 'xyzm' : hasZ ? 'xyz' : hasM ? 'xym' : 'xy';
+  }
+  const geometryType = GEOMETRY_TYPES[geometryCode - 1];
+  if (!geometryType) throw new Error(`Unsupported WKB geometry type ${geometryCode}`);
+
+  let srid: number | undefined;
+  if (hasSrid) {
+    assertRemaining(view, byteOffset, 4);
+    srid = view.getUint32(byteOffset, littleEndian);
+    byteOffset += 4;
+  }
+  const dialect: WKBDialect =
+    hasZ || hasM || hasSrid ? 'ewkb' : dimension === 'xy' ? 'wkb' : 'iso-wkb';
+  return {
+    geometryType,
+    dimension,
+    dialect,
+    littleEndian,
+    byteOffset: startByteOffset,
+    bodyByteOffset: byteOffset,
+    byteLength: byteOffset - startByteOffset,
+    ...(srid === undefined ? {} : {srid})
+  };
+}
+
+function readCount(
+  view: DataView,
+  byteOffset: number,
+  littleEndian: boolean,
+  state: TraversalState
+): number {
+  assertRemaining(view, byteOffset, 4);
+  const count = view.getUint32(byteOffset, littleEndian);
+  state.elementCount += count;
+  if (state.elementCount > state.maximumElements) {
+    throw new Error('WKB element count exceeds maximumElements');
+  }
+  return count;
+}
+
+function updateBounds(bounds: MutableBounds, axis: 'x' | 'y' | 'z' | 'm', value: number): void {
+  if (!Number.isFinite(value)) return;
+  const minimum = `${axis}min` as keyof MutableBounds;
+  const maximum = `${axis}max` as keyof MutableBounds;
+  bounds[minimum] = bounds[minimum] === undefined ? value : Math.min(bounds[minimum]!, value);
+  bounds[maximum] = bounds[maximum] === undefined ? value : Math.max(bounds[maximum]!, value);
+}
+
+function makeBounds(bounds: MutableBounds): WKBBounds | undefined {
+  if (
+    bounds.xmin === undefined ||
+    bounds.ymin === undefined ||
+    bounds.xmax === undefined ||
+    bounds.ymax === undefined
+  ) {
+    return undefined;
+  }
+  return bounds as WKBBounds;
+}
+
+function getDataView(input: ArrayBufferLike | ArrayBufferView): DataView {
+  return ArrayBuffer.isView(input)
+    ? new DataView(input.buffer, input.byteOffset, input.byteLength)
+    : new DataView(input);
+}
+
+function assertRemaining(view: DataView, byteOffset: number, byteLength: number): void {
+  if (byteOffset < 0 || byteOffset + byteLength > view.byteLength) {
+    throw new Error('Unexpected end of WKB');
+  }
+}
+
+function validateLimit(value: number | undefined, fallback: number, name: string): number {
+  const limit = value ?? fallback;
+  if (!Number.isSafeInteger(limit) || limit < 0) {
+    throw new Error(`${name} must be a non-negative safe integer`);
+  }
+  return limit;
+}

--- a/modules/wkb/src/wkb.ts
+++ b/modules/wkb/src/wkb.ts
@@ -4,6 +4,7 @@
 
 import type {WellKnownDimension, WellKnownGeometry} from './types';
 import {getWellKnownDimensionSize, inferWellKnownGeometryDimension} from './types';
+import {inspectWKBHeader} from './wkb-reader';
 
 /** Defensive limits applied before WKB allocates geometry arrays. */
 export type WKBParseOptions = Readonly<{
@@ -70,36 +71,9 @@ function readWKBGeometry(
   depth: number
 ): WKBReadResult {
   if (depth > state.maximumDepth) throw new Error('WKB geometry nesting exceeds maximumDepth');
-  let offset = startOffset;
-  assertRemaining(view, offset, 5);
-  const byteOrder = view.getUint8(offset++);
-  if (byteOrder !== 0 && byteOrder !== 1) throw new Error('Invalid WKB byte order');
-  const littleEndian = byteOrder === 1;
-  let rawType = view.getUint32(offset, littleEndian);
-  offset += 4;
-  const hasZFlag = Boolean(rawType & 0x80000000);
-  const hasMFlag = Boolean(rawType & 0x40000000);
-  const hasSrid = Boolean(rawType & 0x20000000);
-  rawType &= 0x1fffffff;
-  let dimension: WellKnownDimension;
-  if (rawType >= 3000) {
-    dimension = 'xyzm';
-    rawType -= 3000;
-  } else if (rawType >= 2000) {
-    dimension = 'xym';
-    rawType -= 2000;
-  } else if (rawType >= 1000) {
-    dimension = 'xyz';
-    rawType -= 1000;
-  } else {
-    dimension = hasZFlag && hasMFlag ? 'xyzm' : hasZFlag ? 'xyz' : hasMFlag ? 'xym' : 'xy';
-  }
-  let srid: number | undefined;
-  if (hasSrid) {
-    assertRemaining(view, offset, 4);
-    srid = view.getUint32(offset, littleEndian);
-    offset += 4;
-  }
+  const header = inspectWKBHeader(view, startOffset);
+  let offset = header.bodyByteOffset;
+  const {dimension, geometryType, littleEndian, srid} = header;
   const dimensions = getWellKnownDimensionSize(dimension);
   const readCoordinate = (): number[] => {
     assertRemaining(view, offset, dimensions * 8);
@@ -126,37 +100,37 @@ function readWKBGeometry(
   };
 
   let geometry: WellKnownGeometry;
-  switch (rawType) {
-    case 1:
+  switch (geometryType) {
+    case 'Point':
       geometry = {type: 'Point', coordinates: readCoordinate()};
       break;
-    case 2:
+    case 'LineString':
       geometry = {type: 'LineString', coordinates: readCoordinates()};
       break;
-    case 3:
+    case 'Polygon':
       geometry = {type: 'Polygon', coordinates: Array.from({length: readCount()}, readCoordinates)};
       break;
-    case 4:
-    case 5:
-    case 6:
-    case 7: {
+    case 'MultiPoint':
+    case 'MultiLineString':
+    case 'MultiPolygon':
+    case 'GeometryCollection': {
       const children: WellKnownGeometry[] = [];
       for (let index = 0, count = readCount(); index < count; index++) {
         const child = readWKBGeometry(view, offset, state, depth + 1);
         children.push(child.geometry);
         offset = child.offset;
       }
-      if (rawType === 4) {
+      if (geometryType === 'MultiPoint') {
         geometry = {
           type: 'MultiPoint',
           coordinates: children.map(assertPoint).map(point => point.coordinates)
         };
-      } else if (rawType === 5) {
+      } else if (geometryType === 'MultiLineString') {
         geometry = {
           type: 'MultiLineString',
           coordinates: children.map(assertLineString).map(line => line.coordinates)
         };
-      } else if (rawType === 6) {
+      } else if (geometryType === 'MultiPolygon') {
         geometry = {
           type: 'MultiPolygon',
           coordinates: children.map(assertPolygon).map(polygon => polygon.coordinates)
@@ -166,8 +140,6 @@ function readWKBGeometry(
       }
       break;
     }
-    default:
-      throw new Error(`Unsupported WKB geometry type ${rawType}`);
   }
   return {geometry, offset, dimension, ...(srid === undefined ? {} : {srid})};
 }

--- a/modules/wkb/test/buffer-primitives.spec.ts
+++ b/modules/wkb/test/buffer-primitives.spec.ts
@@ -1,0 +1,351 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {
+  inspectWKBHeader,
+  parseWKB,
+  scanWKB,
+  visitWKB,
+  WKBBuilder,
+  writeWKB,
+  type WKBBuilderBaseOptions,
+  type WKBGeometryWriter
+} from '../src/index';
+
+test('inspectWKBHeader reads only ISO WKB and EWKB headers', () => {
+  const isoHeader = writeWKB({type: 'Point', coordinates: [1, 2, 3, 4]}, 'xyzm').subarray(0, 5);
+  expect(inspectWKBHeader(isoHeader)).toMatchObject({
+    geometryType: 'Point',
+    dimension: 'xyzm',
+    dialect: 'iso-wkb',
+    littleEndian: true,
+    byteOffset: 0,
+    bodyByteOffset: 5,
+    byteLength: 5
+  });
+
+  const ewkb = writePointWithBuilder({dimension: 'xym', byteOrder: 'big-endian', srid: 4326});
+  const padded = new Uint8Array(ewkb.length + 4);
+  padded.set(ewkb, 2);
+  expect(inspectWKBHeader(padded.subarray(2, padded.length - 2))).toMatchObject({
+    geometryType: 'Point',
+    dimension: 'xym',
+    dialect: 'ewkb',
+    littleEndian: false,
+    bodyByteOffset: 9,
+    byteLength: 9,
+    srid: 4326
+  });
+  expect(scanWKB(ewkb).bounds).toEqual({
+    xmin: 1,
+    ymin: 2,
+    xmax: 1,
+    ymax: 2,
+    mmin: 4,
+    mmax: 4
+  });
+});
+
+test('visitWKB traverses nested mixed-endian geometry without row objects', () => {
+  const firstPoint = writePointWithBuilder({byteOrder: 'little-endian'}, [1, 2]);
+  const secondPoint = writePointWithBuilder({byteOrder: 'big-endian'}, [3, 4]);
+  const collection = new Uint8Array(9 + firstPoint.length + secondPoint.length);
+  const view = new DataView(collection.buffer);
+  view.setUint8(0, 1);
+  view.setUint32(1, 7, true);
+  view.setUint32(5, 2, true);
+  collection.set(firstPoint, 9);
+  collection.set(secondPoint, 9 + firstPoint.length);
+
+  const geometryTypes: string[] = [];
+  const coordinates: number[] = [];
+  expect(
+    visitWKB(collection, {
+      geometry: header => geometryTypes.push(header.geometryType),
+      coordinate: (x, y) => coordinates.push(x, y)
+    })
+  ).toBe(collection.length);
+  expect(geometryTypes).toEqual(['GeometryCollection', 'Point', 'Point']);
+  expect(coordinates).toEqual([1, 2, 3, 4]);
+});
+
+test('scanWKB combines family counts, nesting, rings, coordinates, and XYZM bounds', () => {
+  const polygon = writePolygonWithBuilder({dimension: 'xyzm'});
+  expect(scanWKB(polygon)).toMatchObject({
+    byteLength: polygon.length,
+    coordinateCount: 5,
+    ringCount: 1,
+    geometryCount: 1,
+    maximumDepth: 0,
+    geometryTypes: ['Polygon'],
+    geometryCounts: {Polygon: 1},
+    bounds: {
+      xmin: 0,
+      ymin: 0,
+      xmax: 2,
+      ymax: 2,
+      zmin: 10,
+      zmax: 14,
+      mmin: 20,
+      mmax: 24
+    }
+  });
+
+  const empty = writeWKB({type: 'LineString', coordinates: []});
+  expect(scanWKB(empty)).toMatchObject({coordinateCount: 0, geometryCount: 1});
+  expect(scanWKB(empty).bounds).toBeUndefined();
+});
+
+test('WKBBuilder measure and write modes produce identical bytes for every family', () => {
+  const writers = makeGeometryWriters();
+  for (const writer of writers) {
+    const measured = new WKBBuilder({mode: 'measure', dimension: 'xyz'});
+    writer(measured);
+    const values = new Uint8Array(measured.finishGeometry());
+    const written = new WKBBuilder({mode: 'write', target: values, dimension: 'xyz'});
+    writer(written);
+    expect(written.finishGeometry()).toBe(values.byteLength);
+    expect(parseWKB(values).geometry).toBeTruthy();
+  }
+});
+
+test('WKBBuilder generic geometry dispatch covers every family and default count', () => {
+  const geometryTypes = [
+    'Point',
+    'LineString',
+    'Polygon',
+    'MultiPoint',
+    'MultiLineString',
+    'MultiPolygon',
+    'GeometryCollection'
+  ] as const;
+
+  for (const geometryType of geometryTypes) {
+    const geometryWriter: WKBGeometryWriter = builder => {
+      builder.beginGeometry(geometryType);
+      if (geometryType === 'Point') builder.writeCoordinate(1, 2);
+    };
+    const valueOffsets = WKBBuilder.measureGeometryArray([geometryWriter]);
+    const values = new Uint8Array(valueOffsets[1]);
+    WKBBuilder.writeGeometryArray([geometryWriter], valueOffsets, values);
+    expect(parseWKB(values).geometry.type).toBe(geometryType);
+  }
+});
+
+test('WKBBuilder writes every ISO dimension and substitutes missing ordinates', () => {
+  for (const dimension of ['xy', 'xyz', 'xym', 'xyzm'] as const) {
+    const geometryWriter: WKBGeometryWriter = builder => {
+      builder.beginPoint();
+      builder.writeCoordinate(1, 2);
+    };
+    const valueOffsets = WKBBuilder.measureGeometryArray([geometryWriter], {dimension});
+    const arrayBuffer = new ArrayBuffer(valueOffsets[1]);
+    WKBBuilder.writeGeometryArray([geometryWriter], valueOffsets, new Uint8Array(arrayBuffer), {
+      dimension,
+      byteOrder: 'big-endian'
+    });
+    const result = parseWKB(new Uint8Array(arrayBuffer));
+    expect(result.dimension).toBe(dimension);
+    expect(result.geometry.type).toBe('Point');
+    if (result.geometry.type !== 'Point') throw new Error('Expected Point');
+    expect(result.geometry.coordinates.slice(0, 2)).toEqual([1, 2]);
+    expect(result.geometry.coordinates.slice(2).every(Number.isNaN)).toBe(true);
+  }
+});
+
+test('WKBBuilder supports destination offsets, endian, EWKB SRID, and transforms', () => {
+  const measure = new WKBBuilder({mode: 'measure', dimension: 'xyzm', srid: 3857});
+  measure.beginPoint();
+  measure.writeCoordinate(1, 2, 3, 4);
+  const target = new Uint8Array(measure.finishGeometry() + 6).fill(255);
+  const writer = new WKBBuilder({
+    mode: 'write',
+    target: target.subarray(2, target.length - 2),
+    byteOffset: 1,
+    dimension: 'xyzm',
+    byteOrder: 'big-endian',
+    srid: 3857,
+    transform: coordinate => coordinate.map(value => value + 10)
+  });
+  writer.beginPoint();
+  writer.writeCoordinate(1, 2, 3, 4);
+  const bytes = target.subarray(3, 3 + writer.finishGeometry());
+  expect(parseWKB(bytes)).toMatchObject({
+    geometry: {type: 'Point', coordinates: [11, 12, 13, 14]},
+    dimension: 'xyzm',
+    srid: 3857
+  });
+  expect(target.subarray(0, 3)).toEqual(new Uint8Array([255, 255, 255]));
+  expect(target.subarray(target.length - 2)).toEqual(new Uint8Array([255, 255]));
+});
+
+test('WKBBuilder builds plain Binary buffers with null rows', () => {
+  const geometryArray = WKBBuilder.buildGeometryArray([
+    builder => {
+      builder.beginPoint();
+      builder.writeCoordinate(1, 2);
+    },
+    null,
+    builder => {
+      builder.beginPoint();
+      builder.writeCoordinate(3, 4);
+    }
+  ]);
+  expect(Array.from(geometryArray.valueOffsets)).toEqual([0, 21, 21, 42]);
+  expect(geometryArray.nullBitmap).toEqual(new Uint8Array([0b00000101]));
+  expect(geometryArray.nullCount).toBe(1);
+  expect(parseWKB(geometryArray.values.subarray(geometryArray.valueOffsets[2])).geometry).toEqual({
+    type: 'Point',
+    coordinates: [3, 4]
+  });
+
+  const nonNullable = WKBBuilder.buildGeometryArray([
+    builder => {
+      builder.beginPoint();
+      builder.writeCoordinate(5, 6);
+    }
+  ]);
+  expect(nonNullable.nullBitmap).toBeUndefined();
+  expect(nonNullable.nullCount).toBe(0);
+});
+
+test('traversal and builder reject malformed structure, limits, and buffer mismatches', () => {
+  const collection = writeWKB({
+    type: 'GeometryCollection',
+    geometries: [{type: 'Point', coordinates: [1, 2]}]
+  });
+  expect(() => visitWKB(collection, {}, {maximumDepth: 0})).toThrow(/maximumDepth/);
+  expect(() => scanWKB(collection, {maximumElements: 0})).toThrow(/maximumElements/);
+  expect(() => visitWKB(Uint8Array.from([...collection, 0]), {})).toThrow(/trailing bytes/);
+
+  const invalidMultiPoint = writeWKB({
+    type: 'GeometryCollection',
+    geometries: [{type: 'LineString', coordinates: []}]
+  });
+  new DataView(invalidMultiPoint.buffer).setUint32(1, 4, true);
+  expect(() => visitWKB(invalidMultiPoint, {})).toThrow(/Point collection contains a LineString/);
+
+  const tooSmall = new Uint8Array(20);
+  const writer = new WKBBuilder({mode: 'write', target: tooSmall});
+  expect(() => {
+    writer.beginPoint();
+    writer.writeCoordinate(1, 2);
+  }).toThrow(/overflow/);
+
+  expect(() =>
+    WKBBuilder.writeGeometryArray(
+      [builder => builder.beginPoint()],
+      new Int32Array([0, 6]),
+      new Uint8Array(6)
+    )
+  ).toThrow(/different byte lengths/);
+
+  expect(() => new WKBBuilder({mode: 'write', target: new Uint8Array(1), byteOffset: -1})).toThrow(
+    /outside the target/
+  );
+  expect(() => new WKBBuilder({mode: 'measure', srid: -1})).toThrow(/srid/);
+  expect(() => {
+    const invalidCount = new WKBBuilder({mode: 'measure'});
+    invalidCount.beginLineString(-1);
+  }).toThrow(/unsigned 32-bit/);
+  expect(() =>
+    WKBBuilder.writeGeometryArray([], new Int32Array([0, 0]), new Uint8Array(0))
+  ).toThrow(/geometry count plus one/);
+  expect(() =>
+    WKBBuilder.writeGeometryArray(
+      [builder => builder.beginPoint()],
+      new Int32Array([0, 21]),
+      new Uint8Array(20)
+    )
+  ).toThrow(/smaller than its final offset/);
+
+  expect(() => inspectWKBHeader(new Uint8Array([2, 1, 0, 0, 0]))).toThrow(/byte order/);
+  expect(() => inspectWKBHeader(new Uint8Array([1, 8, 0, 0, 0]))).toThrow(/geometry type/);
+  expect(() => inspectWKBHeader(new Uint8Array(5), -1)).toThrow(/end of WKB/);
+  expect(() => visitWKB(collection, {}, {maximumDepth: -1})).toThrow(/maximumDepth/);
+
+  const pointBuffer = writeWKB({type: 'Point', coordinates: [1, 2]}).buffer;
+  expect(inspectWKBHeader(pointBuffer).geometryType).toBe('Point');
+});
+
+function writePointWithBuilder(
+  options: WKBBuilderBaseOptions,
+  coordinate: readonly number[] = [1, 2, 3, 4]
+): Uint8Array {
+  const geometryWriter: WKBGeometryWriter = builder => {
+    builder.beginPoint();
+    builder.writeCoordinate(coordinate[0], coordinate[1], coordinate[2], coordinate[3]);
+  };
+  const measure = new WKBBuilder({mode: 'measure', ...options});
+  geometryWriter(measure);
+  const bytes = new Uint8Array(measure.finishGeometry());
+  const write = new WKBBuilder({mode: 'write', target: bytes, ...options});
+  geometryWriter(write);
+  return bytes;
+}
+
+function writePolygonWithBuilder(options: WKBBuilderBaseOptions): Uint8Array {
+  const geometryWriter: WKBGeometryWriter = builder => {
+    builder.beginPolygon(1);
+    builder.beginLinearRing(5);
+    builder.writeCoordinate(0, 0, 10, 20);
+    builder.writeCoordinate(2, 0, 11, 21);
+    builder.writeCoordinate(0, 2, 12, 22);
+    builder.writeCoordinate(0, 0, 13, 23);
+    builder.writeCoordinate(0, 0, 14, 24);
+  };
+  const measure = new WKBBuilder({mode: 'measure', ...options});
+  geometryWriter(measure);
+  const bytes = new Uint8Array(measure.finishGeometry());
+  const write = new WKBBuilder({mode: 'write', target: bytes, ...options});
+  geometryWriter(write);
+  return bytes;
+}
+
+function makeGeometryWriters(): WKBGeometryWriter[] {
+  return [
+    builder => {
+      builder.beginPoint();
+      builder.writeCoordinate(1, 2, 3);
+    },
+    builder => {
+      builder.beginLineString(2);
+      builder.writeCoordinate(1, 2, 3);
+      builder.writeCoordinate(4, 5, 6);
+    },
+    builder => {
+      builder.beginPolygon(1);
+      builder.beginLinearRing(4);
+      builder.writeCoordinate(0, 0, 1);
+      builder.writeCoordinate(1, 0, 1);
+      builder.writeCoordinate(0, 1, 1);
+      builder.writeCoordinate(0, 0, 1);
+    },
+    builder => {
+      builder.beginMultiPoint(1);
+      builder.beginPoint();
+      builder.writeCoordinate(1, 2, 3);
+    },
+    builder => {
+      builder.beginMultiLineString(1);
+      builder.beginLineString(1);
+      builder.writeCoordinate(1, 2, 3);
+    },
+    builder => {
+      builder.beginMultiPolygon(1);
+      builder.beginPolygon(1);
+      builder.beginLinearRing(4);
+      builder.writeCoordinate(0, 0, 1);
+      builder.writeCoordinate(1, 0, 1);
+      builder.writeCoordinate(0, 1, 1);
+      builder.writeCoordinate(0, 0, 1);
+    },
+    builder => {
+      builder.beginGeometry('GeometryCollection', 1);
+      builder.beginPoint();
+      builder.writeCoordinate(1, 2, 3);
+    }
+  ];
+}


### PR DESCRIPTION
## Summary

This is a measured follow-up to #120, consolidating the proven Arrow-independent WKB primitives from loaders.gl:

- `inspectWKBHeader` reads ISO WKB/EWKB type, dimension, byte order, header length, and SRID without coordinate payloads.
- `visitWKB` traverses nested geometries and coordinates without materializing geometry rows.
- `scanWKB` reports geometry-family counts, coordinate/ring counts, nesting depth, byte length, and finite XYZM bounds.
- `WKBBuilder` supports matching measure/write passes, caller-owned buffers, destination offsets, dimensions, byte order, EWKB SRID, transforms, and plain column buffers.
- `parseWKB` now shares the header inspection path.

## Scope

The implementation is dependency-free and does not add Arrow or GeoArrow APIs. It is intended to support the subsequent loaders.gl adapter migration and eventual luma.gl Arrow glue extraction; Arrow table/vector/worker/rendering adapters remain outside math.gl.

## Verification

- `yarn build`
- `yarn test-node` (82 files, 863 passed, 125 skipped)
- `yarn test-headless` (82 files, 864 passed, 124 skipped)
- `yarn lint`
- `yarn check:wkb-boundary`
- Scoped WKB coverage: `wkb-builder.ts` 99.22% statements / 95.09% branches / 100% functions / 100% lines; `wkb-reader.ts` 99.24% statements / 96.11% branches / 100% functions / 100% lines.
