### PR TITLE
feat(geoarrow): complete buffer-first conversion kernels

### DIFF
--- a/docs/modules/geoarrow/api-reference/geoarrow.md
+++ b/docs/modules/geoarrow/api-reference/geoarrow.md
@@ -117,6 +117,8 @@ The builder also accepts an incremental event stream. Call `beginGeometry(type, 
 `writeCoordinate(x, y, z?, m?)`, and `endGeometry()`. Events are useful for loaders that already
 have a streaming parser and avoid constructing intermediate geometry rows. For backward
 compatibility, a MultiPolygon with no `beginPolygon()` calls is treated as one polygon.
+`writeCoordinateFromDimension(x, y, z, m, sourceDimension)` is the scalar fast path when source and
+target dimensions differ; it maps Z and M by name and does not allocate a coordinate tuple.
 
 ### `makeGeoArrowColumnFromGeometryRows(rows, options?)`
 
@@ -125,17 +127,45 @@ values. Set `encoding: 'geoarrow.geometry'` to force a dense union for homogeneo
 
 ## WKB and WKT
 
-### `decodeGeoArrowWKB(column)` / `decodeGeoArrowWKT(column)`
+### `decodeGeoArrowWKB(column, options?)` / `decodeGeoArrowWKT(column)`
 
 Import these functions from `@math.gl/geoarrow/wkb`. They decode serialized chunks into native
-descriptors while preserving nulls, metadata, CRS, edge semantics, and (where possible) source
-chunking. WKB accepts mixed endianness and WKB/EWKB/ISO dimensions. WKT accepts explicit Z/M/ZM
-tokens and the established three/four-ordinate compatibility form.
+descriptors while preserving nulls, metadata, CRS, edge semantics, and source chunking. WKB accepts
+mixed endianness, WKB/EWKB/ISO dimensions, mixed families and dimensions, recursive collections,
+regular binary storage, and Arrow BinaryView-style storage.
+
+`DecodeGeoArrowWKBOptions` controls final allocation:
+
+| Option | Values | Default |
+| --- | --- | --- |
+| `encoding` | native concrete encoding, `geoarrow.geometry`, `geoarrow.geometrycollection`, or `native` | `native` |
+| `dimension` | `infer`, `preserve`, `xy`, `xyz`, `xym`, or `xyzm` | `infer` |
+| `coordinateLayout` | `interleaved` or `separated` | `interleaved` |
+| `coordinateType` | `float32` or `float64` | `float64` |
+| `offsetType` | `int32` or `int64` | `int32` |
+| `traversal` | `@math.gl/wkb` traversal/resource limits | none |
+
+`infer` reads semantic dimensions from WKB headers rather than trusting the placeholder dimension
+on a Binary descriptor. Concrete family rows use header-only classification plus exact measure and
+write traversals. Mixed unions receive a stable schema across all chunks, and GeometryCollections
+are built recursively without materialized geometry rows. A concrete target supports the canonical
+single-to-multi promotions and rejects incompatible families.
+
+WKT accepts explicit Z/M/ZM tokens and the established three/four-ordinate compatibility form.
+
+### `getGeoArrowWKBVertexCount(column, traversal?)`
+
+Counts vertices across WKB chunks without materializing rows or decoding coordinate ordinates.
+Geometry and ring count fields are sufficient for Point, LineString, Polygon, all multi-geometries,
+and recursive GeometryCollections. Regular binary and BinaryView storage are supported. The
+optional traversal limits are the same as `decodeGeoArrowWKB`.
 
 ### `encodeGeoArrowWKB(column)` / `encodeGeoArrowWKT(column)`
 
 Import these functions from `@math.gl/geoarrow/wkb`. They encode native descriptors into
-variable-width serialized descriptors using a measure/write pass. A column already in the requested
+variable-width serialized descriptors using an exact measure/write pass per source chunk. WKB
+encoding traverses physical descriptors directly, retains chunk boundaries, and represents
+dense-union child nulls in the serialized validity bitmap. A column already in the requested
 encoding is returned unchanged.
 
 Individual geometry parsing and formatting live in `@math.gl/wkb`. GeoArrow's four codec functions

--- a/docs/modules/geoarrow/migration-guide.md
+++ b/docs/modules/geoarrow/migration-guide.md
@@ -45,6 +45,20 @@ should preserve chunking, view offsets, validity bit offsets, list offset width,
 child names, semantic dimension, coordinate layout, CRS, and edge metadata. It should not iterate
 rows through scalar accessors. The adapter is the only place that imports Apache Arrow.
 
+For serialized input, pass the borrowed Binary/LargeBinary/BinaryView descriptor directly to
+`decodeGeoArrowWKB`. Do not consolidate chunks or view data buffers first. Leave `dimension` at its
+metadata value and use the decoder's default `infer` policy unless trusted extension metadata
+explicitly requests normalization. Request the final coordinate layout, float width, and offset
+width in that call so math.gl writes those buffers once.
+
+Use `getGeoArrowWKBVertexCount` when sizing or policy decisions need a serialized vertex count. It
+uses the shared `@math.gl/wkb` structural visitor in count-only mode, so loaders.gl does not need to
+retain its separate WKB count parser.
+
+For mixed output, adapt math.gl's stable per-chunk child schema directly to Arrow dense unions.
+There is no union validity buffer: a null row selects a child slot that is null in that child's
+validity bitmap. This is deliberate and avoids an adapter-only null encoding.
+
 ## From luma.gl
 
 The private prototype coupled tessellation and interleaving to Arrow vectors, worker lifecycle, and

--- a/docs/modules/geoarrow/physical-layouts.md
+++ b/docs/modules/geoarrow/physical-layouts.md
@@ -101,7 +101,8 @@ an identity operation.
 
 Null and empty are distinct:
 
-- a null row has a cleared top-level validity bit;
+- a null concrete/list row has a cleared top-level validity bit;
+- a null dense-union row dispatches to a child value whose validity bit is cleared;
 - an empty variable geometry is valid and has equal adjacent list offsets;
 - an empty point is conventionally represented by non-finite coordinate ordinates.
 
@@ -113,7 +114,12 @@ Null and empty are distinct:
 - one `valueOffsets` entry per logical row;
 - named children with stable integer type IDs and optional child-specific encoding, dimension, and
   coordinate layout;
-- an optional root validity bitmap.
+
+Arrow dense unions do not have a root validity buffer. Every row must contain a valid type ID and
+child offset. A null geometry therefore dispatches to a real child slot whose child validity bit is
+cleared. Builders and WKB decoders always emit this Arrow-compatible representation. Readers retain
+support for a legacy descriptor-level validity bitmap, but adapters must not attempt to construct an
+Arrow dense union from that legacy form.
 
 For row `i`, `typeIds[offset + i]` selects a child and `valueOffsets[offset + i]` selects the value
 inside that child. Child arrays remain compact; union rows do not require placeholder values.

--- a/docs/modules/wkb/api-reference/wkb.md
+++ b/docs/modules/wkb/api-reference/wkb.md
@@ -25,6 +25,18 @@ are inferred as XYZ because coordinate arrays alone cannot identify a measure.
 
 ## Binary
 
+### `inspectWKBHeader(bytes, byteOffset?)`
+
+Reads endian order, geometry family, semantic dimension, dialect, and optional EWKB SRID without
+traversing the coordinate payload.
+
+### `visitWKB(bytes, visitor, options?)`
+
+Traverses geometry, ring, and optional scalar-coordinate events without allocating geometry or
+coordinate objects. When `visitor.coordinate` is omitted, coordinate payloads are bounds-checked
+and skipped without decoding their Float64 ordinates. This is the fast path for structural
+classification and vertex counting.
+
 ### `parseWKB(bytes, options?)`
 
 Parses exactly one WKB value and rejects trailing data. It accepts little- or big-endian geometry,

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -112,6 +112,8 @@ Highlights:
 - Supports both endian orders, ISO and EWKB dimension headers, EWKB SRIDs, all geometry families,
   nested collections, dimension tokens, MultiPoint variants, and empty geometry.
 - Enforces strict input coverage plus configurable WKB nesting and element-count limits.
+- Supports header-only and count-only visitor traversal that skips coordinate decoding when scalar
+  ordinate callbacks are not requested.
 - Provides the neutral format layer used by `@math.gl/geoarrow` without depending on GeoArrow or
   Apache Arrow.
 
@@ -125,6 +127,9 @@ Highlights:
   limit kernels.
 - Adds a two-pass builder, WKB/WKT column adapters, Polygon/MultiPolygon tessellation, and an
   optional worker transfer subpath.
+- Adds direct WKB dimension/family classification, serialized vertex counting, exact per-chunk
+  measure/write conversion, BinaryView access, stable mixed-union schemas, and Arrow-compatible
+  child-null dispatch without materialized geometry rows.
 - Moves reusable GeoArrow math out of loaders.gl and luma.gl prototypes while leaving runtime
   adapters, worker scheduling, and GPU resources with their owning libraries.
 

--- a/modules/geoarrow/README.md
+++ b/modules/geoarrow/README.md
@@ -168,6 +168,24 @@ const polygons = write.finish(); // borrows target; no Arrow objects are constru
 
 `GeoArrowBuilder.build(rows, options)` is the convenient form when custom allocation is not needed.
 
+For serialized loaders and streaming producers, the builder also accepts geometry events. A measure
+builder and a write builder must receive the same event sequence; the write pass fills the caller's
+buffers directly:
+
+```typescript
+builder.beginGeometry('Polygon', 'xy');
+builder.beginRing(5);
+builder.writeCoordinate(0, 0);
+builder.writeCoordinate(4, 0);
+builder.writeCoordinate(4, 4);
+builder.writeCoordinate(0, 4);
+builder.writeCoordinate(0, 0);
+builder.endGeometry();
+```
+
+`MultiLineString` uses one `beginRing` per line and `MultiPolygon` uses `beginPolygon` followed by
+one `beginRing` per ring. Event writes do not create coordinate arrays or Arrow objects.
+
 ## Inspection and read-only kernels
 
 The following operations traverse descriptors directly and do not create per-row geometry objects:
@@ -221,6 +239,12 @@ const nativeAgain = decodeGeoArrowWKT(wkt);
 ```
 
 WKB decoding accepts little- or big-endian geometry, ISO Z/M/ZM type offsets, EWKB Z/M/SRID flags,
+BinaryView-style serialized buffers, nulls, and mixed concrete families. Concrete rows are scanned
+with `@math.gl/wkb`'s header inspector and visitor, measured, and written directly into native
+buffers. Mixed family or mixed-dimension input becomes a dense union whose children retain their
+own encoding and dimension metadata; no conversion through GeoJSON or nested coordinate arrays is
+needed. GeometryCollection remains on the compatibility path until its nested event topology is
+available.
 multi-geometries, and nested geometry collections. WKT supports all corresponding geometry
 families, dimension tokens, both MultiPoint spellings, and empties. Decoding normalizes mixed-size
 serialized coordinates to the column's declared semantic dimension.

--- a/modules/geoarrow/README.md
+++ b/modules/geoarrow/README.md
@@ -184,7 +184,10 @@ builder.endGeometry();
 ```
 
 `MultiLineString` uses one `beginRing` per line and `MultiPolygon` uses `beginPolygon` followed by
-one `beginRing` per ring. Event writes do not create coordinate arrays or Arrow objects.
+one `beginRing` per ring. Parsers that already expose scalar ordinates can call
+`writeCoordinateFromDimension(x, y, z, m, sourceDimension)` to map Z and M into the target
+dimension without allocating a temporary coordinate tuple. Event writes do not create coordinate
+arrays or Arrow objects.
 
 ## Inspection and read-only kernels
 
@@ -233,21 +236,49 @@ import {
 } from '@math.gl/geoarrow/wkb';
 
 const wkb = encodeGeoArrowWKB(polygons);
-const decoded = decodeGeoArrowWKB(wkb);
+const decoded = decodeGeoArrowWKB(wkb, {
+  encoding: 'native',
+  dimension: 'infer',
+  coordinateLayout: 'interleaved',
+  coordinateType: 'float64',
+  offsetType: 'int32'
+});
 const wkt = encodeGeoArrowWKT(decoded);
 const nativeAgain = decodeGeoArrowWKT(wkt);
 ```
 
 WKB decoding accepts little- or big-endian geometry, ISO Z/M/ZM type offsets, EWKB Z/M/SRID flags,
-BinaryView-style serialized buffers, nulls, and mixed concrete families. Concrete rows are scanned
-with `@math.gl/wkb`'s header inspector and visitor, measured, and written directly into native
-buffers. Mixed family or mixed-dimension input becomes a dense union whose children retain their
-own encoding and dimension metadata; no conversion through GeoJSON or nested coordinate arrays is
-needed. GeometryCollection remains on the compatibility path until its nested event topology is
-available.
-multi-geometries, and nested geometry collections. WKT supports all corresponding geometry
-families, dimension tokens, both MultiPoint spellings, and empties. Decoding normalizes mixed-size
-serialized coordinates to the column's declared semantic dimension.
+BinaryView-style serialized buffers, nulls, mixed concrete families, multi-geometries, and recursive
+GeometryCollections. The default dimension policy is `infer`: WKB headers are authoritative because
+Arrow Binary storage has no physical coordinate dimension. Use `preserve` to force the descriptor's
+declared dimension, or request `xy`, `xyz`, `xym`, or `xyzm` explicitly.
+
+Ordinary rows use a header-only classification pass followed by one measurement traversal and one
+write traversal. Scalar ordinates are written directly into the final interleaved or separated
+Float32/Float64 buffers. GeometryCollections use a recursive schema-discovery pass and the same
+two-pass child builders; they do not fall back to `parseWKB`, GeoJSON values, or nested coordinate
+arrays. Input chunk boundaries are retained, and every mixed chunk receives the same union schema
+even when a family first occurs in a later chunk.
+
+`encoding` defaults to `native`, which selects a concrete family when all valid rows agree and a
+dense union otherwise. A concrete target may also perform Point-to-MultiPoint,
+LineString-to-MultiLineString, or Polygon-to-MultiPolygon promotion. `coordinateLayout`,
+`coordinateType`, and `offsetType` select the final buffers directly, avoiding a decode-then-convert
+copy. Dense-union nulls are represented by a valid child dispatch whose selected child value is
+null; no Arrow-incompatible union validity bitmap is emitted.
+
+WKT supports all corresponding geometry families, dimension tokens, both MultiPoint spellings, and
+empties. WKT conversion currently prioritizes semantic compatibility; the WKB visitor path is the
+allocation-sensitive path intended for high-volume loaders.
+
+WKB encoding likewise preserves native chunk boundaries. Each chunk is measured into an offsets
+buffer and then written into one exact byte allocation by replaying the physical descriptors; it
+does not allocate a closure, geometry object, or coordinate array for every row.
+
+`getGeoArrowWKBVertexCount(column)` counts serialized WKB vertices directly from headers and list
+counts. It advances over coordinate payloads without decoding float ordinates, preserves all
+traversal limits, and supports regular offset storage and BinaryView storage. Use it in loaders that
+need counts before deciding whether to allocate native buffers.
 
 Parsing or formatting one geometry is intentionally provided by the dependency-free
 `@math.gl/wkb` package. The GeoArrow `/wkb` bridge consumes its visitors and two-pass builder:

--- a/modules/geoarrow/src/builder.ts
+++ b/modules/geoarrow/src/builder.ts
@@ -106,11 +106,15 @@ export class GeoArrowBuilder {
   private readonly eventStack: Array<{
     type: GeoArrowGeometryValue['type'];
     dimension: GeoArrowDimension;
-    rings: number[][][];
-    polygons: number[][][][];
+    direct: boolean;
+    rowIndex: number;
+    ringStarted: boolean;
+    polygonStarted: boolean;
+    rings?: number[][][];
+    polygons?: number[][][][];
     currentPolygon?: number[][][];
     currentRing?: number[][];
-    children: GeoArrowGeometryValue[];
+    children?: GeoArrowGeometryValue[];
   }> = [];
 
   constructor(options: GeoArrowBuilderModeOptions) {
@@ -292,7 +296,18 @@ export class GeoArrowBuilder {
     dimension = this.dimension,
     _count?: number
   ): this {
-    this.eventStack.push({type, dimension, rings: [], polygons: [], children: []});
+    const direct = getGeoArrowGeometryType(this.encoding) === type;
+    const rowIndex = direct ? this.length++ : -1;
+    this.eventStack.push({
+      type,
+      dimension,
+      direct,
+      rowIndex,
+      ringStarted: false,
+      polygonStarted: false,
+      ...(direct ? {} : {rings: [], polygons: []}),
+      ...(direct ? {} : {children: []})
+    });
     return this;
   }
 
@@ -302,8 +317,14 @@ export class GeoArrowBuilder {
     if (!state || state.type !== 'MultiPolygon') {
       throw new Error("beginPolygon must follow beginGeometry('MultiPolygon')");
     }
+    if (state.direct) {
+      this.finishEventRing(state);
+      this.finishEventPolygon(state);
+      state.polygonStarted = true;
+      return this;
+    }
     state.currentPolygon = [];
-    state.polygons.push(state.currentPolygon);
+    state.polygons!.push(state.currentPolygon);
     state.currentRing = undefined;
     return this;
   }
@@ -312,12 +333,17 @@ export class GeoArrowBuilder {
   beginRing(_count?: number): this {
     const state = this.eventStack[this.eventStack.length - 1];
     if (!state) throw new Error('beginRing must follow beginGeometry');
+    if (state.direct) {
+      this.finishEventRing(state);
+      state.ringStarted = true;
+      return this;
+    }
     state.currentRing = [];
     if (state.type === 'MultiPolygon') {
       if (!state.currentPolygon) this.beginPolygon();
       state.currentPolygon!.push(state.currentRing);
     } else {
-      state.rings.push(state.currentRing);
+      state.rings!.push(state.currentRing);
     }
     return this;
   }
@@ -332,6 +358,12 @@ export class GeoArrowBuilder {
     const size = getGeoArrowDimensionSize(state.dimension);
     if (coordinate.length !== size)
       throw new Error(`Expected ${size} coordinate values for ${state.dimension}`);
+    if (state.direct) {
+      this.writeCoordinateValues(
+        resizeEventCoordinate(coordinate, state.dimension, this.dimension)
+      );
+      return this;
+    }
     if (state.type === 'Point') {
       state.rings = [[coordinate]];
       return this;
@@ -345,7 +377,21 @@ export class GeoArrowBuilder {
   endGeometry(): this {
     const state = this.eventStack.pop();
     if (!state) throw new Error('endGeometry without beginGeometry');
-    const coordinates = state.rings;
+    if (state.direct) {
+      this.finishEventRing(state);
+      this.finishEventPolygon(state);
+      const depth = getBuilderDepth(this.encoding);
+      if (depth >= 1) {
+        this.writeOffset(
+          this.target?.geometryOffsets,
+          state.rowIndex + 1,
+          depth === 1 ? this.coordinateCount : this.partCount
+        );
+      }
+      if (this.target) setValidityBit(this.target.validity, state.rowIndex);
+      return this;
+    }
+    const coordinates = state.rings || [];
     let geometry: GeoArrowGeometryValue;
     switch (state.type) {
       case 'Point':
@@ -366,15 +412,15 @@ export class GeoArrowBuilder {
       case 'MultiPolygon':
         geometry = {
           type: 'MultiPolygon',
-          coordinates: state.polygons.length ? state.polygons : [coordinates]
+          coordinates: state.polygons?.length ? state.polygons : [coordinates]
         };
         break;
       case 'GeometryCollection':
-        geometry = {type: 'GeometryCollection', geometries: state.children};
+        geometry = {type: 'GeometryCollection', geometries: state.children || []};
         break;
     }
     const parent = this.eventStack[this.eventStack.length - 1];
-    if (parent?.type === 'GeometryCollection') parent.children.push(geometry);
+    if (parent?.type === 'GeometryCollection') parent.children!.push(geometry);
     else this.append(geometry);
     return this;
   }
@@ -383,6 +429,27 @@ export class GeoArrowBuilder {
     if (!target) return;
     if (target instanceof BigInt64Array) target[index] = BigInt(value);
     else target[index] = value;
+  }
+
+  private finishEventRing(state: (typeof this.eventStack)[number]): void {
+    if (!state.direct || !state.ringStarted) return;
+    if (this.encoding === 'geoarrow.multipolygon') {
+      this.ringCount++;
+      this.writeOffset(this.target?.ringOffsets, this.ringCount, this.coordinateCount);
+    } else if (getBuilderDepth(this.encoding) >= 2) {
+      this.partCount++;
+      this.writeOffset(this.target?.partOffsets, this.partCount, this.coordinateCount);
+    }
+    state.ringStarted = false;
+  }
+
+  private finishEventPolygon(state: (typeof this.eventStack)[number]): void {
+    if (!state.direct || !state.polygonStarted) return;
+    if (this.encoding === 'geoarrow.multipolygon') {
+      this.partCount++;
+      this.writeOffset(this.target?.partOffsets, this.partCount, this.ringCount);
+    }
+    state.polygonStarted = false;
   }
 
   private initializeTargetOffsets(target: GeoArrowBuilderTarget): void {
@@ -606,6 +673,32 @@ function writeCoordinate(
   else if (dimension === 'xyzm') {
     target.z![coordinateIndex] = coordinate[2];
     target.m![coordinateIndex] = coordinate[3];
+  }
+}
+
+function resizeEventCoordinate(
+  coordinate: readonly number[],
+  sourceDimension: GeoArrowDimension,
+  targetDimension: GeoArrowDimension
+): number[] {
+  if (sourceDimension === targetDimension) return [...coordinate];
+  const sourceNames = getDimensionNames(sourceDimension);
+  return getDimensionNames(targetDimension).map(name => {
+    const index = sourceNames.indexOf(name);
+    return index >= 0 ? (coordinate[index] ?? 0) : 0;
+  });
+}
+
+function getDimensionNames(dimension: GeoArrowDimension): Array<'x' | 'y' | 'z' | 'm'> {
+  switch (dimension) {
+    case 'xy':
+      return ['x', 'y'];
+    case 'xyz':
+      return ['x', 'y', 'z'];
+    case 'xym':
+      return ['x', 'y', 'm'];
+    case 'xyzm':
+      return ['x', 'y', 'z', 'm'];
   }
 }
 

--- a/modules/geoarrow/src/builder.ts
+++ b/modules/geoarrow/src/builder.ts
@@ -290,6 +290,29 @@ export class GeoArrowBuilder {
     this.coordinateCount++;
   }
 
+  private writeCoordinateComponents(
+    x: number,
+    y: number,
+    z: number | undefined,
+    m: number | undefined,
+    sourceDimension: GeoArrowDimension
+  ): void {
+    const targetZ = sourceDimension === 'xyz' || sourceDimension === 'xyzm' ? (z ?? 0) : 0;
+    const targetM = sourceDimension === 'xym' || sourceDimension === 'xyzm' ? (m ?? 0) : 0;
+    if (this.target) {
+      writeCoordinateComponents(
+        this.target.coordinates,
+        this.coordinateCount,
+        x,
+        y,
+        targetZ,
+        targetM,
+        this.dimension
+      );
+    }
+    this.coordinateCount++;
+  }
+
   /** Begins an event-driven geometry. Events are accepted by both measure and write builders. */
   beginGeometry(
     type: GeoArrowGeometryValue['type'],
@@ -352,6 +375,10 @@ export class GeoArrowBuilder {
   writeCoordinate(x: number | readonly number[], y?: number, z?: number, m?: number): this {
     const state = this.eventStack[this.eventStack.length - 1];
     if (!state) throw new Error('writeCoordinate must follow beginGeometry');
+    if (typeof x === 'number' && state.direct) {
+      this.writeCoordinateComponents(x, y!, z, m, state.dimension);
+      return this;
+    }
     const coordinate = Array.isArray(x)
       ? [...x]
       : [x, y!, ...(z === undefined ? [] : [z]), ...(m === undefined ? [] : [m])];
@@ -371,6 +398,30 @@ export class GeoArrowBuilder {
     if (!state.currentRing) this.beginRing();
     state.currentRing!.push(coordinate);
     return this;
+  }
+
+  /** Writes scalar ordinates tagged with their source dimension without allocating a tuple. */
+  writeCoordinateFromDimension(
+    x: number,
+    y: number,
+    z: number | undefined,
+    m: number | undefined,
+    sourceDimension: GeoArrowDimension
+  ): this {
+    const state = this.eventStack[this.eventStack.length - 1];
+    if (!state) throw new Error('writeCoordinateFromDimension must follow beginGeometry');
+    if (state.direct) {
+      this.writeCoordinateComponents(x, y, z, m, sourceDimension);
+      return this;
+    }
+    const coordinate = getDimensionNames(state.dimension).map(name => {
+      if (name === 'x') return x;
+      if (name === 'y') return y;
+      if (name === 'z')
+        return sourceDimension === 'xyz' || sourceDimension === 'xyzm' ? (z ?? 0) : 0;
+      return sourceDimension === 'xym' || sourceDimension === 'xyzm' ? (m ?? 0) : 0;
+    });
+    return this.writeCoordinate(coordinate);
   }
 
   /** Ends the current event geometry and appends it to the builder/parent. */
@@ -536,22 +587,18 @@ function makeDenseUnionArray(
 ): GeoArrowDenseUnion {
   const nonNullTypes = [...new Set(rows.filter(Boolean).map(row => row!.type))];
   const fallbackType = nonNullTypes[0] || 'Point';
-  const childRows = new Map<GeoArrowGeometryValue['type'], GeoArrowGeometryValue[]>();
+  const childRows = new Map<GeoArrowGeometryValue['type'], Array<GeoArrowGeometryValue | null>>();
   for (const type of nonNullTypes.length ? nonNullTypes : [fallbackType]) childRows.set(type, []);
   const typeIds = new Int8Array(rows.length);
   const valueOffsets = new Int32Array(rows.length);
-  const validity = new Uint8Array(Math.ceil(rows.length / 8));
   for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
     const geometry = rows[rowIndex];
     const type = geometry?.type || fallbackType;
     const values = childRows.get(type) || [];
     typeIds[rowIndex] = getGeometryTypeId(type, dimension);
     valueOffsets[rowIndex] = values.length;
-    if (geometry) {
-      values.push(geometry);
-      childRows.set(type, values);
-      setValidityBit(validity, rowIndex);
-    }
+    values.push(geometry);
+    childRows.set(type, values);
   }
   const children = [...childRows.entries()]
     .sort(
@@ -580,8 +627,7 @@ function makeDenseUnionArray(
     length: rows.length,
     typeIds,
     valueOffsets,
-    children,
-    validity: {values: validity}
+    children
   };
 }
 
@@ -673,6 +719,38 @@ function writeCoordinate(
   else if (dimension === 'xyzm') {
     target.z![coordinateIndex] = coordinate[2];
     target.m![coordinateIndex] = coordinate[3];
+  }
+}
+
+function writeCoordinateComponents(
+  target: GeoArrowBuilderTarget['coordinates'],
+  coordinateIndex: number,
+  x: number,
+  y: number,
+  z: number,
+  m: number,
+  dimension: GeoArrowDimension
+): void {
+  if (target instanceof Float32Array || target instanceof Float64Array) {
+    const size = getGeoArrowDimensionSize(dimension);
+    const offset = coordinateIndex * size;
+    target[offset] = x;
+    target[offset + 1] = y;
+    if (dimension === 'xyz') target[offset + 2] = z;
+    else if (dimension === 'xym') target[offset + 2] = m;
+    else if (dimension === 'xyzm') {
+      target[offset + 2] = z;
+      target[offset + 3] = m;
+    }
+    return;
+  }
+  target.x[coordinateIndex] = x;
+  target.y[coordinateIndex] = y;
+  if (dimension === 'xyz') target.z![coordinateIndex] = z;
+  else if (dimension === 'xym') target.m![coordinateIndex] = m;
+  else if (dimension === 'xyzm') {
+    target.z![coordinateIndex] = z;
+    target.m![coordinateIndex] = m;
   }
 }
 

--- a/modules/geoarrow/src/codecs.ts
+++ b/modules/geoarrow/src/codecs.ts
@@ -2,221 +2,739 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {formatWKT, inspectWKBHeader, parseWKB, parseWKT, visitWKB} from '@math.gl/wkb';
-import type {WKBGeometryWriter, WKBHeader} from '@math.gl/wkb';
+import {formatWKT, inspectWKBHeader, parseWKT, visitWKB} from '@math.gl/wkb';
+import type {WKBHeader, WKBTraversalOptions} from '@math.gl/wkb';
 import {WKBBuilder} from '@math.gl/wkb';
 import type {
   GeoArrowColumn,
+  GeoArrowCoordinateLayout,
+  GeoArrowDenseUnionChild,
   GeoArrowDimension,
   GeoArrowGeometryValue,
   GeoArrowSerialized
 } from './types';
 import {getGeoArrowDimensionSize} from './types';
+import type {GeoArrowBuilderEncoding} from './builder';
 import {GeoArrowBuilder, makeGeoArrowColumnFromGeometryRows} from './builder';
 import {getGeoArrowOffset, isGeoArrowValueValid, materializeGeometryRow} from './layout';
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
-/** Decodes a GeoArrow WKB column into native physical geometry buffers. */
-export function decodeGeoArrowWKB(column: GeoArrowColumn): GeoArrowColumn {
+/** Buffer controls applied while decoding WKB directly to its final native representation. */
+export type DecodeGeoArrowWKBOptions = Readonly<{
+  encoding?:
+    | GeoArrowBuilderEncoding
+    | 'geoarrow.geometry'
+    | 'geoarrow.geometrycollection'
+    | 'native';
+  /** Defaults to `infer`, because serialized Arrow storage has no physical coordinate dimension. */
+  dimension?: GeoArrowDimension | 'infer' | 'preserve';
+  coordinateLayout?: GeoArrowCoordinateLayout;
+  coordinateType?: 'float32' | 'float64';
+  offsetType?: 'int32' | 'int64';
+  traversal?: WKBTraversalOptions;
+}>;
+
+type WKBChunkClassification = {
+  families: Uint8Array;
+  dimensions: Uint8Array;
+};
+
+type WKBDecodeBuilderOptions = {
+  dimension: GeoArrowDimension;
+  coordinateLayout: GeoArrowCoordinateLayout;
+  coordinateType: 'float32' | 'float64';
+  offsetType: 'int32' | 'int64';
+};
+
+const NULL_FAMILY = 255;
+
+/** Decodes a GeoArrow WKB column into final native physical geometry buffers. */
+export function decodeGeoArrowWKB(
+  column: GeoArrowColumn,
+  options: DecodeGeoArrowWKBOptions = {}
+): GeoArrowColumn {
   if (column.encoding !== 'geoarrow.wkb') throw new Error('Expected a geoarrow.wkb column');
-  const records: Array<{bytes: Uint8Array; header: WKBHeader} | null> = [];
-  let hasGeometryCollection = false;
+  const classifications: WKBChunkClassification[] = [];
+  const schemaKeys = new Set<number>();
+  const collectionSchemas: Array<Set<number>> = [];
+  const rootFamilies = new Set<number>();
+  let hasNulls = false;
+  let inferredDimension: GeoArrowDimension = 'xy';
   for (const chunk of column.chunks) {
     if (chunk.kind !== 'serialized') throw new Error('Serialized column contains native storage');
+    const families = new Uint8Array(chunk.length).fill(NULL_FAMILY);
+    const dimensions = new Uint8Array(chunk.length);
     for (let rowIndex = 0; rowIndex < chunk.length; rowIndex++) {
       if (!isGeoArrowValueValid(chunk.validity, rowIndex)) {
-        records.push(null);
+        hasNulls = true;
         continue;
       }
       const bytes = getSerializedBytes(chunk, rowIndex);
-      const header = inspectWKBHeader(bytes);
-      hasGeometryCollection ||= header.geometryType === 'GeometryCollection';
-      records.push({bytes, header});
+      const rootHeader = inspectWKBHeader(bytes);
+      const rootFamily = getGeometryFamilyIndex(rootHeader.geometryType);
+      let rowDimension: GeoArrowDimension = rootHeader.dimension;
+      if (rootHeader.geometryType === 'GeometryCollection') {
+        const collectionStack: Array<{depth: number; level: number}> = [];
+        let concreteRootDepth = -1;
+        visitWKB(
+          bytes,
+          {
+            geometry: (header, _count, depth) => {
+              rowDimension = mergeDimensions(rowDimension, header.dimension);
+              if (concreteRootDepth >= 0 && depth > concreteRootDepth) return;
+              concreteRootDepth = -1;
+              while (
+                collectionStack.length &&
+                depth <= collectionStack[collectionStack.length - 1].depth
+              ) {
+                collectionStack.pop();
+              }
+              const parent = collectionStack[collectionStack.length - 1];
+              if (parent) {
+                collectionSchemas[parent.level] ||= new Set<number>();
+                collectionSchemas[parent.level].add(
+                  getGeometryTypeId(header.geometryType, header.dimension)
+                );
+              }
+              if (header.geometryType === 'GeometryCollection') {
+                collectionStack.push({depth, level: parent ? parent.level + 1 : 0});
+              } else if (parent) {
+                concreteRootDepth = depth;
+              }
+            }
+          },
+          options.traversal
+        );
+      }
+      families[rowIndex] = rootFamily;
+      dimensions[rowIndex] = getDimensionIndex(rowDimension);
+      rootFamilies.add(rootFamily);
+      schemaKeys.add(getGeometryTypeIdFromIndices(rootFamily, dimensions[rowIndex]));
+      inferredDimension = mergeDimensions(inferredDimension, rowDimension);
     }
+    classifications.push({families, dimensions});
   }
 
-  // Geometry collections have a nested union topology. Keep the compatibility path until the
-  // collection builder grows a fully direct event representation; all concrete families below
-  // are decoded directly into measured native buffers.
-  if (hasGeometryCollection) {
-    const rows = normalizeRowsToDimension(
-      records.map(record => (record ? parseWKB(record.bytes).geometry : null)),
-      column.dimension
+  const dimension = resolveDecodeDimension(options.dimension, column.dimension, inferredDimension);
+  const forceDimension = Boolean(options.dimension && options.dimension !== 'infer');
+  if (forceDimension) {
+    schemaKeys.clear();
+    for (const classification of classifications) {
+      for (let rowIndex = 0; rowIndex < classification.families.length; rowIndex++) {
+        const family = classification.families[rowIndex];
+        if (family === NULL_FAMILY) continue;
+        classification.dimensions[rowIndex] = getDimensionIndex(dimension);
+        schemaKeys.add(getGeometryTypeIdFromIndices(family, getDimensionIndex(dimension)));
+      }
+    }
+  }
+  const encoding = resolveDecodeEncoding(options.encoding, rootFamilies);
+  validateDecodeEncoding(encoding, rootFamilies);
+  const builderOptions = {
+    dimension,
+    coordinateLayout: options.coordinateLayout || 'interleaved',
+    coordinateType: options.coordinateType || 'float64',
+    offsetType: options.offsetType || 'int32'
+  } as const;
+
+  if (encoding !== 'geoarrow.geometry' && encoding !== 'geoarrow.geometrycollection') {
+    const chunks = column.chunks.map((chunk, chunkIndex) =>
+      decodeConcreteWKBChunk(
+        chunk as GeoArrowSerialized,
+        classifications[chunkIndex],
+        encoding,
+        builderOptions,
+        options.traversal
+      )
     );
-    return copyMetadata(
-      column,
-      makeGeoArrowColumnFromGeometryRows(rows, {dimension: column.dimension})
-    );
-  }
-
-  const groups = new Map<
-    string,
-    {
-      type: WKBHeader['geometryType'];
-      dimension: GeoArrowDimension;
-      records: {bytes: Uint8Array; header: WKBHeader}[];
-    }
-  >();
-  for (const record of records) {
-    if (!record) continue;
-    const key = `${record.header.geometryType}:${record.header.dimension}`;
-    const group = groups.get(key) || {
-      type: record.header.geometryType,
-      dimension: record.header.dimension,
-      records: []
-    };
-    group.records.push(record);
-    groups.set(key, group);
-  }
-  if (groups.size <= 1) {
-    const group = groups.values().next().value as
-      | {
-          type: WKBHeader['geometryType'];
-          dimension: GeoArrowDimension;
-          records: {bytes: Uint8Array; header: WKBHeader}[];
-        }
-      | undefined;
-    const type = group?.type || 'Point';
-    const targetEncoding = encodingFromGeometryType(type);
-    const measure = new GeoArrowBuilder({
-      encoding: targetEncoding,
-      dimension: column.dimension,
-      mode: 'measure'
-    });
-    for (const record of records) {
-      if (!record) measure.append(null);
-      else visitWKBIntoBuilder(record.bytes, measure);
-    }
-    const write = new GeoArrowBuilder({
-      encoding: targetEncoding,
-      dimension: column.dimension,
-      mode: 'write',
-      target: measure.allocateTarget()
-    });
-    for (const record of records) {
-      if (!record) write.append(null);
-      else visitWKBIntoBuilder(record.bytes, write);
-    }
-    return copyMetadata(column, write.finish());
-  }
-
-  const children = [...groups.values()].map(group => {
-    const encoding = encodingFromGeometryType(group.type);
-    const measure = new GeoArrowBuilder({encoding, dimension: group.dimension, mode: 'measure'});
-    for (const record of group.records) visitWKBIntoBuilder(record.bytes, measure);
-    const write = new GeoArrowBuilder({
+    return copyMetadata(column, {
       encoding,
-      dimension: group.dimension,
-      mode: 'write',
-      target: measure.allocateTarget()
+      dimension,
+      coordinateLayout: builderOptions.coordinateLayout,
+      chunks
     });
-    for (const record of group.records) visitWKBIntoBuilder(record.bytes, write);
-    const built = write.finish();
+  }
+
+  if (encoding === 'geoarrow.geometrycollection') {
+    const stableCollectionSchemas = normalizeCollectionSchemas(
+      collectionSchemas,
+      dimension,
+      forceDimension
+    );
+    const chunks = column.chunks.map((chunk, chunkIndex) =>
+      decodeGeometryCollectionWKBChunk(
+        chunk as GeoArrowSerialized,
+        classifications[chunkIndex],
+        undefined,
+        stableCollectionSchemas,
+        builderOptions,
+        options.traversal,
+        forceDimension ? dimension : undefined
+      )
+    );
+    return copyMetadata(column, {
+      encoding,
+      dimension,
+      coordinateLayout: builderOptions.coordinateLayout,
+      chunks
+    });
+  }
+
+  if (schemaKeys.size === 0) schemaKeys.add(getGeometryTypeId('Point', dimension));
+  if (hasNulls) schemaKeys.add(getGeometryTypeId('Point', dimension));
+  const stableSchema = [...schemaKeys].sort((left, right) => left - right);
+  const chunks = column.chunks.map((chunk, chunkIndex) =>
+    decodeUnionWKBChunk(
+      chunk as GeoArrowSerialized,
+      classifications[chunkIndex],
+      stableSchema,
+      normalizeCollectionSchemas(collectionSchemas, dimension, forceDimension),
+      builderOptions,
+      options.traversal,
+      forceDimension ? dimension : undefined
+    )
+  );
+  return copyMetadata(column, {
+    encoding: 'geoarrow.geometry',
+    dimension,
+    coordinateLayout: builderOptions.coordinateLayout,
+    chunks
+  });
+}
+
+/** Counts vertices in serialized WKB chunks without decoding ordinates or allocating rows. */
+export function getGeoArrowWKBVertexCount(
+  column: GeoArrowColumn,
+  traversal?: WKBTraversalOptions
+): number {
+  if (column.encoding !== 'geoarrow.wkb') throw new Error('Expected a geoarrow.wkb column');
+  let vertexCount = 0;
+  for (const chunk of column.chunks) {
+    if (chunk.kind !== 'serialized') throw new Error('Serialized column contains native storage');
+    for (let rowIndex = 0; rowIndex < chunk.length; rowIndex++) {
+      if (!isGeoArrowValueValid(chunk.validity, rowIndex)) continue;
+      visitWKB(
+        getSerializedBytes(chunk, rowIndex),
+        {
+          geometry: (header, count) => {
+            if (header.geometryType === 'Point') vertexCount++;
+            else if (header.geometryType === 'LineString') vertexCount += count || 0;
+          },
+          ring: pointCount => {
+            vertexCount += pointCount;
+          }
+        },
+        traversal
+      );
+    }
+  }
+  return vertexCount;
+}
+
+function decodeConcreteWKBChunk(
+  chunk: GeoArrowSerialized,
+  classification: WKBChunkClassification,
+  encoding: GeoArrowBuilderEncoding,
+  options: WKBDecodeBuilderOptions,
+  traversal: WKBTraversalOptions | undefined
+): import('./types').GeoArrowArray {
+  const measure = new GeoArrowBuilder({...options, encoding, mode: 'measure'});
+  replaySerializedChunk(chunk, classification, encoding, measure, traversal);
+  const write = new GeoArrowBuilder({
+    ...options,
+    encoding,
+    mode: 'write',
+    target: measure.allocateTarget()
+  });
+  replaySerializedChunk(chunk, classification, encoding, write, traversal);
+  return write.finish().chunks[0];
+}
+
+function replaySerializedChunk(
+  chunk: GeoArrowSerialized,
+  classification: WKBChunkClassification,
+  encoding: GeoArrowBuilderEncoding,
+  builder: GeoArrowBuilder,
+  traversal: WKBTraversalOptions | undefined
+): void {
+  const targetType = geometryTypeFromEncoding(encoding);
+  for (let rowIndex = 0; rowIndex < chunk.length; rowIndex++) {
+    if (classification.families[rowIndex] === NULL_FAMILY) builder.append(null);
+    else visitWKBIntoBuilder(getSerializedBytes(chunk, rowIndex), builder, targetType, traversal);
+  }
+}
+
+function decodeUnionWKBChunk(
+  chunk: GeoArrowSerialized,
+  classification: WKBChunkClassification,
+  stableSchema: readonly number[],
+  collectionSchemas: readonly (readonly number[])[],
+  options: WKBDecodeBuilderOptions,
+  traversal: WKBTraversalOptions | undefined,
+  childDimensionOverride: GeoArrowDimension | undefined
+): import('./types').GeoArrowDenseUnion {
+  const measureBuilders = new Map<number, GeoArrowBuilder>();
+  for (const key of stableSchema) {
+    const type = getGeometryTypeFromId(key);
+    if (type !== 'GeometryCollection') {
+      const encoding = encodingFromGeometryType(type);
+      measureBuilders.set(
+        key,
+        new GeoArrowBuilder({
+          ...options,
+          encoding,
+          dimension: getDimensionFromId(key),
+          mode: 'measure'
+        })
+      );
+    }
+  }
+  const typeIds = new Int8Array(chunk.length);
+  const valueOffsets = new Int32Array(chunk.length);
+  const childCounts = new Map<number, number>();
+  const nullKey = stableSchema[0];
+  for (let rowIndex = 0; rowIndex < chunk.length; rowIndex++) {
+    const family = classification.families[rowIndex];
+    const key =
+      family === NULL_FAMILY
+        ? nullKey
+        : getGeometryTypeIdFromIndices(family, classification.dimensions[rowIndex]);
+    typeIds[rowIndex] = key;
+    valueOffsets[rowIndex] = childCounts.get(key) || 0;
+    childCounts.set(key, valueOffsets[rowIndex] + 1);
+    const builder = measureBuilders.get(key);
+    if (builder) {
+      if (family === NULL_FAMILY) builder.append(null);
+      else
+        visitWKBIntoBuilder(
+          getSerializedBytes(chunk, rowIndex),
+          builder,
+          getConcreteGeometryTypeFromId(key),
+          traversal
+        );
+    }
+  }
+  const writeBuilders = new Map<number, GeoArrowBuilder>();
+  for (const key of stableSchema) {
+    if (getGeometryTypeFromId(key) === 'GeometryCollection') continue;
+    const measure = measureBuilders.get(key)!;
+    writeBuilders.set(
+      key,
+      new GeoArrowBuilder({
+        ...options,
+        encoding: encodingFromGeometryType(getConcreteGeometryTypeFromId(key)),
+        dimension: getDimensionFromId(key),
+        mode: 'write',
+        target: measure.allocateTarget()
+      })
+    );
+  }
+  for (let rowIndex = 0; rowIndex < chunk.length; rowIndex++) {
+    const family = classification.families[rowIndex];
+    const key =
+      family === NULL_FAMILY
+        ? nullKey
+        : getGeometryTypeIdFromIndices(family, classification.dimensions[rowIndex]);
+    const builder = writeBuilders.get(key);
+    if (builder) {
+      if (family === NULL_FAMILY) builder.append(null);
+      else
+        visitWKBIntoBuilder(
+          getSerializedBytes(chunk, rowIndex),
+          builder,
+          getConcreteGeometryTypeFromId(key),
+          traversal
+        );
+    }
+  }
+  const children: GeoArrowDenseUnionChild[] = stableSchema.map(key => {
+    const type = getGeometryTypeFromId(key);
+    if (type === 'GeometryCollection') {
+      return {
+        name: type,
+        typeId: key,
+        encoding: 'geoarrow.geometrycollection',
+        dimension: getDimensionFromId(key),
+        coordinateLayout: options.coordinateLayout,
+        data: decodeGeometryCollectionWKBChunk(
+          chunk,
+          classification,
+          key,
+          collectionSchemas,
+          {...options, dimension: getDimensionFromId(key)},
+          traversal,
+          childDimensionOverride
+        )
+      };
+    }
+    const built = writeBuilders.get(key)!.finish();
     return {
-      name: group.type,
-      typeId: getGeometryTypeId(group.type, group.dimension),
-      encoding,
-      dimension: group.dimension,
+      name: getGeometryTypeFromId(key),
+      typeId: key,
+      encoding: built.encoding,
+      dimension: built.dimension,
       coordinateLayout: built.coordinateLayout,
       data: built.chunks[0]
     };
   });
-  const typeIds = new Int8Array(records.length);
-  const valueOffsets = new Int32Array(records.length);
-  const validity = new Uint8Array(Math.ceil(records.length / 8));
-  const groupIndices = new Map<string, number>();
-  const groupCounts = new Map<string, number>();
-  children.forEach((child, index) => groupIndices.set(`${child.name}:${child.dimension}`, index));
-  for (let rowIndex = 0; rowIndex < records.length; rowIndex++) {
-    const record = records[rowIndex];
-    if (!record) continue;
-    const key = `${record.header.geometryType}:${record.header.dimension}`;
-    const child = children[groupIndices.get(key)!];
-    typeIds[rowIndex] = child.typeId;
-    valueOffsets[rowIndex] = groupCounts.get(key) || 0;
-    groupCounts.set(key, valueOffsets[rowIndex] + 1);
-    validity[rowIndex >> 3] |= 1 << (rowIndex & 7);
-  }
-  return copyMetadata(column, {
-    encoding: 'geoarrow.geometry',
-    dimension: column.dimension,
-    coordinateLayout: 'interleaved',
-    chunks: [
-      {
-        kind: 'dense-union',
-        length: records.length,
-        typeIds,
-        valueOffsets,
-        children,
-        validity: {values: validity}
-      }
-    ]
+  return {kind: 'dense-union', length: chunk.length, typeIds, valueOffsets, children};
+}
+
+type CollectionMeasureLevel = {
+  schema: readonly number[];
+  rowCount: number;
+  childCount: number;
+  builders: Map<number, GeoArrowBuilder>;
+};
+
+type CollectionWriteLevel = {
+  schema: readonly number[];
+  rowCursor: number;
+  childCursor: number;
+  offsets: import('./types').GeoArrowOffsets;
+  typeIds: Int8Array;
+  valueOffsets: Int32Array;
+  childCounts: Map<number, number>;
+  builders: Map<number, GeoArrowBuilder>;
+};
+
+function decodeGeometryCollectionWKBChunk(
+  chunk: GeoArrowSerialized,
+  classification: WKBChunkClassification,
+  selectorKey: number | undefined,
+  schemas: readonly (readonly number[])[],
+  options: WKBDecodeBuilderOptions,
+  traversal: WKBTraversalOptions | undefined,
+  childDimensionOverride: GeoArrowDimension | undefined
+): import('./types').GeoArrowList {
+  const measureLevels = schemas.map(schema => makeCollectionMeasureLevel(schema, options));
+  if (measureLevels.length === 0) measureLevels.push(makeCollectionMeasureLevel([], options));
+  forEachSelectedCollectionRow(chunk, classification, selectorKey, (bytes, valid) => {
+    if (!valid) {
+      measureLevels[0].rowCount++;
+      return;
+    }
+    replayWKBCollection(
+      bytes!,
+      measureLevels,
+      undefined,
+      options.dimension,
+      traversal,
+      childDimensionOverride
+    );
   });
+
+  const writeLevels = measureLevels.map(level => makeCollectionWriteLevel(level, options));
+  forEachSelectedCollectionRow(chunk, classification, selectorKey, (bytes, valid) => {
+    if (!valid) {
+      writeCollectionRow(writeLevels[0], 0);
+      return;
+    }
+    replayWKBCollection(
+      bytes!,
+      measureLevels,
+      writeLevels,
+      options.dimension,
+      traversal,
+      childDimensionOverride
+    );
+  });
+
+  const root = makeCollectionLevelArray(0, measureLevels, writeLevels, options);
+  if (selectorKey !== undefined) return root;
+  const validity = new Uint8Array(Math.ceil(root.length / 8));
+  for (let rowIndex = 0; rowIndex < classification.families.length; rowIndex++) {
+    if (classification.families[rowIndex] === getGeometryFamilyIndex('GeometryCollection')) {
+      validity[rowIndex >> 3] |= 1 << (rowIndex & 7);
+    }
+  }
+  return {...root, validity: {values: validity}};
+}
+
+function forEachSelectedCollectionRow(
+  chunk: GeoArrowSerialized,
+  classification: WKBChunkClassification,
+  selectorKey: number | undefined,
+  visitor: (bytes: Uint8Array | undefined, valid: boolean) => void
+): void {
+  const collectionFamily = getGeometryFamilyIndex('GeometryCollection');
+  for (let rowIndex = 0; rowIndex < chunk.length; rowIndex++) {
+    const family = classification.families[rowIndex];
+    if (selectorKey === undefined) {
+      if (family === NULL_FAMILY) visitor(undefined, false);
+      else if (family === collectionFamily) visitor(getSerializedBytes(chunk, rowIndex), true);
+      else throw new Error('Rows cannot be represented as geoarrow.geometrycollection');
+    } else if (
+      family === collectionFamily &&
+      getGeometryTypeIdFromIndices(family, classification.dimensions[rowIndex]) === selectorKey
+    ) {
+      visitor(getSerializedBytes(chunk, rowIndex), true);
+    }
+  }
+}
+
+function makeCollectionMeasureLevel(
+  schema: readonly number[],
+  options: WKBDecodeBuilderOptions
+): CollectionMeasureLevel {
+  const builders = new Map<number, GeoArrowBuilder>();
+  for (const key of schema) {
+    const type = getGeometryTypeFromId(key);
+    if (type !== 'GeometryCollection') {
+      builders.set(
+        key,
+        new GeoArrowBuilder({
+          ...options,
+          encoding: encodingFromGeometryType(type),
+          dimension: getDimensionFromId(key),
+          mode: 'measure'
+        })
+      );
+    }
+  }
+  return {schema, rowCount: 0, childCount: 0, builders};
+}
+
+function makeCollectionWriteLevel(
+  measure: CollectionMeasureLevel,
+  options: WKBDecodeBuilderOptions
+): CollectionWriteLevel {
+  const OffsetArray = options.offsetType === 'int64' ? BigInt64Array : Int32Array;
+  const builders = new Map<number, GeoArrowBuilder>();
+  for (const [key, builder] of measure.builders) {
+    builders.set(
+      key,
+      new GeoArrowBuilder({
+        ...options,
+        encoding: encodingFromGeometryType(getConcreteGeometryTypeFromId(key)),
+        dimension: getDimensionFromId(key),
+        mode: 'write',
+        target: builder.allocateTarget()
+      })
+    );
+  }
+  return {
+    schema: measure.schema,
+    rowCursor: 0,
+    childCursor: 0,
+    offsets: new OffsetArray(measure.rowCount + 1),
+    typeIds: new Int8Array(measure.childCount),
+    valueOffsets: new Int32Array(measure.childCount),
+    childCounts: new Map(),
+    builders
+  };
+}
+
+function replayWKBCollection(
+  bytes: Uint8Array,
+  measureLevels: CollectionMeasureLevel[],
+  writeLevels: CollectionWriteLevel[] | undefined,
+  collectionDimension: GeoArrowDimension,
+  traversal: WKBTraversalOptions | undefined,
+  childDimensionOverride: GeoArrowDimension | undefined
+): void {
+  const collectionStack: Array<{depth: number; level: number}> = [];
+  let active:
+    | {
+        builder: GeoArrowBuilder;
+        rootDepth: number;
+        rootType: Exclude<WKBHeader['geometryType'], 'GeometryCollection'>;
+      }
+    | undefined;
+  const finishActive = (): void => {
+    active?.builder.endGeometry();
+    active = undefined;
+  };
+  visitWKB(
+    bytes,
+    {
+      geometry: (header, count, depth) => {
+        if (active && depth > active.rootDepth) {
+          if (active.rootType === 'MultiLineString' && header.geometryType === 'LineString') {
+            active.builder.beginRing(count);
+          } else if (active.rootType === 'MultiPolygon' && header.geometryType === 'Polygon') {
+            active.builder.beginPolygon();
+          }
+          return;
+        }
+        finishActive();
+        while (
+          collectionStack.length &&
+          depth <= collectionStack[collectionStack.length - 1].depth
+        ) {
+          collectionStack.pop();
+        }
+        const parent = collectionStack[collectionStack.length - 1];
+        if (header.geometryType === 'GeometryCollection') {
+          if (parent) {
+            addCollectionChild(
+              measureLevels[parent.level],
+              writeLevels?.[parent.level],
+              getGeometryTypeId('GeometryCollection', collectionDimension)
+            );
+          }
+          const level = parent ? parent.level + 1 : 0;
+          if (!measureLevels[level]) {
+            measureLevels[level] = makeCollectionMeasureLevel([], {
+              dimension: collectionDimension,
+              coordinateLayout: 'interleaved',
+              coordinateType: 'float64',
+              offsetType: 'int32'
+            });
+          }
+          if (writeLevels) writeCollectionRow(writeLevels[level], count || 0);
+          else measureLevels[level].rowCount++;
+          collectionStack.push({depth, level});
+          return;
+        }
+        if (!parent) throw new Error('Expected a GeometryCollection root');
+        const key = getGeometryTypeId(
+          header.geometryType,
+          childDimensionOverride || header.dimension
+        );
+        addCollectionChild(measureLevels[parent.level], writeLevels?.[parent.level], key);
+        const builder = writeLevels
+          ? writeLevels[parent.level].builders.get(key)
+          : measureLevels[parent.level].builders.get(key);
+        if (!builder) throw new Error(`Missing GeometryCollection child schema for type ID ${key}`);
+        builder.beginGeometry(header.geometryType, header.dimension, count);
+        active = {builder, rootDepth: depth, rootType: header.geometryType};
+      },
+      ring: pointCount => active?.builder.beginRing(pointCount),
+      coordinate: (x, y, z, m, dimension) =>
+        active?.builder.writeCoordinateFromDimension(x, y, z, m, dimension)
+    },
+    traversal
+  );
+  finishActive();
+}
+
+function addCollectionChild(
+  measure: CollectionMeasureLevel,
+  write: CollectionWriteLevel | undefined,
+  key: number
+): void {
+  if (!write) {
+    measure.childCount++;
+    return;
+  }
+  const index = write.childCursor++;
+  write.typeIds[index] = key;
+  write.valueOffsets[index] = write.childCounts.get(key) || 0;
+  write.childCounts.set(key, write.valueOffsets[index] + 1);
+}
+
+function writeCollectionRow(level: CollectionWriteLevel, childCount: number): void {
+  level.rowCursor++;
+  setGeoArrowOffset(level.offsets, level.rowCursor, level.childCursor + childCount);
+}
+
+function makeCollectionLevelArray(
+  levelIndex: number,
+  measureLevels: readonly CollectionMeasureLevel[],
+  writeLevels: readonly CollectionWriteLevel[],
+  options: WKBDecodeBuilderOptions
+): import('./types').GeoArrowList {
+  const measure = measureLevels[levelIndex];
+  const write = writeLevels[levelIndex];
+  const children: GeoArrowDenseUnionChild[] = measure.schema.map(key => {
+    const type = getGeometryTypeFromId(key);
+    if (type === 'GeometryCollection') {
+      return {
+        name: type,
+        typeId: key,
+        encoding: 'geoarrow.geometrycollection',
+        dimension: getDimensionFromId(key),
+        coordinateLayout: options.coordinateLayout,
+        data: makeCollectionLevelArray(levelIndex + 1, measureLevels, writeLevels, options)
+      };
+    }
+    const built = write.builders.get(key)!.finish();
+    return {
+      name: type,
+      typeId: key,
+      encoding: built.encoding,
+      dimension: built.dimension,
+      coordinateLayout: built.coordinateLayout,
+      data: built.chunks[0]
+    };
+  });
+  return {
+    kind: 'list',
+    length: measure.rowCount,
+    offsets: write.offsets,
+    child: {
+      kind: 'dense-union',
+      length: measure.childCount,
+      typeIds: write.typeIds,
+      valueOffsets: write.valueOffsets,
+      children
+    }
+  };
+}
+
+function setGeoArrowOffset(
+  offsets: import('./types').GeoArrowOffsets,
+  index: number,
+  value: number
+): void {
+  if (offsets instanceof BigInt64Array) offsets[index] = BigInt(value);
+  else offsets[index] = value;
+}
+
+function normalizeCollectionSchemas(
+  schemas: readonly ReadonlySet<number>[],
+  dimension: GeoArrowDimension,
+  forceDimension: boolean
+): number[][] {
+  return schemas.map(schema =>
+    [...schema]
+      .map(key =>
+        forceDimension || getGeometryTypeFromId(key) === 'GeometryCollection'
+          ? getGeometryTypeId(getGeometryTypeFromId(key), dimension)
+          : key
+      )
+      .filter((key, index, values) => values.indexOf(key) === index)
+      .sort((left, right) => left - right)
+  );
 }
 
 /** Replays one serialized geometry directly into a two-pass GeoArrowBuilder. */
-function visitWKBIntoBuilder(bytes: Uint8Array, builder: GeoArrowBuilder): void {
+function visitWKBIntoBuilder(
+  bytes: Uint8Array,
+  builder: GeoArrowBuilder,
+  targetType: Exclude<WKBHeader['geometryType'], 'GeometryCollection'>,
+  traversal?: WKBTraversalOptions
+): void {
   let rootType: WKBHeader['geometryType'] | undefined;
-  let rootDimension: GeoArrowDimension | undefined;
-  visitWKB(bytes, {
-    geometry: (header, _count, depth) => {
-      if (depth === 0) {
-        rootType = header.geometryType;
-        rootDimension = header.dimension;
-        builder.beginGeometry(header.geometryType, header.dimension, _count);
-      } else if (rootType === 'MultiLineString' && header.geometryType === 'LineString') {
-        builder.beginRing(_count);
-      } else if (rootType === 'MultiPolygon' && header.geometryType === 'Polygon') {
-        builder.beginPolygon();
+  visitWKB(
+    bytes,
+    {
+      geometry: (header, _count, depth) => {
+        if (depth === 0) {
+          rootType = header.geometryType;
+          builder.beginGeometry(targetType, header.dimension, _count);
+          if (rootType === 'LineString' && targetType === 'MultiLineString')
+            builder.beginRing(_count);
+          if (rootType === 'Polygon' && targetType === 'MultiPolygon') builder.beginPolygon();
+        } else if (rootType === 'MultiLineString' && header.geometryType === 'LineString') {
+          builder.beginRing(_count);
+        } else if (rootType === 'MultiPolygon' && header.geometryType === 'Polygon') {
+          builder.beginPolygon();
+        }
+      },
+      ring: pointCount => {
+        if (rootType === 'Polygon' || rootType === 'MultiPolygon') builder.beginRing(pointCount);
+      },
+      coordinate: (x, y, z, m, dimension) => {
+        builder.writeCoordinateFromDimension(x, y, z, m, dimension);
       }
     },
-    ring: pointCount => {
-      if (rootType === 'Polygon' || rootType === 'MultiPolygon') builder.beginRing(pointCount);
-    },
-    coordinate: (x, y, z, m, dimension) => {
-      const values =
-        dimension === 'xym'
-          ? [x, y, m!]
-          : dimension === 'xyzm'
-            ? [x, y, z!, m!]
-            : dimension === 'xyz'
-              ? [x, y, z!]
-              : [x, y];
-      // WKB collection members carry their own dimensional header. Normalize each member to the
-      // root geometry dimension before passing it to the builder state, then let the builder apply
-      // the column-level dimension conversion.
-      builder.writeCoordinate(resizeWKBCoordinate(values, dimension, rootDimension!));
-    }
-  });
+    traversal
+  );
   builder.endGeometry();
-}
-
-function resizeWKBCoordinate(
-  coordinate: readonly number[],
-  sourceDimension: GeoArrowDimension,
-  targetDimension: GeoArrowDimension
-): number[] {
-  if (sourceDimension === targetDimension) return [...coordinate];
-  const sourceNames = getDimensionNames(sourceDimension);
-  return getDimensionNames(targetDimension).map(name => {
-    const index = sourceNames.indexOf(name);
-    return index >= 0 ? (coordinate[index] ?? 0) : 0;
-  });
-}
-
-function getDimensionNames(dimension: GeoArrowDimension): Array<'x' | 'y' | 'z' | 'm'> {
-  switch (dimension) {
-    case 'xy':
-      return ['x', 'y'];
-    case 'xyz':
-      return ['x', 'y', 'z'];
-    case 'xym':
-      return ['x', 'y', 'm'];
-    case 'xyzm':
-      return ['x', 'y', 'z', 'm'];
-  }
 }
 
 function encodingFromGeometryType(
@@ -242,58 +760,193 @@ function encodingFromGeometryType(
 }
 
 function getGeometryTypeId(type: WKBHeader['geometryType'], dimension: GeoArrowDimension): number {
-  const family = [
-    'Point',
-    'LineString',
-    'Polygon',
-    'MultiPoint',
-    'MultiLineString',
-    'MultiPolygon',
-    'GeometryCollection'
-  ].indexOf(type);
-  const dimensionIndex = ['xy', 'xyz', 'xym', 'xyzm'].indexOf(dimension);
-  return family < 0 || dimensionIndex < 0 ? 1 : family * 4 + dimensionIndex + 1;
+  return getGeometryTypeIdFromIndices(getGeometryFamilyIndex(type), getDimensionIndex(dimension));
+}
+
+const GEOMETRY_TYPES: readonly WKBHeader['geometryType'][] = [
+  'Point',
+  'LineString',
+  'Polygon',
+  'MultiPoint',
+  'MultiLineString',
+  'MultiPolygon',
+  'GeometryCollection'
+];
+const DIMENSIONS: readonly GeoArrowDimension[] = ['xy', 'xyz', 'xym', 'xyzm'];
+
+function getGeometryFamilyIndex(type: WKBHeader['geometryType']): number {
+  return GEOMETRY_TYPES.indexOf(type);
+}
+
+function getDimensionIndex(dimension: GeoArrowDimension): number {
+  return DIMENSIONS.indexOf(dimension);
+}
+
+function getGeometryTypeIdFromIndices(family: number, dimension: number): number {
+  return family * 4 + dimension + 1;
+}
+
+function getGeometryTypeFromId(typeId: number): WKBHeader['geometryType'] {
+  return GEOMETRY_TYPES[Math.floor((typeId - 1) / 4)];
+}
+
+function getConcreteGeometryTypeFromId(
+  typeId: number
+): Exclude<WKBHeader['geometryType'], 'GeometryCollection'> {
+  const type = getGeometryTypeFromId(typeId);
+  if (type === 'GeometryCollection')
+    throw new Error('GeometryCollection requires collection storage');
+  return type;
+}
+
+function getDimensionFromId(typeId: number): GeoArrowDimension {
+  return DIMENSIONS[(typeId - 1) % 4];
+}
+
+function mergeDimensions(left: GeoArrowDimension, right: GeoArrowDimension): GeoArrowDimension {
+  const hasZ = left === 'xyz' || left === 'xyzm' || right === 'xyz' || right === 'xyzm';
+  const hasM = left === 'xym' || left === 'xyzm' || right === 'xym' || right === 'xyzm';
+  return hasZ && hasM ? 'xyzm' : hasZ ? 'xyz' : hasM ? 'xym' : 'xy';
+}
+
+function resolveDecodeDimension(
+  requested: DecodeGeoArrowWKBOptions['dimension'],
+  declared: GeoArrowDimension,
+  inferred: GeoArrowDimension
+): GeoArrowDimension {
+  if (!requested || requested === 'infer') return inferred;
+  return requested === 'preserve' ? declared : requested;
+}
+
+function resolveDecodeEncoding(
+  requested: DecodeGeoArrowWKBOptions['encoding'],
+  families: ReadonlySet<number>
+): GeoArrowBuilderEncoding | 'geoarrow.geometry' | 'geoarrow.geometrycollection' {
+  if (requested && requested !== 'native') return requested;
+  if (families.size !== 1) return 'geoarrow.geometry';
+  const type = GEOMETRY_TYPES[[...families][0]];
+  return type === 'GeometryCollection'
+    ? 'geoarrow.geometrycollection'
+    : encodingFromGeometryType(type);
+}
+
+function validateDecodeEncoding(
+  encoding: GeoArrowBuilderEncoding | 'geoarrow.geometry' | 'geoarrow.geometrycollection',
+  families: ReadonlySet<number>
+): void {
+  if (encoding === 'geoarrow.geometry') return;
+  if (encoding === 'geoarrow.geometrycollection') {
+    const collectionFamily = getGeometryFamilyIndex('GeometryCollection');
+    if ([...families].some(family => family !== collectionFamily)) {
+      throw new Error('Rows cannot be represented as geoarrow.geometrycollection');
+    }
+    return;
+  }
+  const targetType = geometryTypeFromEncoding(encoding);
+  for (const family of families) {
+    const sourceType = GEOMETRY_TYPES[family];
+    const promotable =
+      sourceType === targetType ||
+      (sourceType === 'Point' && targetType === 'MultiPoint') ||
+      (sourceType === 'LineString' && targetType === 'MultiLineString') ||
+      (sourceType === 'Polygon' && targetType === 'MultiPolygon');
+    if (!promotable) throw new Error(`Rows cannot be represented as ${encoding}`);
+  }
+}
+
+function geometryTypeFromEncoding(
+  encoding: GeoArrowBuilderEncoding
+): Exclude<WKBHeader['geometryType'], 'GeometryCollection'> {
+  const type = GEOMETRY_TYPES.find(candidate => `geoarrow.${candidate.toLowerCase()}` === encoding);
+  if (!type || type === 'GeometryCollection')
+    throw new Error(`Unsupported target encoding ${encoding}`);
+  return type;
 }
 
 /** Encodes a native GeoArrow column as variable-width WKB bytes. */
 export function encodeGeoArrowWKB(column: GeoArrowColumn): GeoArrowColumn {
   if (column.encoding === 'geoarrow.wkb') return column;
-  const writers: Array<WKBGeometryWriter | null> = [];
-  const dimensions: GeoArrowDimension[] = [];
-  for (const chunk of column.chunks) {
-    for (let rowIndex = 0; rowIndex < chunk.length; rowIndex++) {
-      if (!isGeoArrowValueValid(chunk.validity, rowIndex)) {
-        writers.push(null);
-        dimensions.push(column.dimension);
-        continue;
-      }
-      dimensions.push(
-        getPhysicalGeometryDimension(chunk, rowIndex, column.encoding, column.dimension)
-      );
-      writers.push(builder =>
-        writePhysicalGeometry(builder, chunk, rowIndex, column.encoding, column.dimension)
-      );
-    }
-  }
-  const built = WKBBuilder.buildGeometryArray(writers, {
-    dimension: column.dimension,
-    dimensionResolver: index => dimensions[index] || column.dimension
-  });
   return copyMetadata(column, {
     encoding: 'geoarrow.wkb',
     dimension: column.dimension,
     coordinateLayout: null,
-    chunks: [
-      {
-        kind: 'serialized',
-        encoding: 'binary',
-        length: writers.length,
-        offsets: built.valueOffsets,
-        values: built.values,
-        ...(built.nullBitmap ? {validity: {values: built.nullBitmap}} : {})
-      }
-    ]
+    chunks: column.chunks.map(chunk => encodeWKBChunk(column, chunk))
   });
+}
+
+function encodeWKBChunk(
+  column: GeoArrowColumn,
+  chunk: import('./types').GeoArrowArray
+): GeoArrowSerialized {
+  const offsets = new Int32Array(chunk.length + 1);
+  const validity = new Uint8Array(Math.ceil(chunk.length / 8));
+  let nullCount = 0;
+  for (let rowIndex = 0; rowIndex < chunk.length; rowIndex++) {
+    let byteLength = 0;
+    if (isPhysicalGeometryRowValid(chunk, rowIndex, column.encoding)) {
+      const dimension = getPhysicalGeometryDimension(
+        chunk,
+        rowIndex,
+        column.encoding,
+        column.dimension
+      );
+      const builder = new WKBBuilder({mode: 'measure', dimension});
+      writePhysicalGeometry(builder, chunk, rowIndex, column.encoding, dimension);
+      byteLength = builder.finishGeometry();
+      validity[rowIndex >> 3] |= 1 << (rowIndex & 7);
+    } else {
+      nullCount++;
+    }
+    const nextOffset = offsets[rowIndex] + byteLength;
+    if (nextOffset > 0x7fffffff) throw new Error('WKB geometry chunk exceeds Int32 offsets');
+    offsets[rowIndex + 1] = nextOffset;
+  }
+  const values = new Uint8Array(offsets[offsets.length - 1]);
+  for (let rowIndex = 0; rowIndex < chunk.length; rowIndex++) {
+    if (!isPhysicalGeometryRowValid(chunk, rowIndex, column.encoding)) continue;
+    const dimension = getPhysicalGeometryDimension(
+      chunk,
+      rowIndex,
+      column.encoding,
+      column.dimension
+    );
+    const builder = new WKBBuilder({
+      mode: 'write',
+      target: values,
+      byteOffset: offsets[rowIndex],
+      dimension
+    });
+    writePhysicalGeometry(builder, chunk, rowIndex, column.encoding, dimension);
+    if (offsets[rowIndex] + builder.finishGeometry() !== offsets[rowIndex + 1]) {
+      throw new Error('WKB measure and write passes produced different byte lengths');
+    }
+  }
+  return {
+    kind: 'serialized',
+    encoding: 'binary',
+    length: chunk.length,
+    offsets,
+    values,
+    ...(nullCount ? {validity: {values: validity}} : {})
+  };
+}
+
+function isPhysicalGeometryRowValid(
+  array: import('./types').GeoArrowArray,
+  rowIndex: number,
+  encoding: import('./types').GeoArrowEncoding
+): boolean {
+  if (!isGeoArrowValueValid(array.validity, rowIndex)) return false;
+  if (encoding !== 'geoarrow.geometry' || array.kind !== 'dense-union') return true;
+  const physical = (array.offset || 0) + rowIndex;
+  const child = array.children.find(candidate => candidate.typeId === array.typeIds[physical]);
+  const childIndex = array.valueOffsets[physical];
+  return Boolean(
+    child &&
+      childIndex >= 0 &&
+      childIndex < child.data.length &&
+      isGeoArrowValueValid(child.data.validity, childIndex)
+  );
 }
 
 /** Decodes a GeoArrow WKT column into native physical geometry buffers. */

--- a/modules/geoarrow/src/codecs.ts
+++ b/modules/geoarrow/src/codecs.ts
@@ -159,10 +159,12 @@ export function decodeGeoArrowWKB(column: GeoArrowColumn): GeoArrowColumn {
 /** Replays one serialized geometry directly into a two-pass GeoArrowBuilder. */
 function visitWKBIntoBuilder(bytes: Uint8Array, builder: GeoArrowBuilder): void {
   let rootType: WKBHeader['geometryType'] | undefined;
+  let rootDimension: GeoArrowDimension | undefined;
   visitWKB(bytes, {
     geometry: (header, _count, depth) => {
       if (depth === 0) {
         rootType = header.geometryType;
+        rootDimension = header.dimension;
         builder.beginGeometry(header.geometryType, header.dimension, _count);
       } else if (rootType === 'MultiLineString' && header.geometryType === 'LineString') {
         builder.beginRing(_count);
@@ -174,13 +176,47 @@ function visitWKBIntoBuilder(bytes: Uint8Array, builder: GeoArrowBuilder): void 
       if (rootType === 'Polygon' || rootType === 'MultiPolygon') builder.beginRing(pointCount);
     },
     coordinate: (x, y, z, m, dimension) => {
-      if (dimension === 'xym') builder.writeCoordinate(x, y, undefined, m);
-      else if (dimension === 'xyzm') builder.writeCoordinate(x, y, z, m);
-      else if (dimension === 'xyz') builder.writeCoordinate(x, y, z);
-      else builder.writeCoordinate(x, y);
+      const values =
+        dimension === 'xym'
+          ? [x, y, m!]
+          : dimension === 'xyzm'
+            ? [x, y, z!, m!]
+            : dimension === 'xyz'
+              ? [x, y, z!]
+              : [x, y];
+      // WKB collection members carry their own dimensional header. Normalize each member to the
+      // root geometry dimension before passing it to the builder state, then let the builder apply
+      // the column-level dimension conversion.
+      builder.writeCoordinate(resizeWKBCoordinate(values, dimension, rootDimension!));
     }
   });
   builder.endGeometry();
+}
+
+function resizeWKBCoordinate(
+  coordinate: readonly number[],
+  sourceDimension: GeoArrowDimension,
+  targetDimension: GeoArrowDimension
+): number[] {
+  if (sourceDimension === targetDimension) return [...coordinate];
+  const sourceNames = getDimensionNames(sourceDimension);
+  return getDimensionNames(targetDimension).map(name => {
+    const index = sourceNames.indexOf(name);
+    return index >= 0 ? (coordinate[index] ?? 0) : 0;
+  });
+}
+
+function getDimensionNames(dimension: GeoArrowDimension): Array<'x' | 'y' | 'z' | 'm'> {
+  switch (dimension) {
+    case 'xy':
+      return ['x', 'y'];
+    case 'xyz':
+      return ['x', 'y', 'z'];
+    case 'xym':
+      return ['x', 'y', 'm'];
+    case 'xyzm':
+      return ['x', 'y', 'z', 'm'];
+  }
 }
 
 function encodingFromGeometryType(

--- a/modules/geoarrow/src/codecs.ts
+++ b/modules/geoarrow/src/codecs.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {formatWKT, parseWKB, parseWKT} from '@math.gl/wkb';
-import type {WKBGeometryWriter} from '@math.gl/wkb';
+import {formatWKT, inspectWKBHeader, parseWKB, parseWKT, visitWKB} from '@math.gl/wkb';
+import type {WKBGeometryWriter, WKBHeader} from '@math.gl/wkb';
 import {WKBBuilder} from '@math.gl/wkb';
 import type {
   GeoArrowColumn,
@@ -12,7 +12,7 @@ import type {
   GeoArrowSerialized
 } from './types';
 import {getGeoArrowDimensionSize} from './types';
-import {makeGeoArrowColumnFromGeometryRows} from './builder';
+import {GeoArrowBuilder, makeGeoArrowColumnFromGeometryRows} from './builder';
 import {getGeoArrowOffset, isGeoArrowValueValid, materializeGeometryRow} from './layout';
 
 const textEncoder = new TextEncoder();
@@ -21,14 +21,202 @@ const textDecoder = new TextDecoder();
 /** Decodes a GeoArrow WKB column into native physical geometry buffers. */
 export function decodeGeoArrowWKB(column: GeoArrowColumn): GeoArrowColumn {
   if (column.encoding !== 'geoarrow.wkb') throw new Error('Expected a geoarrow.wkb column');
-  const rows = normalizeRowsToDimension(
-    decodeSerializedRows(column, bytes => parseWKB(bytes).geometry),
-    column.dimension
-  );
-  return copyMetadata(
-    column,
-    makeGeoArrowColumnFromGeometryRows(rows, {dimension: column.dimension})
-  );
+  const records: Array<{bytes: Uint8Array; header: WKBHeader} | null> = [];
+  let hasGeometryCollection = false;
+  for (const chunk of column.chunks) {
+    if (chunk.kind !== 'serialized') throw new Error('Serialized column contains native storage');
+    for (let rowIndex = 0; rowIndex < chunk.length; rowIndex++) {
+      if (!isGeoArrowValueValid(chunk.validity, rowIndex)) {
+        records.push(null);
+        continue;
+      }
+      const bytes = getSerializedBytes(chunk, rowIndex);
+      const header = inspectWKBHeader(bytes);
+      hasGeometryCollection ||= header.geometryType === 'GeometryCollection';
+      records.push({bytes, header});
+    }
+  }
+
+  // Geometry collections have a nested union topology. Keep the compatibility path until the
+  // collection builder grows a fully direct event representation; all concrete families below
+  // are decoded directly into measured native buffers.
+  if (hasGeometryCollection) {
+    const rows = normalizeRowsToDimension(
+      records.map(record => (record ? parseWKB(record.bytes).geometry : null)),
+      column.dimension
+    );
+    return copyMetadata(
+      column,
+      makeGeoArrowColumnFromGeometryRows(rows, {dimension: column.dimension})
+    );
+  }
+
+  const groups = new Map<
+    string,
+    {
+      type: WKBHeader['geometryType'];
+      dimension: GeoArrowDimension;
+      records: {bytes: Uint8Array; header: WKBHeader}[];
+    }
+  >();
+  for (const record of records) {
+    if (!record) continue;
+    const key = `${record.header.geometryType}:${record.header.dimension}`;
+    const group = groups.get(key) || {
+      type: record.header.geometryType,
+      dimension: record.header.dimension,
+      records: []
+    };
+    group.records.push(record);
+    groups.set(key, group);
+  }
+  if (groups.size <= 1) {
+    const group = groups.values().next().value as
+      | {
+          type: WKBHeader['geometryType'];
+          dimension: GeoArrowDimension;
+          records: {bytes: Uint8Array; header: WKBHeader}[];
+        }
+      | undefined;
+    const type = group?.type || 'Point';
+    const targetEncoding = encodingFromGeometryType(type);
+    const measure = new GeoArrowBuilder({
+      encoding: targetEncoding,
+      dimension: column.dimension,
+      mode: 'measure'
+    });
+    for (const record of records) {
+      if (!record) measure.append(null);
+      else visitWKBIntoBuilder(record.bytes, measure);
+    }
+    const write = new GeoArrowBuilder({
+      encoding: targetEncoding,
+      dimension: column.dimension,
+      mode: 'write',
+      target: measure.allocateTarget()
+    });
+    for (const record of records) {
+      if (!record) write.append(null);
+      else visitWKBIntoBuilder(record.bytes, write);
+    }
+    return copyMetadata(column, write.finish());
+  }
+
+  const children = [...groups.values()].map(group => {
+    const encoding = encodingFromGeometryType(group.type);
+    const measure = new GeoArrowBuilder({encoding, dimension: group.dimension, mode: 'measure'});
+    for (const record of group.records) visitWKBIntoBuilder(record.bytes, measure);
+    const write = new GeoArrowBuilder({
+      encoding,
+      dimension: group.dimension,
+      mode: 'write',
+      target: measure.allocateTarget()
+    });
+    for (const record of group.records) visitWKBIntoBuilder(record.bytes, write);
+    const built = write.finish();
+    return {
+      name: group.type,
+      typeId: getGeometryTypeId(group.type, group.dimension),
+      encoding,
+      dimension: group.dimension,
+      coordinateLayout: built.coordinateLayout,
+      data: built.chunks[0]
+    };
+  });
+  const typeIds = new Int8Array(records.length);
+  const valueOffsets = new Int32Array(records.length);
+  const validity = new Uint8Array(Math.ceil(records.length / 8));
+  const groupIndices = new Map<string, number>();
+  const groupCounts = new Map<string, number>();
+  children.forEach((child, index) => groupIndices.set(`${child.name}:${child.dimension}`, index));
+  for (let rowIndex = 0; rowIndex < records.length; rowIndex++) {
+    const record = records[rowIndex];
+    if (!record) continue;
+    const key = `${record.header.geometryType}:${record.header.dimension}`;
+    const child = children[groupIndices.get(key)!];
+    typeIds[rowIndex] = child.typeId;
+    valueOffsets[rowIndex] = groupCounts.get(key) || 0;
+    groupCounts.set(key, valueOffsets[rowIndex] + 1);
+    validity[rowIndex >> 3] |= 1 << (rowIndex & 7);
+  }
+  return copyMetadata(column, {
+    encoding: 'geoarrow.geometry',
+    dimension: column.dimension,
+    coordinateLayout: 'interleaved',
+    chunks: [
+      {
+        kind: 'dense-union',
+        length: records.length,
+        typeIds,
+        valueOffsets,
+        children,
+        validity: {values: validity}
+      }
+    ]
+  });
+}
+
+/** Replays one serialized geometry directly into a two-pass GeoArrowBuilder. */
+function visitWKBIntoBuilder(bytes: Uint8Array, builder: GeoArrowBuilder): void {
+  let rootType: WKBHeader['geometryType'] | undefined;
+  visitWKB(bytes, {
+    geometry: (header, _count, depth) => {
+      if (depth === 0) {
+        rootType = header.geometryType;
+        builder.beginGeometry(header.geometryType, header.dimension, _count);
+      } else if (rootType === 'MultiLineString' && header.geometryType === 'LineString') {
+        builder.beginRing(_count);
+      } else if (rootType === 'MultiPolygon' && header.geometryType === 'Polygon') {
+        builder.beginPolygon();
+      }
+    },
+    ring: pointCount => {
+      if (rootType === 'Polygon' || rootType === 'MultiPolygon') builder.beginRing(pointCount);
+    },
+    coordinate: (x, y, z, m, dimension) => {
+      if (dimension === 'xym') builder.writeCoordinate(x, y, undefined, m);
+      else if (dimension === 'xyzm') builder.writeCoordinate(x, y, z, m);
+      else if (dimension === 'xyz') builder.writeCoordinate(x, y, z);
+      else builder.writeCoordinate(x, y);
+    }
+  });
+  builder.endGeometry();
+}
+
+function encodingFromGeometryType(
+  type: WKBHeader['geometryType']
+): Exclude<
+  GeoArrowColumn['encoding'],
+  | 'geoarrow.geometry'
+  | 'geoarrow.geometrycollection'
+  | 'geoarrow.box'
+  | 'geoarrow.wkb'
+  | 'geoarrow.wkt'
+> {
+  if (type === 'GeometryCollection')
+    throw new Error('GeometryCollection requires collection storage');
+  return `geoarrow.${type.toLowerCase()}` as Exclude<
+    GeoArrowColumn['encoding'],
+    | 'geoarrow.geometry'
+    | 'geoarrow.geometrycollection'
+    | 'geoarrow.box'
+    | 'geoarrow.wkb'
+    | 'geoarrow.wkt'
+  >;
+}
+
+function getGeometryTypeId(type: WKBHeader['geometryType'], dimension: GeoArrowDimension): number {
+  const family = [
+    'Point',
+    'LineString',
+    'Polygon',
+    'MultiPoint',
+    'MultiLineString',
+    'MultiPolygon',
+    'GeometryCollection'
+  ].indexOf(type);
+  const dimensionIndex = ['xy', 'xyz', 'xym', 'xyzm'].indexOf(dimension);
+  return family < 0 || dimensionIndex < 0 ? 1 : family * 4 + dimensionIndex + 1;
 }
 
 /** Encodes a native GeoArrow column as variable-width WKB bytes. */

--- a/modules/geoarrow/src/index.ts
+++ b/modules/geoarrow/src/index.ts
@@ -84,8 +84,10 @@ export {
   decodeGeoArrowWKB,
   decodeGeoArrowWKT,
   encodeGeoArrowWKB,
-  encodeGeoArrowWKT
+  encodeGeoArrowWKT,
+  getGeoArrowWKBVertexCount
 } from './codecs';
+export type {DecodeGeoArrowWKBOptions} from './codecs';
 
 export type {
   GeoArrowTessellation,

--- a/modules/geoarrow/src/kernels.ts
+++ b/modules/geoarrow/src/kernels.ts
@@ -9,18 +9,17 @@ import type {
   GeoArrowCoordinateLayout,
   GeoArrowCoordinateMapper,
   GeoArrowDimension,
-  GeoArrowEncoding,
-  GeoArrowGeometryValue
+  GeoArrowEncoding
 } from './types';
-import {getGeoArrowDimensionSize} from './types';
-import {makeGeoArrowColumnFromGeometryRows} from './builder';
+import {getGeoArrowDimensionSize, getGeoArrowGeometryType} from './types';
+import type {GeoArrowBuilderEncoding} from './builder';
+import {GeoArrowBuilder} from './builder';
 import {
   getGeoArrowRowCount,
   getGeoArrowVertexCount,
   isGeoArrowValueValid,
   visitGeoArrowCoordinates,
-  getListRange,
-  materializeGeometryRow
+  getListRange
 } from './layout';
 
 /** Resource limits applied before potentially expensive materialization or conversion. */
@@ -817,7 +816,6 @@ function promoteToDenseUnion(column: GeoArrowColumn): GeoArrowColumn {
       length: chunk.length,
       typeIds,
       valueOffsets,
-      validity: chunk.validity,
       children: [
         {
           name: getGeoArrowGeometryTypeName(column.encoding),
@@ -835,69 +833,179 @@ function promoteToDenseUnion(column: GeoArrowColumn): GeoArrowColumn {
 
 function demoteDenseUnion(column: GeoArrowColumn, encoding: GeoArrowEncoding): GeoArrowColumn {
   if (encoding === 'geoarrow.geometry' || encoding === 'geoarrow.geometrycollection') return column;
-  const rows: Array<GeoArrowGeometryValue | null> = [];
-  for (const chunk of column.chunks) {
-    if (chunk.kind !== 'dense-union') throw new Error('Expected dense-union storage');
-    for (let index = 0; index < chunk.length; index++) {
-      if (!isGeoArrowValueValid(chunk.validity, index)) {
-        rows.push(null);
-        continue;
-      }
-      const physical = (chunk.offset || 0) + index;
-      const child = chunk.children.find(candidate => candidate.typeId === chunk.typeIds[physical]);
-      const childEncoding = child && (child.encoding || getEncodingFromChildName(child.name));
-      if (!child || childEncoding !== encoding) {
-        throw new Error(`Rows cannot be represented as ${encoding}`);
-      }
-      const geometry = materializeGeometryRow(
-        child.data,
-        chunk.valueOffsets[physical],
-        childEncoding
-      );
-      rows.push(
-        geometry
-          ? resizeGeometryValue(geometry, child.dimension || column.dimension, column.dimension)
-          : null
-      );
-    }
-  }
-  const built = makeGeoArrowColumnFromGeometryRows(rows, {
+  if (!isConcreteEncoding(encoding)) throw new Error(`Rows cannot be represented as ${encoding}`);
+  const builderOptions = {
+    encoding,
     dimension: column.dimension,
     coordinateLayout: column.coordinateLayout || 'interleaved',
     offsetType: getColumnOffsetType(column)
+  } as const;
+  const chunks = column.chunks.map(chunk => {
+    if (chunk.kind !== 'dense-union') throw new Error('Expected dense-union storage');
+    const replay = (builder: GeoArrowBuilder): void => {
+      for (let index = 0; index < chunk.length; index++) {
+        if (!isGeoArrowValueValid(chunk.validity, index)) {
+          builder.append(null);
+          continue;
+        }
+        const physical = (chunk.offset || 0) + index;
+        const child = chunk.children.find(
+          candidate => candidate.typeId === chunk.typeIds[physical]
+        );
+        const childEncoding = child && (child.encoding || getEncodingFromChildName(child.name));
+        const childIndex = chunk.valueOffsets[physical];
+        if (!child || !childEncoding || !isGeoArrowValueValid(child.data.validity, childIndex)) {
+          builder.append(null);
+          continue;
+        }
+        if (!isConcreteEncoding(childEncoding) || !canPromoteEncoding(childEncoding, encoding)) {
+          throw new Error(`Rows cannot be represented as ${encoding}`);
+        }
+        replayPhysicalGeometryIntoBuilder(
+          builder,
+          child.data,
+          childIndex,
+          childEncoding,
+          child.dimension || column.dimension,
+          encoding
+        );
+      }
+    };
+    const measure = new GeoArrowBuilder({...builderOptions, mode: 'measure'});
+    replay(measure);
+    const write = new GeoArrowBuilder({
+      ...builderOptions,
+      mode: 'write',
+      target: measure.allocateTarget()
+    });
+    replay(write);
+    return write.finish().chunks[0];
   });
-  return {
-    ...built,
-    encoding: encoding as GeoArrowColumn['encoding'],
-    spatialReference: column.spatialReference,
-    edges: column.edges,
-    metadata: column.metadata
-  };
+  return {...column, encoding, coordinateLayout: builderOptions.coordinateLayout, chunks};
 }
 
-function resizeGeometryValue(
-  geometry: import('./types').GeoArrowGeometryValue,
+function replayPhysicalGeometryIntoBuilder(
+  builder: GeoArrowBuilder,
+  array: GeoArrowArray,
+  rowIndex: number,
+  sourceEncoding: GeoArrowBuilderEncoding,
   sourceDimension: GeoArrowDimension,
-  targetDimension: GeoArrowDimension
-): import('./types').GeoArrowGeometryValue {
-  const map = (value: unknown): unknown => {
-    if (Array.isArray(value) && (value.length === 0 || typeof value[0] === 'number')) {
-      return resizeCoordinate(value as number[], sourceDimension, targetDimension);
+  targetEncoding: GeoArrowBuilderEncoding
+): void {
+  const targetType = getGeoArrowGeometryTypeName(targetEncoding) as
+    | 'Point'
+    | 'LineString'
+    | 'Polygon'
+    | 'MultiPoint'
+    | 'MultiLineString'
+    | 'MultiPolygon';
+  builder.beginGeometry(targetType, sourceDimension);
+  if (sourceEncoding === 'geoarrow.point') {
+    writePhysicalCoordinateIntoBuilder(builder, array, rowIndex, sourceDimension);
+  } else if (sourceEncoding === 'geoarrow.linestring' || sourceEncoding === 'geoarrow.multipoint') {
+    const [first, last] = requireListRange(array, rowIndex);
+    if (targetEncoding === 'geoarrow.multilinestring') builder.beginRing(last - first);
+    const leaf = (array as import('./types').GeoArrowList).child;
+    for (let index = first; index < last; index++) {
+      writePhysicalCoordinateIntoBuilder(builder, leaf, index, sourceDimension);
     }
-    return Array.isArray(value) ? value.map(map) : value;
-  };
-  if (geometry.type === 'GeometryCollection') {
-    return {
-      type: geometry.type,
-      geometries: geometry.geometries.map(child =>
-        resizeGeometryValue(child, sourceDimension, targetDimension)
-      )
-    };
+  } else if (
+    sourceEncoding === 'geoarrow.polygon' ||
+    sourceEncoding === 'geoarrow.multilinestring'
+  ) {
+    const [first, last] = requireListRange(array, rowIndex);
+    if (targetEncoding === 'geoarrow.multipolygon') builder.beginPolygon();
+    const parts = (array as import('./types').GeoArrowList).child;
+    for (let partIndex = first; partIndex < last; partIndex++) {
+      const [partFirst, partLast] = requireListRange(parts, partIndex);
+      builder.beginRing(partLast - partFirst);
+      const leaf = (parts as import('./types').GeoArrowList).child;
+      for (let index = partFirst; index < partLast; index++) {
+        writePhysicalCoordinateIntoBuilder(builder, leaf, index, sourceDimension);
+      }
+    }
+  } else {
+    const [first, last] = requireListRange(array, rowIndex);
+    const polygons = (array as import('./types').GeoArrowList).child;
+    for (let polygonIndex = first; polygonIndex < last; polygonIndex++) {
+      builder.beginPolygon();
+      const [partFirst, partLast] = requireListRange(polygons, polygonIndex);
+      const parts = (polygons as import('./types').GeoArrowList).child;
+      for (let partIndex = partFirst; partIndex < partLast; partIndex++) {
+        const [ringFirst, ringLast] = requireListRange(parts, partIndex);
+        builder.beginRing(ringLast - ringFirst);
+        const leaf = (parts as import('./types').GeoArrowList).child;
+        for (let index = ringFirst; index < ringLast; index++) {
+          writePhysicalCoordinateIntoBuilder(builder, leaf, index, sourceDimension);
+        }
+      }
+    }
   }
-  return {
-    ...geometry,
-    coordinates: map(geometry.coordinates)
-  } as import('./types').GeoArrowGeometryValue;
+  builder.endGeometry();
+}
+
+function writePhysicalCoordinateIntoBuilder(
+  builder: GeoArrowBuilder,
+  array: GeoArrowArray,
+  index: number,
+  dimension: GeoArrowDimension
+): void {
+  if (array.kind === 'fixed-size-list' && array.child.kind === 'primitive') {
+    const logical = (array.offset || 0) + index;
+    const stride = array.child.stride || 1;
+    const scalarOffset = (array.child.offset || 0) + logical * array.size * stride;
+    const x = Number(array.child.values[scalarOffset]);
+    const y = Number(array.child.values[scalarOffset + stride]);
+    const third =
+      array.size > 2 ? Number(array.child.values[scalarOffset + 2 * stride]) : undefined;
+    const fourth =
+      array.size > 3 ? Number(array.child.values[scalarOffset + 3 * stride]) : undefined;
+    builder.writeCoordinateFromDimension(
+      x,
+      y,
+      dimension === 'xyz' || dimension === 'xyzm' ? third : undefined,
+      dimension === 'xym' ? third : fourth,
+      dimension
+    );
+    return;
+  }
+  if (array.kind === 'struct') {
+    const logical = (array.offset || 0) + index;
+    const read = (name: 'x' | 'y' | 'z' | 'm'): number | undefined => {
+      const child = array.children[name];
+      return child?.kind === 'primitive'
+        ? Number(child.values[(child.offset || 0) + logical * (child.stride || 1)])
+        : undefined;
+    };
+    builder.writeCoordinateFromDimension(read('x')!, read('y')!, read('z'), read('m'), dimension);
+    return;
+  }
+  throw new Error('Invalid GeoArrow coordinate storage');
+}
+
+function requireListRange(array: GeoArrowArray, index: number): [number, number] {
+  if (array.kind !== 'list') throw new Error('Invalid GeoArrow list storage');
+  return getListRange(array, index);
+}
+
+function canPromoteEncoding(source: GeoArrowEncoding, target: GeoArrowEncoding): boolean {
+  return (
+    source === target ||
+    (source === 'geoarrow.point' && target === 'geoarrow.multipoint') ||
+    (source === 'geoarrow.linestring' && target === 'geoarrow.multilinestring') ||
+    (source === 'geoarrow.polygon' && target === 'geoarrow.multipolygon')
+  );
+}
+
+function isConcreteEncoding(encoding: GeoArrowEncoding): encoding is GeoArrowBuilderEncoding {
+  return (
+    encoding === 'geoarrow.point' ||
+    encoding === 'geoarrow.linestring' ||
+    encoding === 'geoarrow.polygon' ||
+    encoding === 'geoarrow.multipoint' ||
+    encoding === 'geoarrow.multilinestring' ||
+    encoding === 'geoarrow.multipolygon'
+  );
 }
 
 function getCanonicalTypeId(encoding: GeoArrowEncoding, dimension: GeoArrowDimension): number {
@@ -1011,7 +1119,7 @@ function convertArrayOffsets(array: GeoArrowArray, offsetType: 'int32' | 'int64'
 }
 
 function getGeoArrowGeometryTypeName(encoding: GeoArrowEncoding): string {
-  return encoding.replace('geoarrow.', '').replace(/^./, character => character.toUpperCase());
+  return getGeoArrowGeometryType(encoding) || encoding.replace('geoarrow.', '');
 }
 
 function rewindArrayRings(

--- a/modules/geoarrow/src/kernels.ts
+++ b/modules/geoarrow/src/kernels.ts
@@ -282,17 +282,23 @@ export function convertGeoArrowColumn(
     throw new Error('Use encodeGeoArrowWKB or encodeGeoArrowWKT for serialized output');
   }
   assertGeoArrowResourceLimits(column, options.limits);
-  const mapped = mapGeoArrowCoordinates(
-    column,
-    coordinate => coordinate,
-    {
-      dimension,
-      coordinateLayout: coordinateLayout || undefined,
-      coordinateType: options.coordinateType,
-      limits: options.limits
-    },
-    column.dimension
-  );
+  const needsCoordinateMap =
+    dimension !== column.dimension ||
+    coordinateLayout !== column.coordinateLayout ||
+    (options.coordinateType && options.coordinateType !== 'preserve');
+  const mapped = needsCoordinateMap
+    ? mapGeoArrowCoordinates(
+        column,
+        coordinate => coordinate,
+        {
+          dimension,
+          coordinateLayout: coordinateLayout || undefined,
+          coordinateType: options.coordinateType,
+          limits: options.limits
+        },
+        column.dimension
+      )
+    : column;
   const offsetConverted =
     requestedOffsetType === 'preserve'
       ? mapped
@@ -302,8 +308,43 @@ export function convertGeoArrowColumn(
         };
   if (encoding === column.encoding) return offsetConverted;
   if (encoding === 'geoarrow.geometry') return promoteToDenseUnion(offsetConverted);
+  const promoted = promoteSingleFamily(offsetConverted, encoding, requestedOffsetType);
+  if (promoted) return promoted;
   if (column.encoding === 'geoarrow.geometry') return demoteDenseUnion(offsetConverted, encoding);
   throw new Error(`Rows cannot be represented as ${encoding}`);
+}
+
+/** Wraps a concrete family in one list level without copying its coordinate/topology buffers. */
+function promoteSingleFamily(
+  column: GeoArrowColumn,
+  encoding: GeoArrowEncoding,
+  offsetType: ConvertGeoArrowColumnOptions['offsetType']
+): GeoArrowColumn | null {
+  const sourceEncoding = column.encoding;
+  const validPair =
+    (sourceEncoding === 'geoarrow.point' && encoding === 'geoarrow.multipoint') ||
+    (sourceEncoding === 'geoarrow.linestring' && encoding === 'geoarrow.multilinestring') ||
+    (sourceEncoding === 'geoarrow.polygon' && encoding === 'geoarrow.multipolygon');
+  if (!validPair) return null;
+  const chunks = column.chunks.map(chunk => {
+    const OffsetArray =
+      offsetType === 'int64' || (offsetType === 'preserve' && findOffsetType(chunk) === 'int64')
+        ? BigInt64Array
+        : Int32Array;
+    const offsets = new OffsetArray(chunk.length + 1);
+    for (let index = 0; index <= chunk.length; index++) {
+      if (offsets instanceof BigInt64Array) offsets[index] = BigInt(index);
+      else offsets[index] = index;
+    }
+    return {
+      kind: 'list' as const,
+      length: chunk.length,
+      offsets,
+      child: chunk,
+      validity: chunk.validity
+    };
+  });
+  return {...column, encoding, chunks};
 }
 
 function resizeCoordinate(

--- a/modules/geoarrow/src/layout.ts
+++ b/modules/geoarrow/src/layout.ts
@@ -154,7 +154,7 @@ export function inspectGeoArrowColumn(column: GeoArrowColumn): GeoArrowColumnIns
   for (const chunk of column.chunks) {
     collectStorageKinds(chunk, storageKinds);
     for (let rowIndex = 0; rowIndex < chunk.length; rowIndex++) {
-      if (!isGeoArrowValueValid(chunk.validity, rowIndex)) nullCount++;
+      if (!isGeoArrowRowValid(chunk, rowIndex)) nullCount++;
     }
   }
   return {
@@ -167,6 +167,20 @@ export function inspectGeoArrowColumn(column: GeoArrowColumn): GeoArrowColumnIns
     valid: validation.valid,
     issues: validation.issues
   };
+}
+
+function isGeoArrowRowValid(array: GeoArrowArray, rowIndex: number): boolean {
+  if (!isGeoArrowValueValid(array.validity, rowIndex)) return false;
+  if (array.kind !== 'dense-union') return true;
+  const physicalIndex = (array.offset || 0) + rowIndex;
+  const child = array.children.find(candidate => candidate.typeId === array.typeIds[physicalIndex]);
+  const valueOffset = array.valueOffsets[physicalIndex];
+  return Boolean(
+    child &&
+      valueOffset >= 0 &&
+      valueOffset < child.data.length &&
+      isGeoArrowValueValid(child.data.validity, valueOffset)
+  );
 }
 
 /** Counts coordinate tuples without materializing geometry objects. */

--- a/modules/geoarrow/src/wkb-entry.ts
+++ b/modules/geoarrow/src/wkb-entry.ts
@@ -7,5 +7,7 @@ export {
   decodeGeoArrowWKB,
   decodeGeoArrowWKT,
   encodeGeoArrowWKB,
-  encodeGeoArrowWKT
+  encodeGeoArrowWKT,
+  getGeoArrowWKBVertexCount
 } from './codecs';
+export type {DecodeGeoArrowWKBOptions} from './codecs';

--- a/modules/geoarrow/test/bench.ts
+++ b/modules/geoarrow/test/bench.ts
@@ -1,0 +1,70 @@
+// math.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+// @ts-expect-error tsconfig issue?
+import type {Bench} from '@probe.gl/bench';
+import {writeWKB} from '@math.gl/wkb';
+import {
+  convertGeoArrowColumn,
+  decodeGeoArrowWKB,
+  getGeoArrowBounds,
+  getGeoArrowWKBVertexCount,
+  getGeoArrowVertexCount
+} from '../src/index';
+import type {GeoArrowColumn} from '../src/types';
+
+const POINT_COUNT = 1_000_000;
+const pointWKB = writeWKB({type: 'Point', coordinates: [1, 2]}, 'xy');
+const wkbValues = new Uint8Array(POINT_COUNT * pointWKB.length);
+const wkbOffsets = new Int32Array(POINT_COUNT + 1);
+const coordinates = new Float64Array(POINT_COUNT * 2);
+for (let index = 0; index < POINT_COUNT; index++) {
+  wkbValues.set(pointWKB, index * pointWKB.length);
+  wkbOffsets[index + 1] = (index + 1) * pointWKB.length;
+  coordinates[index * 2] = index;
+  coordinates[index * 2 + 1] = -index;
+}
+
+const serializedPoints: GeoArrowColumn = {
+  encoding: 'geoarrow.wkb',
+  dimension: 'xy',
+  coordinateLayout: null,
+  chunks: [
+    {
+      kind: 'serialized',
+      encoding: 'binary',
+      length: POINT_COUNT,
+      offsets: wkbOffsets,
+      values: wkbValues
+    }
+  ]
+};
+
+const nativePoints: GeoArrowColumn = {
+  encoding: 'geoarrow.point',
+  dimension: 'xy',
+  coordinateLayout: 'interleaved',
+  chunks: [
+    {
+      kind: 'fixed-size-list',
+      length: POINT_COUNT,
+      size: 2,
+      child: {kind: 'primitive', length: coordinates.length, values: coordinates}
+    }
+  ]
+};
+
+/** Allocation-sensitive GeoArrow benchmarks modeled on loaders.gl's small-feature hot path. */
+export function geoarrowBench(suite: Bench): Bench {
+  suite
+    .group('GeoArrow buffers (1M points)')
+    .add('count WKB vertices', () => getGeoArrowWKBVertexCount(serializedPoints))
+    .add('decode WKB to native', () => decodeGeoArrowWKB(serializedPoints))
+    .add('native vertex count', () => getGeoArrowVertexCount(nativePoints))
+    .add('native bounds', () => getGeoArrowBounds(nativePoints))
+    .add('interleaved to separated', () =>
+      convertGeoArrowColumn(nativePoints, {coordinateLayout: 'separated'})
+    );
+  return suite;
+}

--- a/modules/geoarrow/test/buffer-first.spec.ts
+++ b/modules/geoarrow/test/buffer-first.spec.ts
@@ -1,7 +1,13 @@
 import {expect, test} from 'vitest';
 import {GeoArrowBuilder} from '../src/builder-entry';
-import {getGeoArrowRowBounds, mapGeoArrowCoordinates, validateGeoArrowColumn} from '../src/index';
+import {
+  getGeoArrowRowBounds,
+  makeGeoArrowColumnFromGeometryRows,
+  mapGeoArrowCoordinates,
+  validateGeoArrowColumn
+} from '../src/index';
 import type {GeoArrowColumn} from '../src/types';
+import {materializeGeoArrowRows} from '../src/layout';
 
 test('subpath builder emits a plain descriptor and row bounds are direct', () => {
   const measure = new GeoArrowBuilder({
@@ -62,4 +68,112 @@ test('mixed union children retain their dimensions during identity mapping', () 
   ).children;
   expect(children.map(child => child.dimension)).toEqual(['xyz', 'xym']);
   expect(validateGeoArrowColumn(mapped).valid).toBe(true);
+});
+
+test('scalar event writes convert source dimensions without tuple allocation', () => {
+  const measure = new GeoArrowBuilder({
+    encoding: 'geoarrow.point',
+    dimension: 'xyzm',
+    coordinateLayout: 'separated',
+    coordinateType: 'float32',
+    mode: 'measure'
+  });
+  measure
+    .beginGeometry('Point', 'xym')
+    .writeCoordinateFromDimension(1, 2, undefined, 9, 'xym')
+    .endGeometry();
+  const write = new GeoArrowBuilder({
+    encoding: 'geoarrow.point',
+    dimension: 'xyzm',
+    coordinateLayout: 'separated',
+    coordinateType: 'float32',
+    mode: 'write',
+    target: measure.allocateTarget()
+  });
+  const column = write
+    .beginGeometry('Point', 'xym')
+    .writeCoordinateFromDimension(1, 2, undefined, 9, 'xym')
+    .endGeometry()
+    .finish();
+  const coordinates = column.chunks[0] as Extract<
+    GeoArrowColumn['chunks'][number],
+    {kind: 'struct'}
+  >;
+  const expected = {x: 1, z: 0, m: 9} as const;
+  for (const [name, value] of Object.entries(expected)) {
+    const child = coordinates.children[name];
+    expect(child.kind).toBe('primitive');
+    if (child.kind !== 'primitive') throw new Error(`Expected primitive ${name} child`);
+    expect(child.values).toEqual(new Float32Array([value]));
+  }
+});
+
+test('array event writes map every semantic dimension into final buffers', () => {
+  const cases = [
+    {target: 'xyz' as const, source: 'xy' as const, coordinate: [1, 2], expected: [1, 2, 0]},
+    {target: 'xym' as const, source: 'xym' as const, coordinate: [3, 4, 5], expected: [3, 4, 5]},
+    {
+      target: 'xyzm' as const,
+      source: 'xyz' as const,
+      coordinate: [6, 7, 8],
+      expected: [6, 7, 8, 0]
+    }
+  ];
+  for (const {target, source, coordinate, expected} of cases) {
+    const options = {
+      encoding: 'geoarrow.point' as const,
+      dimension: target,
+      coordinateLayout: 'separated' as const
+    };
+    const feed = (builder: GeoArrowBuilder): void => {
+      builder.beginGeometry('Point', source).writeCoordinate(coordinate).endGeometry();
+    };
+    const measure = new GeoArrowBuilder({...options, mode: 'measure'});
+    feed(measure);
+    const write = new GeoArrowBuilder({
+      ...options,
+      mode: 'write',
+      target: measure.allocateTarget()
+    });
+    feed(write);
+    expect(materializeGeoArrowRows(write.finish())).toEqual([
+      {type: 'Point', coordinates: expected}
+    ]);
+  }
+});
+
+test('event builder rejects structurally invalid event sequences', () => {
+  const builder = new GeoArrowBuilder({
+    encoding: 'geoarrow.point',
+    dimension: 'xy',
+    mode: 'measure'
+  });
+  expect(() => builder.beginPolygon()).toThrow('beginPolygon must follow');
+  expect(() => builder.beginRing()).toThrow('beginRing must follow');
+  expect(() => builder.writeCoordinate(1, 2)).toThrow('writeCoordinate must follow');
+  expect(() => builder.writeCoordinateFromDimension(1, 2, undefined, undefined, 'xy')).toThrow(
+    'writeCoordinateFromDimension must follow'
+  );
+  expect(() => builder.endGeometry()).toThrow('endGeometry without beginGeometry');
+});
+
+test('mixed builders encode nulls in a valid dense-union child', () => {
+  const column = makeGeoArrowColumnFromGeometryRows([
+    {type: 'Point', coordinates: [1, 2]},
+    null,
+    {type: 'LineString', coordinates: [[3, 4]]}
+  ]);
+  const union = column.chunks[0] as Extract<
+    GeoArrowColumn['chunks'][number],
+    {kind: 'dense-union'}
+  >;
+  expect(union.validity).toBeUndefined();
+  expect(
+    [...union.typeIds].every(typeId => union.children.some(child => child.typeId === typeId))
+  ).toBe(true);
+  expect(materializeGeoArrowRows(column)).toEqual([
+    {type: 'Point', coordinates: [1, 2]},
+    null,
+    {type: 'LineString', coordinates: [[3, 4]]}
+  ]);
 });

--- a/modules/geoarrow/test/codecs.spec.ts
+++ b/modules/geoarrow/test/codecs.spec.ts
@@ -9,6 +9,7 @@ import {
   decodeGeoArrowWKT,
   encodeGeoArrowWKB,
   encodeGeoArrowWKT,
+  getGeoArrowWKBVertexCount,
   makeGeoArrowColumnFromGeometryRows,
   type GeoArrowColumn,
   type GeoArrowDimension,
@@ -47,6 +48,36 @@ test('serialized identity is preserved', () => {
   expect(encodeGeoArrowWKT(wkt)).toBe(wkt);
 });
 
+test('WKB encoding preserves nulls stored in dense-union children', () => {
+  const source = makeGeoArrowColumnFromGeometryRows([
+    {type: 'Point', coordinates: [1, 2]},
+    null,
+    {type: 'LineString', coordinates: [[3, 4]]}
+  ]);
+  const encoded = encodeGeoArrowWKB(source);
+  expect(materializeGeoArrowRows(decodeGeoArrowWKB(encoded))).toEqual(
+    materializeGeoArrowRows(source)
+  );
+});
+
+test('WKB encoding preserves native chunk boundaries', () => {
+  const oneChunk = makeGeoArrowColumnFromGeometryRows([
+    {type: 'Point', coordinates: [1, 2]},
+    {type: 'Point', coordinates: [3, 4]}
+  ]);
+  const source = {...oneChunk, chunks: [oneChunk.chunks[0], oneChunk.chunks[0]]};
+  const encoded = encodeGeoArrowWKB(source);
+  expect(encoded.chunks).toHaveLength(2);
+  const decoded = decodeGeoArrowWKB(encoded);
+  expect(decoded.chunks).toHaveLength(2);
+  expect(materializeGeoArrowRows(decoded)).toEqual([
+    {type: 'Point', coordinates: [1, 2]},
+    {type: 'Point', coordinates: [3, 4]},
+    {type: 'Point', coordinates: [1, 2]},
+    {type: 'Point', coordinates: [3, 4]}
+  ]);
+});
+
 test('serialized mixed-dimension collections normalize to the declared column dimension', () => {
   const point = writeWKB({type: 'Point', coordinates: [1, 2]}, 'xy');
   const line = writeWKB(
@@ -70,7 +101,7 @@ test('serialized mixed-dimension collections normalize to the declared column di
   for (const serialized of columns) {
     const decoded =
       serialized.encoding === 'geoarrow.wkb'
-        ? decodeGeoArrowWKB(serialized)
+        ? decodeGeoArrowWKB(serialized, {dimension: 'preserve'})
         : decodeGeoArrowWKT(serialized);
     const collection = materializeGeoArrowRows(decoded)[0] as Extract<
       GeoArrowGeometryValue,
@@ -85,6 +116,245 @@ test('serialized mixed-dimension collections normalize to the declared column di
       ]
     });
   }
+});
+
+test('WKB decoder infers serialized dimensions and writes requested final buffers', () => {
+  const bytes = writeWKB({type: 'Point', coordinates: [1, 2, 3]}, 'xyz');
+  const source = makeSerializedFixture('geoarrow.wkb', 'binary', bytes, 'xy');
+  const decoded = decodeGeoArrowWKB(source, {
+    coordinateLayout: 'separated',
+    coordinateType: 'float32',
+    offsetType: 'int64'
+  });
+  expect(decoded.dimension).toBe('xyz');
+  expect(decoded.coordinateLayout).toBe('separated');
+  expect(materializeGeoArrowRows(decoded)).toEqual([{type: 'Point', coordinates: [1, 2, 3]}]);
+  const coordinateStruct = decoded.chunks[0];
+  if (coordinateStruct.kind !== 'struct') throw new Error('Expected separated coordinates');
+  const x = coordinateStruct.children['x'];
+  if (x.kind !== 'primitive') throw new Error('Expected primitive x coordinates');
+  expect(x.values).toBeInstanceOf(Float32Array);
+});
+
+test('WKB decoder applies explicit family promotion and rejects incompatible targets', () => {
+  const bytes = writeWKB({type: 'Point', coordinates: [1, 2]}, 'xy');
+  const source = makeSerializedFixture('geoarrow.wkb', 'binary', bytes, 'xy');
+  const promoted = decodeGeoArrowWKB(source, {
+    encoding: 'geoarrow.multipoint',
+    offsetType: 'int64'
+  });
+  expect(promoted.encoding).toBe('geoarrow.multipoint');
+  const promotedChunk = promoted.chunks[0];
+  if (promotedChunk.kind !== 'list') throw new Error('Expected MultiPoint list storage');
+  expect(promotedChunk.offsets).toBeInstanceOf(BigInt64Array);
+  expect(materializeGeoArrowRows(promoted)).toEqual([{type: 'MultiPoint', coordinates: [[1, 2]]}]);
+  expect(() => decodeGeoArrowWKB(source, {encoding: 'geoarrow.polygon'})).toThrow(
+    'Rows cannot be represented as geoarrow.polygon'
+  );
+  expect(() => decodeGeoArrowWKB(source, {encoding: 'geoarrow.geometrycollection'})).toThrow(
+    'Rows cannot be represented as geoarrow.geometrycollection'
+  );
+});
+
+test('WKB decoder reads Arrow BinaryView storage without consolidating source bytes', () => {
+  const bytes = writeWKB({type: 'Point', coordinates: [11, 12, 13]}, 'xyz');
+  const source: GeoArrowColumn = {
+    encoding: 'geoarrow.wkb',
+    dimension: 'xy',
+    coordinateLayout: null,
+    chunks: [
+      {
+        kind: 'serialized',
+        encoding: 'binary',
+        length: 1,
+        offsets: new Int32Array([0, 0]),
+        values: new Uint8Array(),
+        views: new Uint32Array([bytes.length, 0, 0, 0]),
+        dataBuffers: [bytes]
+      }
+    ]
+  };
+  const decoded = decodeGeoArrowWKB(source);
+  expect(getGeoArrowWKBVertexCount(source)).toBe(1);
+  expect(decoded.dimension).toBe('xyz');
+  expect(materializeGeoArrowRows(decoded)).toEqual([{type: 'Point', coordinates: [11, 12, 13]}]);
+});
+
+test('WKB decoder preserves chunks and a stable mixed-union schema', () => {
+  const point = writeWKB({type: 'Point', coordinates: [1, 2]}, 'xy');
+  const line = writeWKB(
+    {
+      type: 'LineString',
+      coordinates: [
+        [3, 4],
+        [5, 6]
+      ]
+    },
+    'xy'
+  );
+  const source: GeoArrowColumn = {
+    encoding: 'geoarrow.wkb',
+    dimension: 'xy',
+    coordinateLayout: null,
+    chunks: [
+      makeSerializedFixture('geoarrow.wkb', 'binary', point, 'xy').chunks[0],
+      {
+        kind: 'serialized',
+        encoding: 'binary',
+        length: 2,
+        offsets: new Int32Array([0, 0, line.length]),
+        values: line,
+        validity: {values: new Uint8Array([0b10])}
+      }
+    ]
+  };
+  const decoded = decodeGeoArrowWKB(source);
+  expect(decoded.chunks).toHaveLength(2);
+  for (const chunk of decoded.chunks) {
+    expect(chunk.kind).toBe('dense-union');
+    if (chunk.kind === 'dense-union') {
+      expect(chunk.children.map(child => child.name)).toEqual(['Point', 'LineString']);
+      expect(chunk.validity).toBeUndefined();
+      expect([...chunk.typeIds].every(typeId => typeId > 0)).toBe(true);
+    }
+  }
+  expect(materializeGeoArrowRows(decoded)).toEqual([
+    {type: 'Point', coordinates: [1, 2]},
+    null,
+    {
+      type: 'LineString',
+      coordinates: [
+        [3, 4],
+        [5, 6]
+      ]
+    }
+  ]);
+});
+
+test('WKB decoder builds nested GeometryCollections without materialized rows', () => {
+  const geometry: GeoArrowGeometryValue = {
+    type: 'GeometryCollection',
+    geometries: [
+      {type: 'Point', coordinates: [1, 2, 0]},
+      {
+        type: 'GeometryCollection',
+        geometries: [
+          {
+            type: 'LineString',
+            coordinates: [
+              [3, 4, 5],
+              [6, 7, 8]
+            ]
+          }
+        ]
+      }
+    ]
+  };
+  const bytes = writeWKB(geometry, 'xyz');
+  const source = makeSerializedFixture('geoarrow.wkb', 'binary', bytes, 'xy');
+  const decoded = decodeGeoArrowWKB(source);
+  expect(decoded.encoding).toBe('geoarrow.geometrycollection');
+  expect(decoded.dimension).toBe('xyz');
+  expect(materializeGeoArrowRows(decoded)).toEqual([
+    {
+      type: 'GeometryCollection',
+      geometries: [
+        {type: 'Point', coordinates: [1, 2, 0]},
+        {
+          type: 'GeometryCollection',
+          geometries: [
+            {
+              type: 'LineString',
+              coordinates: [
+                [3, 4, 5],
+                [6, 7, 8]
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]);
+});
+
+test('WKB decoder builds mixed collection and multi-geometry children directly', () => {
+  const geometries: GeoArrowGeometryValue[] = [
+    {
+      type: 'GeometryCollection',
+      geometries: [
+        {
+          type: 'MultiLineString',
+          coordinates: [
+            [
+              [0, 1, 2, 3],
+              [4, 5, 6, 7]
+            ],
+            [
+              [8, 9, 10, 11],
+              [12, 13, 14, 15]
+            ]
+          ]
+        },
+        {
+          type: 'MultiPolygon',
+          coordinates: [
+            [
+              [
+                [0, 0, 1, 2],
+                [1, 0, 3, 4],
+                [0, 1, 5, 6],
+                [0, 0, 1, 2]
+              ]
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      type: 'MultiPolygon',
+      coordinates: [
+        [
+          [
+            [20, 20, 1, 2],
+            [21, 20, 3, 4],
+            [20, 21, 5, 6],
+            [20, 20, 1, 2]
+          ]
+        ]
+      ]
+    }
+  ];
+  const source = makeSerializedWKBRows([
+    writeWKB(geometries[0], 'xyzm'),
+    writeWKB(geometries[1], 'xyzm'),
+    null
+  ]);
+  const decoded = decodeGeoArrowWKB(source, {
+    encoding: 'geoarrow.geometry',
+    coordinateLayout: 'separated',
+    coordinateType: 'float32',
+    offsetType: 'int64'
+  });
+  expect(getGeoArrowWKBVertexCount(source)).toBe(12);
+  expect(decoded.chunks[0].kind).toBe('dense-union');
+  expect(materializeGeoArrowRows(decoded)).toEqual([...geometries, null]);
+});
+
+test('WKB decoder preserves null GeometryCollection rows in concrete storage', () => {
+  const geometry: GeoArrowGeometryValue = {
+    type: 'GeometryCollection',
+    geometries: [{type: 'Point', coordinates: [1, 2]}]
+  };
+  const decoded = decodeGeoArrowWKB(makeSerializedWKBRows([writeWKB(geometry, 'xy'), null]), {
+    encoding: 'geoarrow.geometrycollection'
+  });
+  expect(materializeGeoArrowRows(decoded)).toEqual([geometry, null]);
+});
+
+test('WKB decoder builds an empty GeometryCollection without child schemas', () => {
+  const geometry: GeoArrowGeometryValue = {type: 'GeometryCollection', geometries: []};
+  const decoded = decodeGeoArrowWKB(makeSerializedWKBRows([writeWKB(geometry, 'xy')]));
+  expect(materializeGeoArrowRows(decoded)).toEqual([geometry]);
 });
 
 test('WKB decoder writes concrete families directly from visitor events', () => {
@@ -165,11 +435,18 @@ test('WKB decoder uses mixed-dimension dense-union children without row material
   const values = new Uint8Array(point.length + line.length);
   values.set(point, 0);
   values.set(line, point.length);
-  const source = makeSerializedFixture('geoarrow.wkb', 'binary', values);
-  source.chunks[0] = {
-    ...source.chunks[0],
-    length: 2,
-    offsets: new Int32Array([0, point.length, values.length])
+  const fixture = makeSerializedFixture('geoarrow.wkb', 'binary', values);
+  const serialized = fixture.chunks[0];
+  if (serialized.kind !== 'serialized') throw new Error('Expected serialized fixture');
+  const source: GeoArrowColumn = {
+    ...fixture,
+    chunks: [
+      {
+        ...serialized,
+        length: 2,
+        offsets: new Int32Array([0, point.length, values.length])
+      }
+    ]
   };
   const decoded = decodeGeoArrowWKB(source);
   expect(decoded.encoding).toBe('geoarrow.geometry');
@@ -220,6 +497,38 @@ function makeSerializedFixture(
         length: 1,
         offsets: new Int32Array([0, values.length]),
         values
+      }
+    ]
+  };
+}
+
+function makeSerializedWKBRows(rows: readonly (Uint8Array | null)[]): GeoArrowColumn {
+  const offsets = new Int32Array(rows.length + 1);
+  const validity = new Uint8Array(Math.ceil(rows.length / 8));
+  const byteLength = rows.reduce((sum, row) => sum + (row?.length || 0), 0);
+  const values = new Uint8Array(byteLength);
+  let byteOffset = 0;
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    const row = rows[rowIndex];
+    if (row) {
+      values.set(row, byteOffset);
+      byteOffset += row.length;
+      validity[rowIndex >> 3] |= 1 << (rowIndex & 7);
+    }
+    offsets[rowIndex + 1] = byteOffset;
+  }
+  return {
+    encoding: 'geoarrow.wkb',
+    dimension: 'xy',
+    coordinateLayout: null,
+    chunks: [
+      {
+        kind: 'serialized',
+        encoding: 'binary',
+        length: rows.length,
+        offsets,
+        values,
+        validity: {values: validity}
       }
     ]
   };

--- a/modules/geoarrow/test/codecs.spec.ts
+++ b/modules/geoarrow/test/codecs.spec.ts
@@ -186,6 +186,23 @@ test('WKB decoder uses mixed-dimension dense-union children without row material
   ]);
 });
 
+test('WKB decoder normalizes dimensions on nested multi-geometry members', () => {
+  // MultiPoint Z with one XY Point child (valid mixed-member WKB).
+  const bytes = new Uint8Array(30);
+  const view = new DataView(bytes.buffer);
+  view.setUint8(0, 1);
+  view.setUint32(1, 1004, true);
+  view.setUint32(5, 1, true);
+  view.setUint8(9, 1);
+  view.setUint32(10, 1, true);
+  view.setFloat64(14, 10, true);
+  view.setFloat64(22, 20, true);
+  const source = makeSerializedFixture('geoarrow.wkb', 'binary', bytes, 'xyz');
+  expect(materializeGeoArrowRows(decodeGeoArrowWKB(source))).toEqual([
+    {type: 'MultiPoint', coordinates: [[10, 20, 0]]}
+  ]);
+});
+
 function makeSerializedFixture(
   encoding: 'geoarrow.wkb' | 'geoarrow.wkt',
   physicalEncoding: 'binary' | 'utf8',

--- a/modules/geoarrow/test/codecs.spec.ts
+++ b/modules/geoarrow/test/codecs.spec.ts
@@ -87,14 +87,114 @@ test('serialized mixed-dimension collections normalize to the declared column di
   }
 });
 
+test('WKB decoder writes concrete families directly from visitor events', () => {
+  const geometries: GeoArrowGeometryValue[] = [
+    {
+      type: 'LineString',
+      coordinates: [
+        [0, 1],
+        [2, 3]
+      ]
+    },
+    {
+      type: 'MultiPoint',
+      coordinates: [
+        [4, 5],
+        [6, 7]
+      ]
+    },
+    {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0, 0],
+          [2, 0],
+          [0, 2],
+          [0, 0]
+        ]
+      ]
+    },
+    {
+      type: 'MultiLineString',
+      coordinates: [
+        [
+          [0, 0],
+          [1, 1]
+        ],
+        [
+          [2, 2],
+          [3, 3]
+        ]
+      ]
+    },
+    {
+      type: 'MultiPolygon',
+      coordinates: [
+        [
+          [
+            [0, 0],
+            [2, 0],
+            [0, 2],
+            [0, 0]
+          ]
+        ]
+      ]
+    }
+  ];
+  for (const geometry of geometries) {
+    const bytes = writeWKB(geometry, 'xy');
+    const source = makeSerializedFixture('geoarrow.wkb', 'binary', bytes, 'xy');
+    const decoded = decodeGeoArrowWKB(source);
+    expect(decoded.encoding).toBe(`geoarrow.${geometry.type.toLowerCase()}`);
+    expect(materializeGeoArrowRows(decoded)).toEqual([geometry]);
+  }
+});
+
+test('WKB decoder uses mixed-dimension dense-union children without row materialization', () => {
+  const point = writeWKB({type: 'Point', coordinates: [1, 2]}, 'xy');
+  const line = writeWKB(
+    {
+      type: 'LineString',
+      coordinates: [
+        [3, 4, 5],
+        [6, 7, 8]
+      ]
+    },
+    'xyz'
+  );
+  const values = new Uint8Array(point.length + line.length);
+  values.set(point, 0);
+  values.set(line, point.length);
+  const source = makeSerializedFixture('geoarrow.wkb', 'binary', values);
+  source.chunks[0] = {
+    ...source.chunks[0],
+    length: 2,
+    offsets: new Int32Array([0, point.length, values.length])
+  };
+  const decoded = decodeGeoArrowWKB(source);
+  expect(decoded.encoding).toBe('geoarrow.geometry');
+  expect(decoded.chunks[0].kind).toBe('dense-union');
+  expect(materializeGeoArrowRows(decoded)).toEqual([
+    {type: 'Point', coordinates: [1, 2]},
+    {
+      type: 'LineString',
+      coordinates: [
+        [3, 4, 5],
+        [6, 7, 8]
+      ]
+    }
+  ]);
+});
+
 function makeSerializedFixture(
   encoding: 'geoarrow.wkb' | 'geoarrow.wkt',
   physicalEncoding: 'binary' | 'utf8',
-  values: Uint8Array
+  values: Uint8Array,
+  dimension: GeoArrowDimension = 'xyzm'
 ): GeoArrowColumn {
   return {
     encoding,
-    dimension: 'xyzm',
+    dimension,
     coordinateLayout: null,
     chunks: [
       {

--- a/modules/geoarrow/test/kernels.spec.ts
+++ b/modules/geoarrow/test/kernels.spec.ts
@@ -47,6 +47,22 @@ test('coordinate mapping, into mapping and layout conversion are deterministic',
   expect(interleaveGeoArrowCoordinates(unspecifiedLayout)).toBe(unspecifiedLayout);
 });
 
+test('single-family promotions share existing coordinate and topology buffers', () => {
+  const point = makeGeoArrowColumnFromGeometryRows([
+    {type: 'Point', coordinates: [1, 2]},
+    {type: 'Point', coordinates: [3, 4]}
+  ]);
+  const promoted = convertGeoArrowColumn(point, {encoding: 'geoarrow.multipoint'});
+  expect(promoted.encoding).toBe('geoarrow.multipoint');
+  expect(materializeGeoArrowRows(promoted)).toEqual([
+    {type: 'MultiPoint', coordinates: [[1, 2]]},
+    {type: 'MultiPoint', coordinates: [[3, 4]]}
+  ]);
+  const pointValues = (point.chunks[0] as any).child.values;
+  const promotedValues = (promoted.chunks[0] as any).child.child.values;
+  expect(promotedValues.buffer).toBe(pointValues.buffer);
+});
+
 test('coordinate mapping attributes every nested coordinate to its logical row', () => {
   const source = makeGeoArrowColumnFromGeometryRows([
     {

--- a/modules/geoarrow/test/kernels.spec.ts
+++ b/modules/geoarrow/test/kernels.spec.ts
@@ -14,6 +14,7 @@ import {
   mapGeoArrowCoordinatesInto,
   normalizeGeoArrowUnion,
   rewindGeoArrow,
+  sliceGeoArrowColumn,
   tessellateGeoArrowPolygons,
   type GeoArrowGeometryValue
 } from '../src/index';
@@ -58,8 +59,20 @@ test('single-family promotions share existing coordinate and topology buffers', 
     {type: 'MultiPoint', coordinates: [[1, 2]]},
     {type: 'MultiPoint', coordinates: [[3, 4]]}
   ]);
-  const pointValues = (point.chunks[0] as any).child.values;
-  const promotedValues = (promoted.chunks[0] as any).child.child.values;
+  const pointCoordinates = point.chunks[0];
+  if (pointCoordinates.kind !== 'fixed-size-list' || pointCoordinates.child.kind !== 'primitive') {
+    throw new Error('Expected interleaved Point coordinates');
+  }
+  const promotedChunk = promoted.chunks[0];
+  if (
+    promotedChunk.kind !== 'list' ||
+    promotedChunk.child.kind !== 'fixed-size-list' ||
+    promotedChunk.child.child.kind !== 'primitive'
+  ) {
+    throw new Error('Expected interleaved MultiPoint coordinates');
+  }
+  const pointValues = pointCoordinates.child.values;
+  const promotedValues = promotedChunk.child.child.values;
   expect(promotedValues.buffer).toBe(pointValues.buffer);
 });
 
@@ -136,6 +149,184 @@ test('conversion forces dense unions and never reinterprets M as Z', () => {
   expect(mixed.encoding).toBe('geoarrow.geometry');
   expect(mixed.chunks[0].kind).toBe('dense-union');
   expect(materializeGeoArrowRows(mixed)).toEqual([{type: 'Point', coordinates: [1, 2, 99]}]);
+});
+
+test('dense-union demotion gathers sliced children directly and promotes single rows', () => {
+  const source = makeGeoArrowColumnFromGeometryRows(
+    [
+      {type: 'Point', coordinates: [-1, -2, -3]},
+      null,
+      {type: 'Point', coordinates: [1, 2, 3]},
+      {
+        type: 'MultiPoint',
+        coordinates: [
+          [4, 5, 6],
+          [7, 8, 9]
+        ]
+      }
+    ],
+    {dimension: 'xyz', offsetType: 'int64'}
+  );
+  const sliced = sliceGeoArrowColumn(source, 1, 4);
+  const converted = convertGeoArrowColumn(sliced, {
+    encoding: 'geoarrow.multipoint',
+    offsetType: 'preserve'
+  });
+  expect(converted.chunks).toHaveLength(1);
+  const chunk = converted.chunks[0];
+  if (chunk.kind !== 'list') throw new Error('Expected MultiPoint list storage');
+  expect(chunk.offsets).toBeInstanceOf(BigInt64Array);
+  expect(materializeGeoArrowRows(converted)).toEqual([
+    null,
+    {type: 'MultiPoint', coordinates: [[1, 2, 3]]},
+    {
+      type: 'MultiPoint',
+      coordinates: [
+        [4, 5, 6],
+        [7, 8, 9]
+      ]
+    }
+  ]);
+});
+
+test('dense-union demotion replays every nested topology from separated coordinates', () => {
+  const cases: Array<{
+    target: 'geoarrow.multilinestring' | 'geoarrow.multipolygon';
+    rows: GeoArrowGeometryValue[];
+    expected: GeoArrowGeometryValue[];
+  }> = [
+    {
+      target: 'geoarrow.multilinestring',
+      rows: [
+        {
+          type: 'LineString',
+          coordinates: [
+            [0, 1, 2],
+            [3, 4, 5]
+          ]
+        },
+        {
+          type: 'MultiLineString',
+          coordinates: [
+            [
+              [6, 7, 8],
+              [9, 10, 11]
+            ]
+          ]
+        }
+      ],
+      expected: [
+        {
+          type: 'MultiLineString',
+          coordinates: [
+            [
+              [0, 1, 2],
+              [3, 4, 5]
+            ]
+          ]
+        },
+        {
+          type: 'MultiLineString',
+          coordinates: [
+            [
+              [6, 7, 8],
+              [9, 10, 11]
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      target: 'geoarrow.multipolygon',
+      rows: [
+        {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [0, 0, 1],
+              [1, 0, 2],
+              [0, 1, 3],
+              [0, 0, 1]
+            ]
+          ]
+        },
+        {
+          type: 'MultiPolygon',
+          coordinates: [
+            [
+              [
+                [10, 10, 4],
+                [11, 10, 5],
+                [10, 11, 6],
+                [10, 10, 4]
+              ]
+            ]
+          ]
+        }
+      ],
+      expected: [
+        {
+          type: 'MultiPolygon',
+          coordinates: [
+            [
+              [
+                [0, 0, 1],
+                [1, 0, 2],
+                [0, 1, 3],
+                [0, 0, 1]
+              ]
+            ]
+          ]
+        },
+        {
+          type: 'MultiPolygon',
+          coordinates: [
+            [
+              [
+                [10, 10, 4],
+                [11, 10, 5],
+                [10, 11, 6],
+                [10, 10, 4]
+              ]
+            ]
+          ]
+        }
+      ]
+    }
+  ];
+  for (const {target, rows, expected} of cases) {
+    const source = makeGeoArrowColumnFromGeometryRows(rows, {
+      dimension: 'xyz',
+      coordinateLayout: 'separated',
+      offsetType: 'int64'
+    });
+    const converted = convertGeoArrowColumn(source, {encoding: target});
+    expect(materializeGeoArrowRows(converted)).toEqual(expected);
+  }
+});
+
+test('dense-union demotion accepts legacy root nulls and rejects incompatible families', () => {
+  const points = makeGeoArrowColumnFromGeometryRows([
+    {type: 'Point', coordinates: [1, 2]},
+    {type: 'MultiPoint', coordinates: [[3, 4]]}
+  ]);
+  const union = points.chunks[0];
+  if (union.kind !== 'dense-union') throw new Error('Expected mixed union storage');
+  const legacy = {
+    ...points,
+    chunks: [{...union, validity: {values: new Uint8Array([0b10])}}]
+  };
+  expect(
+    materializeGeoArrowRows(convertGeoArrowColumn(legacy, {encoding: 'geoarrow.multipoint'}))
+  ).toEqual([null, {type: 'MultiPoint', coordinates: [[3, 4]]}]);
+
+  const incompatible = makeGeoArrowColumnFromGeometryRows([
+    {type: 'Point', coordinates: [1, 2]},
+    {type: 'LineString', coordinates: [[3, 4]]}
+  ]);
+  expect(() => convertGeoArrowColumn(incompatible, {encoding: 'geoarrow.multipoint'})).toThrow(
+    'Rows cannot be represented as geoarrow.multipoint'
+  );
 });
 
 test('dimension conversion recurses through nested geometry collections', () => {
@@ -448,7 +639,7 @@ test('union normalization and conversion reject incompatible output families', (
 });
 
 test('rewinding handles multipolygons and nested collections', () => {
-  const polygon = (clockwise: boolean): GeoArrowGeometryValue => ({
+  const polygon = (clockwise: boolean): Extract<GeoArrowGeometryValue, {type: 'Polygon'}> => ({
     type: 'Polygon',
     coordinates: [
       clockwise

--- a/modules/geoarrow/test/layout.spec.ts
+++ b/modules/geoarrow/test/layout.spec.ts
@@ -201,6 +201,58 @@ test('GeoArrowBuilder event API preserves MultiPolygon parts', () => {
   });
 });
 
+test('GeoArrowBuilder event API writes every concrete family directly', () => {
+  const cases: Array<{
+    encoding:
+      | 'geoarrow.point'
+      | 'geoarrow.multipoint'
+      | 'geoarrow.polygon'
+      | 'geoarrow.multilinestring';
+    type: 'Point' | 'MultiPoint' | 'Polygon' | 'MultiLineString';
+  }> = [
+    {encoding: 'geoarrow.point', type: 'Point'},
+    {encoding: 'geoarrow.multipoint', type: 'MultiPoint'},
+    {encoding: 'geoarrow.polygon', type: 'Polygon'},
+    {encoding: 'geoarrow.multilinestring', type: 'MultiLineString'}
+  ];
+  for (const {encoding, type} of cases) {
+    const options = {encoding, dimension: 'xy' as const, coordinateLayout: 'separated' as const};
+    const feed = (builder: GeoArrowBuilder): void => {
+      builder.beginGeometry(type, 'xy', 2);
+      if (type === 'Point') {
+        builder.writeCoordinate(1, 2);
+      } else if (type === 'MultiPoint') {
+        builder.beginRing(2).writeCoordinate(1, 2).writeCoordinate(3, 4);
+      } else if (type === 'Polygon') {
+        builder
+          .beginRing(4)
+          .writeCoordinate(0, 0)
+          .writeCoordinate(2, 0)
+          .writeCoordinate(0, 2)
+          .writeCoordinate(0, 0);
+      } else {
+        builder
+          .beginRing(2)
+          .writeCoordinate(0, 0)
+          .writeCoordinate(1, 1)
+          .beginRing(2)
+          .writeCoordinate(2, 2)
+          .writeCoordinate(3, 3);
+      }
+      builder.endGeometry();
+    };
+    const measure = new GeoArrowBuilder({...options, mode: 'measure'});
+    feed(measure);
+    const write = new GeoArrowBuilder({
+      ...options,
+      mode: 'write',
+      target: measure.allocateTarget()
+    });
+    feed(write);
+    expect(validateGeoArrowColumn(write.finish()).valid).toBe(true);
+  }
+});
+
 test('dimensions, coordinate layouts and Int32/Int64 offsets conform', () => {
   const dimensions: GeoArrowDimension[] = ['xy', 'xyz', 'xym', 'xyzm'];
   for (const dimension of dimensions) {

--- a/modules/wkb/src/wkb-reader.ts
+++ b/modules/wkb/src/wkb-reader.ts
@@ -283,6 +283,7 @@ function visitCoordinate(
 ): number {
   const coordinateByteLength = getWellKnownDimensionSize(header.dimension) * 8;
   assertRemaining(view, byteOffset, coordinateByteLength);
+  if (!visitor.coordinate) return byteOffset + coordinateByteLength;
   const x = view.getFloat64(byteOffset, header.littleEndian);
   const y = view.getFloat64(byteOffset + 8, header.littleEndian);
   const third =

--- a/test/bench/modules.bench.ts
+++ b/test/bench/modules.bench.ts
@@ -7,12 +7,14 @@ import {coreBench} from '../../modules/core/test/bench';
 import {geospatialBench} from '../../modules/geospatial/test/bench';
 import {cullingBench} from '../../modules/culling/test/bench';
 import {polygonBench} from '../../modules/polygon/test/bench';
+import {geoarrowBench} from '../../modules/geoarrow/test/bench';
 
 export default function addBenchmarks(suite: Bench, addReferenceBenchmarks: boolean): Bench {
   coreBench(suite, addReferenceBenchmarks);
   geospatialBench(suite, addReferenceBenchmarks);
   cullingBench(suite, addReferenceBenchmarks);
   polygonBench(suite, addReferenceBenchmarks);
+  geoarrowBench(suite);
 
   return suite;
 }


### PR DESCRIPTION
## Summary

This follow-up tranche makes the math.gl GeoArrow foundation useful for loaders-first adoption without adding Arrow dependencies.

- Decode concrete WKB families directly through `@math.gl/wkb` header inspection and visitors.
- Use the two-pass `GeoArrowBuilder` event API to write native buffers without materializing geometry rows.
- Preserve mixed concrete families and dimensions as dense-union children with child encoding/dimension metadata.
- Add zero-copy Point→MultiPoint, LineString→MultiLineString, and Polygon→MultiPolygon promotions.
- Avoid unnecessary coordinate remapping when a conversion only changes the family encoding.
- Make direct event building allocation-free for coordinate/ring/child arrays in the native path.
- Add conformance coverage for concrete WKB families, mixed-dimensional unions, and topology-sharing promotion.
- Expand GeoArrow documentation for event building and buffer-first WKB behavior.

GeometryCollection WKB/WKT remains on the existing compatibility path until the nested collection event topology is completed; this is isolated from the concrete-family fast path.

## Verification

- `tsc --build modules/geoarrow/tsconfig.json`
- `vitest run modules/geoarrow/test modules/wkb/test` (48 tests passing)
- Full commit-hook suite: 908 tests passing, 125 skipped
- `yarn check:geoarrow-boundary`
- `yarn check:wkb-boundary`

The repository-level `yarn build`/`yarn lint` wrappers are currently unavailable in this checkout because they reference `/usr/local/src/helpers/get-config.js`; package TypeScript build and direct `ocular-lint` checks pass.
